### PR TITLE
Bugfix/update community tabs dot functionality

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -344,17 +344,16 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
 
         <TabDots>
           {tabs.map((tab, index) => {
-            const url = tab.route.replace('{urlSearch}', urlSearch);
             return (
               <li key={index}>
                 <TabDot
-                  href={url}
+                  href={tab.route.replace('{urlSearch}', urlSearch)}
                   title={tab.title}
                   data-selected={index === activeTabIndex}
                   onClick={(ev) => {
                     ev.preventDefault();
-                    setActiveTabIndex(index);
-                    navigate(url);
+                    const tabList = tabListRef.current;
+                    if (tabList) tabList.children[index].click();
                   }}
                 />
               </li>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3151043

  The previously merged in update of the Community page tabs (#6) introduced a bug when one of the "tab dots" below the tabs were clicked. They were supposed to mirror the Reach UI tab click's functionality, by setting the active tab (which updates the lower tab content below), and changing the URL (which captures a Google Analytics pageview), without causing a full page refresh. This worked locally, but when deployed to Cloud.gov, clicking a dot would cause a full page refresh.

## Main Changes:
* Instead of duplicating logic to set the active tab and change the URL, when a "tab dot" is clicked, we now trigger a native DOM click event on the corresponding Reach UI tab element, and rely on it to set the active tab and change the URL. Since we're already using a ref to get the Reach UI rendered "tablist" div (to focus the active tab whenever the active tab index changes), it's very little work to trigger a click event on the active tab's DOM node.
* It's my hunch the duplicate use of `navigate()` in the last PR is what's causing the page to refresh when deployed to Cloud.gov.
* This change is better anyway, as we're not duplicating logic, and relying on shared state for the intended functionality in keeping the tabs and the dots below in sync.

## Steps To Test:
1. Test locally, but really the real test is when deployed to Cloud.gov, as the previous PR worked as expected locally.
