### PR TITLE
Feature/remove homepage keys from package json

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -14,7 +14,6 @@
     "WQX"
   ],
   "repository": "github:USEPA/mywaterway",
-  "homepage": "https://github.com/USEPA/mywaterway",
   "bugs": "https://github.com/USEPA/mywaterway/issues",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,6 @@
     "WQX"
   ],
   "repository": "github:USEPA/mywaterway",
-  "homepage": "https://github.com/USEPA/mywaterway",
   "bugs": "https://github.com/USEPA/mywaterway/issues",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -14,7 +14,6 @@
     "WQX"
   ],
   "repository": "github:USEPA/mywaterway",
-  "homepage": "https://github.com/USEPA/mywaterway",
   "bugs": "https://github.com/USEPA/mywaterway/issues",
   "license": "CC0-1.0",
   "author": "USEPA (https://www.epa.gov)",


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3167822

## Main Changes:
* A recent update to the `client` app's package.json metadata inadvertently broke the deployed version on cloud.gov. `create-react-app` uses the package.json file's `homepage` field as a [base for all relative paths of the compiled project](https://create-react-app.dev/docs/deployment/#building-for-relative-paths). It's not a required field ([npm reference](https://docs.npmjs.com/files/package.json#homepage)), so removing it restores the previous functionality of the deployed app.

## Steps To Test:
1. Merge and trigger CircleCI deployment to Cloud.gov
