### PR TITLE
Feature/split eating-fish and aquatic-life

### DIFF
--- a/app/client/src/components/pages/AquaticLife/index.js
+++ b/app/client/src/components/pages/AquaticLife/index.js
@@ -38,34 +38,38 @@ type Props = {
   ...RouteProps,
 };
 
-function Swimming({ ...props }: Props) {
+function AquaticLife({ ...props }: Props) {
   return (
     <Page>
       <NavBar title="Explore Topics" />
 
       <StyledTopic>
-        <SwimmingIcon />
-        <p>Swimming</p>
+        <FishingIcon />
+        <p>Aquatic Life</p>
       </StyledTopic>
 
       <StyledText className="container">
         <Prompt>
-          <em>Find out more about water you may potentially swim in.</em>
+          <em>
+            Find out about the overall status of aquatic life and what
+            impairments exist in your local waterbodies.
+          </em>
         </Prompt>
 
-        <LocationSearch route="/community/{urlSearch}/swimming" />
+        <LocationSearch route="/community/{urlSearch}/aquatic-life" />
 
         <br />
 
         <p>
-          Learn whether your local waters have been deemed safe for swimming and
-          other recreational activities. Find out about what impairments exist
-          in your local waterbodies.
+          Learn whether fish caught in your local waters are deemed safe to eat.
+          Find out more about the overall status of aquatic life and what
+          impairments exist in your local waterbodies.
           <ShowLessMore
             text={`
-            Water quality can change on very short notice. When deciding if it is
-            safe to swim in a water body, refer to any local or state advisories.
-            If available, refer to local or state real-time water quality reports.`}
+            The information in How’s My Waterway about the safety of eating
+            fish caught recreationally should only be considered as general
+            reference. Please consult with your state for local or state-wide
+            fish advisories.`}
             charLimit={0}
           />
         </p>
@@ -86,13 +90,13 @@ function Swimming({ ...props }: Props) {
         <h2>Other Topics</h2>
 
         <StyledButtons>
+          <TopicButtonLink to="/swimming">
+            <SwimmingIcon />
+            Swimming
+          </TopicButtonLink>
           <TopicButtonLink to="/eating-fish">
             <FishingIcon />
             Eating Fish
-          </TopicButtonLink>
-          <TopicButtonLink to="/aquatic-life">
-            <FishingIcon />
-            Aquatic Life
           </TopicButtonLink>
           <TopicButtonLink to="/drinking-water">
             <DrinkingWaterIcon />
@@ -104,4 +108,4 @@ function Swimming({ ...props }: Props) {
   );
 }
 
-export default Swimming;
+export default AquaticLife;

--- a/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
@@ -93,7 +93,7 @@ function CommunityIntro({ ...props }: Props) {
 
         <Topic>
           <TopicIcon>
-            <img src={fishingIcon} alt="Fishing" />
+            <img src={fishingIcon} alt="Eating Fish" />
           </TopicIcon>
           <TopicText>
             <strong>Fish Consumption and Aquatic Life:</strong> &nbsp; EPA,

--- a/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
@@ -96,9 +96,9 @@ function CommunityIntro({ ...props }: Props) {
             <img src={fishingIcon} alt="Eating Fish" />
           </TopicIcon>
           <TopicText>
-            <strong>Fish Consumption:</strong> &nbsp; EPA, states, and tribes
-            monitor and assess water quality to determine if fish and shellfish
-            are safe to eat.
+            <strong>Eating Fish:</strong> &nbsp; EPA, states, and tribes monitor
+            and assess water quality to determine if fish and shellfish are safe
+            to eat.
           </TopicText>
         </Topic>
 

--- a/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
@@ -96,10 +96,20 @@ function CommunityIntro({ ...props }: Props) {
             <img src={fishingIcon} alt="Eating Fish" />
           </TopicIcon>
           <TopicText>
-            <strong>Fish Consumption and Aquatic Life:</strong> &nbsp; EPA,
-            states, and tribes monitor and assess water quality to determine the
-            impact of impairments on plants and animals living in the water.
-            They also monitor and assess if fish and shellfish are safe to eat.
+            <strong>Fish Consumption:</strong> &nbsp; EPA, states, and tribes
+            monitor and assess water quality to determine if fish and shellfish
+            are safe to eat.
+          </TopicText>
+        </Topic>
+
+        <Topic>
+          <TopicIcon>
+            <img src={fishingIcon} alt="Aquatic Life" />
+          </TopicIcon>
+          <TopicText>
+            <strong>Aquatic Life:</strong> &nbsp; EPA, states, and tribes
+            monitor and assess water quality to determine the impact of
+            impairments on plants and animals living in the water.
           </TopicText>
         </Topic>
 

--- a/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
+++ b/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
@@ -13,13 +13,14 @@ import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
 
 // --- styled components ---
 const Container = styled.div`
-  padding: 1em;
+  padding: 0 1em 1em;
 `;
 
 // --- components ---
 type Props = {
   // props passed implicitly in Community component
   esriModules: Object,
+  infoToggleChecked: boolean,
 };
 
 function AquaticLife({ esriModules, infoToggleChecked }: Props) {

--- a/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
+++ b/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
@@ -1,0 +1,56 @@
+// @flow
+
+import React from 'react';
+import styled from 'styled-components';
+// components
+import TabErrorBoundary from 'components/shared/ErrorBoundary/TabErrorBoundary';
+import AssessmentSummary from 'components/shared/AssessmentSummary';
+import WaterbodyList from 'components/shared/WaterbodyList';
+// contexts
+import { LocationSearchContext } from 'contexts/locationSearch';
+// utilities
+import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+
+// --- styled components ---
+const Container = styled.div`
+  padding: 1em;
+`;
+
+// --- components ---
+type Props = {
+  // props passed implicitly in Community component
+  esriModules: Object,
+};
+
+function AquaticLife({ esriModules, infoToggleChecked }: Props) {
+  const { watershed } = React.useContext(LocationSearchContext);
+
+  const waterbodies = useWaterbodyFeatures();
+
+  useWaterbodyOnMap('ecological_use');
+
+  return (
+    <Container>
+      <AssessmentSummary
+        waterbodies={waterbodies}
+        fieldName="ecological_use"
+        usageName="aquatic life"
+      />
+
+      <WaterbodyList
+        waterbodies={waterbodies}
+        fieldName="ecological_use"
+        usageName="Aquatic Life"
+        title={`Waterbodies assessed for aquatic life in the ${watershed} watershed.`}
+      />
+    </Container>
+  );
+}
+
+export default function AquaticLifeContainer({ ...props }: Props) {
+  return (
+    <TabErrorBoundary tabName="Aquatic Life">
+      <AquaticLife {...props} />
+    </TabErrorBoundary>
+  );
+}

--- a/app/client/src/components/pages/Community/components/tabs/EatingFish.js
+++ b/app/client/src/components/pages/Community/components/tabs/EatingFish.js
@@ -48,7 +48,7 @@ type Props = {
   infoToggleChecked: boolean,
 };
 
-function Fishing({ esriModules, infoToggleChecked }: Props) {
+function EatingFish({ esriModules, infoToggleChecked }: Props) {
   const {
     watershed,
     fishingInfo,
@@ -105,7 +105,6 @@ function Fishing({ esriModules, infoToggleChecked }: Props) {
                       `}
             />
           </p>
-
           <Disclaimer>
             <p>
               Users of this application should not rely on information relating
@@ -135,10 +134,10 @@ function Fishing({ esriModules, infoToggleChecked }: Props) {
   );
 }
 
-export default function FishingContainer({ ...props }: Props) {
+export default function EatingFishContainer({ ...props }: Props) {
   return (
-    <TabErrorBoundary tabName="Fishing">
-      <Fishing {...props} />
+    <TabErrorBoundary tabName="Eating Fish">
+      <EatingFish {...props} />
     </TabErrorBoundary>
   );
 }

--- a/app/client/src/components/pages/Community/components/tabs/EatingFish.js
+++ b/app/client/src/components/pages/Community/components/tabs/EatingFish.js
@@ -34,7 +34,7 @@ function addSerialComma(index: number, arrayLength: number) {
 
 // --- styled components ---
 const Container = styled.div`
-  padding: 0 1em 1em 1em;
+  padding: 0 1em 1em;
 `;
 
 const Disclaimer = styled(DisclaimerModal)`

--- a/app/client/src/components/pages/Community/components/tabs/Fishing.js
+++ b/app/client/src/components/pages/Community/components/tabs/Fishing.js
@@ -1,11 +1,9 @@
 // @flow
 
 import React from 'react';
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
 import styled from 'styled-components';
 // components
 import TabErrorBoundary from 'components/shared/ErrorBoundary/TabErrorBoundary';
-import { ContentTabs } from 'components/shared/ContentTabs';
 import AssessmentSummary from 'components/shared/AssessmentSummary';
 import WaterbodyList from 'components/shared/WaterbodyList';
 import DisclaimerModal from 'components/shared/DisclaimerModal';
@@ -36,7 +34,7 @@ function addSerialComma(index: number, arrayLength: number) {
 
 // --- styled components ---
 const Container = styled.div`
-  padding: 1em;
+  padding: 0 1em 1em 1em;
 `;
 
 const Disclaimer = styled(DisclaimerModal)`
@@ -59,161 +57,80 @@ function Fishing({ esriModules, infoToggleChecked }: Props) {
 
   const waterbodies = useWaterbodyFeatures();
 
-  // redefine waterbodies when a tab changes
-  const [currentTabIndex, setCurrentTabIndex] = React.useState(0);
-
-  const [
-    attributeName,
-    setAttributeName, //
-  ] = React.useState('fishconsumption_use');
-
-  React.useEffect(() => {
-    // wait until waterbodies data is set from custom useWaterbodyFeatures() hook
-    if (!waterbodies) return;
-
-    let attributeName;
-    if (currentTabIndex === 0) attributeName = 'fishconsumption_use';
-    if (currentTabIndex === 1) attributeName = 'ecological_use';
-    setAttributeName(attributeName);
-  }, [currentTabIndex, attributeName, waterbodies]);
-
-  useWaterbodyOnMap(attributeName);
+  useWaterbodyOnMap('fishconsumption_use');
 
   return (
     <Container>
-      <ContentTabs>
-        <Tabs onChange={(index) => setCurrentTabIndex(index)}>
-          <TabList>
-            <Tab>Fish Consumption</Tab>
-            <Tab>What is the status of aquatic life?</Tab>
-          </TabList>
-
-          <TabPanels>
-            <TabPanel>
-              {infoToggleChecked && (
-                <>
-                  <p>
-                    Eating fish and shellfish caught in impaired waters can pose
-                    health risks. For the {watershed} watershed, be sure to look
-                    for posted fish advisories or consult your local or state
-                    environmental health department for{' '}
-                    {fishingInfo.status === 'success' ? (
-                      <>
-                        {fishingInfo.data.map((state, index, array) => (
-                          <React.Fragment key={index}>
-                            {addSerialComma(index, array.length)}
-                            <a
-                              href={state.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {convertStateCode(
-                                state.stateCode,
-                                statesData.data,
-                              )}
-                            </a>
-                          </React.Fragment>
-                        ))}
-                        .{' '}
-                        <a
-                          className="exit-disclaimer"
-                          href="https://www.epa.gov/home/exit-epa"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          EXIT
-                        </a>
-                      </>
-                    ) : (
-                      'your state.'
-                    )}
-                    <ShowLessMore
-                      charLimit={0}
-                      text={`
+      {infoToggleChecked && (
+        <>
+          <p>
+            Eating fish and shellfish caught in impaired waters can pose health
+            risks. For the {watershed} watershed, be sure to look for posted
+            fish advisories or consult your local or state environmental health
+            department for{' '}
+            {fishingInfo.status === 'success' ? (
+              <>
+                {fishingInfo.data.map((state, index, array) => (
+                  <React.Fragment key={index}>
+                    {addSerialComma(index, array.length)}
+                    <a
+                      href={state.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {convertStateCode(state.stateCode, statesData.data)}
+                    </a>
+                  </React.Fragment>
+                ))}
+                .{' '}
+                <a
+                  className="exit-disclaimer"
+                  href="https://www.epa.gov/home/exit-epa"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  EXIT
+                </a>
+              </>
+            ) : (
+              'your state.'
+            )}
+            <ShowLessMore
+              charLimit={0}
+              text={`
                         The information in How’s My Waterway about the safety of
                         eating fish caught recreationally should only be
                         considered as general reference. Please consult with your
                         state for local or state-wide fish advisories.
                       `}
-                    />
-                  </p>
+            />
+          </p>
 
-                  <Disclaimer>
-                    <p>
-                      Users of this application should not rely on information
-                      relating to environmental laws and regulations posted on
-                      this application. Application users are solely responsible
-                      for ensuring that they are in compliance with all relevant
-                      environmental laws and regulations. In addition, EPA
-                      cannot attest to the accuracy of data provided by
-                      organizations outside of the federal government.
-                    </p>
-                  </Disclaimer>
-                </>
-              )}
+          <Disclaimer>
+            <p>
+              Users of this application should not rely on information relating
+              to environmental laws and regulations posted on this application.
+              Application users are solely responsible for ensuring that they
+              are in compliance with all relevant environmental laws and
+              regulations. In addition, EPA cannot attest to the accuracy of
+              data provided by organizations outside of the federal government.
+            </p>
+          </Disclaimer>
+        </>
+      )}
 
-              <AssessmentSummary
-                waterbodies={waterbodies}
-                fieldName="fishconsumption_use"
-                usageName="fish and shellfish consumption"
-              />
+      <AssessmentSummary
+        waterbodies={waterbodies}
+        fieldName="fishconsumption_use"
+        usageName="fish and shellfish consumption"
+      />
 
-              <WaterbodyList
-                waterbodies={waterbodies}
-                fieldName="fishconsumption_use"
-                usageName="Fish and Shellfish Consumption"
-                title={`Waterbodies assessed for fish and shellfish consumption in the ${watershed} watershed.`}
-              />
-            </TabPanel>
-
-            <TabPanel>
-              {infoToggleChecked && (
-                <>
-                  <p>
-                    Plants and animals depend on clean water. Impairments can
-                    affect the quality of water, which can have adverse effects
-                    on plants and animals living in the water.
-                    <ShowLessMore
-                      charLimit={0}
-                      text={`
-                        The condition of a waterbody is dynamic and can change at
-                        any time, and the information in How’s My Waterway should
-                        only be used for general reference. If available, refer to
-                        local or state real-time water quality reports.
-                      `}
-                    />
-                  </p>
-
-                  <Disclaimer>
-                    <p>
-                      Users of this application should not rely on information
-                      relating to environmental laws and regulations posted on
-                      this application. Application users are solely responsible
-                      for ensuring that they are in compliance with all relevant
-                      environmental laws and regulations. In addition, EPA
-                      cannot attest to the accuracy of data provided by
-                      organizations outside of the federal government.
-                    </p>
-                  </Disclaimer>
-                </>
-              )}
-
-              <AssessmentSummary
-                waterbodies={waterbodies}
-                fieldName="ecological_use"
-                usageName="aquatic life"
-              />
-
-              <WaterbodyList
-                waterbodies={waterbodies}
-                fieldName="ecological_use"
-                usageName="Aquatic Life"
-                title={`Waterbodies assessed for aquatic life in the ${watershed} watershed.`}
-              />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      </ContentTabs>
+      <WaterbodyList
+        waterbodies={waterbodies}
+        fieldName="fishconsumption_use"
+        usageName="Fish and Shellfish Consumption"
+        title={`Waterbodies assessed for fish and shellfish consumption in the ${watershed} watershed.`}
+      />
     </Container>
   );
 }

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -263,7 +263,7 @@ const tabs = [
     route: '/community/{urlSearch}/aquatic-life',
     icon: fishingIcon, // TODO: replace once icon is created
     upper: aquaticUpper,
-    lower: <AquaticLife />, // TODO: replace once tab content is defined
+    lower: <AquaticLife />,
     layers: { waterbodyLayer: true },
   },
   {

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -125,9 +125,8 @@ const swimmingUpper = (
 const fishingUpper = (
   <>
     <p>
-      EPA, states, and tribes monitor and assess water quality to determine the
-      impact of impairments on plants and animals living in the water. They also
-      monitor and assess if fish and shellfish are safe to eat.
+      EPA, states, and tribes monitor and assess water quality to determine if
+      fish and shellfish are safe to eat.
     </p>
   </>
 );
@@ -136,8 +135,7 @@ const aquaticUpper = (
   <>
     <p>
       EPA, states, and tribes monitor and assess water quality to determine the
-      impact of impairments on plants and animals living in the water. They also
-      monitor and assess if fish and shellfish are safe to eat.
+      impact of impairments on plants and animals living in the water.
     </p>
     <p>
       Plants and animals depend on clean water. Impairments can affect the

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -7,7 +7,7 @@ import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import Overview from './components/tabs/Overview';
 import DrinkingWater from './components/tabs/DrinkingWater';
 import Swimming from './components/tabs/Swimming';
-import Fishing from './components/tabs/Fishing';
+import EatingFish from './components/tabs/EatingFish';
 import AquaticLife from './components/tabs/AquaticLife';
 import Monitoring from './components/tabs/Monitoring';
 import IdentifiedIssues from './components/tabs/IdentifiedIssues';
@@ -255,7 +255,7 @@ const tabs = [
     route: '/community/{urlSearch}/eating-fish',
     icon: fishingIcon,
     upper: fishingUpper,
-    lower: <Fishing />,
+    lower: <EatingFish />,
     layers: { waterbodyLayer: true },
   },
   {

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -8,6 +8,7 @@ import Overview from './components/tabs/Overview';
 import DrinkingWater from './components/tabs/DrinkingWater';
 import Swimming from './components/tabs/Swimming';
 import Fishing from './components/tabs/Fishing';
+import AquaticLife from './components/tabs/AquaticLife';
 import Monitoring from './components/tabs/Monitoring';
 import IdentifiedIssues from './components/tabs/IdentifiedIssues';
 import Restore from './components/tabs/Restore';
@@ -133,7 +134,36 @@ const fishingUpper = (
 
 const aquaticUpper = (
   <>
-    <p>(Aquatic Life placeholder...)</p>
+    <p>
+      EPA, states, and tribes monitor and assess water quality to determine the
+      impact of impairments on plants and animals living in the water. They also
+      monitor and assess if fish and shellfish are safe to eat.
+    </p>
+    <p>
+      Plants and animals depend on clean water. Impairments can affect the
+      quality of water, which can have adverse effects on plants and animals
+      living in the water.
+      <ShowLessMore
+        charLimit={0}
+        text={`
+                The condition of a waterbody is dynamic and can change at
+                any time, and the information in How’s My Waterway should
+                only be used for general reference. If available, refer to
+                local or state real-time water quality reports.
+              `}
+      />
+    </p>
+
+    <Disclaimer>
+      <p>
+        Users of this application should not rely on information relating to
+        environmental laws and regulations posted on this application.
+        Application users are solely responsible for ensuring that they are in
+        compliance with all relevant environmental laws and regulations. In
+        addition, EPA cannot attest to the accuracy of data provided by
+        organizations outside of the federal government.
+      </p>
+    </Disclaimer>
   </>
 );
 
@@ -222,7 +252,7 @@ const tabs = [
   },
   {
     title: 'Eating Fish',
-    route: '/community/{urlSearch}/fishing',
+    route: '/community/{urlSearch}/eating-fish',
     icon: fishingIcon,
     upper: fishingUpper,
     lower: <Fishing />,
@@ -230,10 +260,10 @@ const tabs = [
   },
   {
     title: 'Aquatic Life',
-    route: '/community/{urlSearch}/aquatic',
+    route: '/community/{urlSearch}/aquatic-life',
     icon: fishingIcon, // TODO: replace once icon is created
     upper: aquaticUpper,
-    lower: <Fishing />, // TODO: replace once tab content is defined
+    lower: <AquaticLife />, // TODO: replace once tab content is defined
     layers: { waterbodyLayer: true },
   },
   {

--- a/app/client/src/components/pages/DrinkingWater/index.js
+++ b/app/client/src/components/pages/DrinkingWater/index.js
@@ -70,7 +70,7 @@ function DrinkingWater({ ...props }: Props) {
             <SwimmingIcon />
             Swimming
           </TopicButtonLink>
-          <TopicButtonLink to="/fishing">
+          <TopicButtonLink to="/eating-fish">
             <FishingIcon />
             Fishing
           </TopicButtonLink>

--- a/app/client/src/components/pages/DrinkingWater/index.js
+++ b/app/client/src/components/pages/DrinkingWater/index.js
@@ -15,7 +15,7 @@ import { StyledText, StyledTopic } from 'components/shared/Topics';
 import {
   StyledButtons,
   StyledTopicButtonLink,
-  StyledTwoButtonLinks,
+  StyledThreeButtonLinks,
 } from 'components/shared/ButtonLinks';
 
 // --- styled components ---
@@ -24,7 +24,7 @@ const Prompt = styled.p`
 `;
 
 const TopicButtonLink = styled(StyledTopicButtonLink)`
-  ${StyledTwoButtonLinks}
+  ${StyledThreeButtonLinks}
 `;
 
 // --- components ---
@@ -70,9 +70,13 @@ function DrinkingWater({ ...props }: Props) {
             <SwimmingIcon />
             Swimming
           </TopicButtonLink>
+          <TopicButtonLink to="/aquatic-life">
+            <FishingIcon />
+            Aquatic Life
+          </TopicButtonLink>
           <TopicButtonLink to="/eating-fish">
             <FishingIcon />
-            Fishing
+            Eating Fish
           </TopicButtonLink>
         </StyledButtons>
       </StyledText>

--- a/app/client/src/components/pages/EatingFish/index.js
+++ b/app/client/src/components/pages/EatingFish/index.js
@@ -17,7 +17,7 @@ import { StyledText, StyledTopic } from 'components/shared/Topics';
 import {
   StyledButtons,
   StyledTopicButtonLink,
-  StyledTwoButtonLinks,
+  StyledThreeButtonLinks,
 } from 'components/shared/ButtonLinks';
 
 // --- styled components ---
@@ -30,7 +30,7 @@ const Prompt = styled.p`
 `;
 
 const TopicButtonLink = styled(StyledTopicButtonLink)`
-  ${StyledTwoButtonLinks}
+  ${StyledThreeButtonLinks}
 `;
 
 // --- components ---
@@ -38,19 +38,22 @@ type Props = {
   ...RouteProps,
 };
 
-function Fishing({ ...props }: Props) {
+function EatingFish({ ...props }: Props) {
   return (
     <Page>
       <NavBar title="Explore Topics" />
 
       <StyledTopic>
         <FishingIcon />
-        <p>Fishing</p>
+        <p>Eating Fish</p>
       </StyledTopic>
 
       <StyledText className="container">
         <Prompt>
-          <em>Find out more about your fish and other aquatic life.</em>
+          <em>
+            Learn whether fish caught in your local waters are deemed safe to
+            eat.
+          </em>
         </Prompt>
 
         <LocationSearch route="/community/{urlSearch}/eating-fish" />
@@ -91,6 +94,10 @@ function Fishing({ ...props }: Props) {
             <SwimmingIcon />
             Swimming
           </TopicButtonLink>
+          <TopicButtonLink to="/aquatic-life">
+            <FishingIcon />
+            Aquatic Life
+          </TopicButtonLink>
           <TopicButtonLink to="/drinking-water">
             <DrinkingWaterIcon />
             Drinking Water
@@ -101,4 +108,4 @@ function Fishing({ ...props }: Props) {
   );
 }
 
-export default Fishing;
+export default EatingFish;

--- a/app/client/src/components/pages/Fishing/index.js
+++ b/app/client/src/components/pages/Fishing/index.js
@@ -53,7 +53,7 @@ function Fishing({ ...props }: Props) {
           <em>Find out more about your fish and other aquatic life.</em>
         </Prompt>
 
-        <LocationSearch route="/community/{urlSearch}/fishing" />
+        <LocationSearch route="/community/{urlSearch}/eating-fish" />
 
         <br />
 

--- a/app/client/src/components/pages/Home/index.js
+++ b/app/client/src/components/pages/Home/index.js
@@ -106,7 +106,7 @@ function Home({ ...props }: Props) {
             <SwimmingIcon />
             Swimming
           </TopicButtonLink>
-          <TopicButtonLink to="/fishing">
+          <TopicButtonLink to="/eating-fish">
             <FishingIcon />
             Fishing
           </TopicButtonLink>

--- a/app/client/src/components/pages/Home/index.js
+++ b/app/client/src/components/pages/Home/index.js
@@ -16,6 +16,7 @@ import {
   StyledButtonLink,
   StyledTopicButtonLink,
   StyledThreeButtonLinks,
+  StyledFourButtonLinks,
 } from 'components/shared/ButtonLinks';
 // styles
 import { colors } from 'styles/index.js';
@@ -42,7 +43,7 @@ const Paragraph = styled.p`
 `;
 
 const TopicButtonLink = styled(StyledTopicButtonLink)`
-  ${StyledThreeButtonLinks}
+  ${StyledFourButtonLinks}
 `;
 
 const PlaceButtonLink = styled(StyledButtonLink)`
@@ -108,7 +109,11 @@ function Home({ ...props }: Props) {
           </TopicButtonLink>
           <TopicButtonLink to="/eating-fish">
             <FishingIcon />
-            Fishing
+            Eating Fish
+          </TopicButtonLink>
+          <TopicButtonLink to="/aquatic-life">
+            <FishingIcon />
+            Aquatic Life
           </TopicButtonLink>
           <TopicButtonLink to="/drinking-water">
             <DrinkingWaterIcon />

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -704,7 +704,7 @@ function WaterQualityOverview({ ...props }: Props) {
     },
     {
       id: 'fishing',
-      title: 'Fishing',
+      title: 'Eating Fish',
       icon: <FishingIcon height="2.5em" />,
     },
     {

--- a/app/client/src/components/pages/Swimming/index.js
+++ b/app/client/src/components/pages/Swimming/index.js
@@ -86,7 +86,7 @@ function Swimming({ ...props }: Props) {
         <h2>Other Topics</h2>
 
         <StyledButtons>
-          <TopicButtonLink to="/fishing">
+          <TopicButtonLink to="/eating-fish">
             <FishingIcon />
             Fishing
           </TopicButtonLink>

--- a/app/client/src/components/shared/ButtonLinks/index.js
+++ b/app/client/src/components/shared/ButtonLinks/index.js
@@ -49,6 +49,16 @@ const StyledTopicButtonLink = styled(StyledButtonLink)`
   }
 `;
 
+const StyledFourButtonLinks = css`
+  @media (min-width: 35em) {
+    width: calc(25% - 0.75em);
+  }
+
+  @media (min-width: 45em) {
+    width: calc(25% - 1.25em);
+  }
+`;
+
 const StyledThreeButtonLinks = css`
   @media (min-width: 35em) {
     width: calc((100% / 3) - 0.75em);
@@ -73,6 +83,7 @@ export {
   StyledButtons,
   StyledButtonLink,
   StyledTopicButtonLink,
+  StyledFourButtonLinks,
   StyledThreeButtonLinks,
   StyledTwoButtonLinks,
 };

--- a/app/client/src/components/shared/DataContent/index.js
+++ b/app/client/src/components/shared/DataContent/index.js
@@ -123,8 +123,8 @@ function Data({ ...props }: Props) {
           <GlossaryTerm term="overall waterbody condition">
             waterbody condition
           </GlossaryTerm>{' '}
-          list and map), Swimming, Fish Consumption and Aquatic Life, Identified
-          Issues ( <GlossaryTerm term="impairment">impairments</GlossaryTerm> ),
+          list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues
+          ( <GlossaryTerm term="impairment">impairments</GlossaryTerm> ),
           Restore (
           <GlossaryTerm term="restoration plan">restoration plans</GlossaryTerm>{' '}
           ), Drinking Water (Which waters have been assessed for drinking water

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -16,7 +16,8 @@ import StateTabs from 'components/pages/State/components/routes/StateTabs';
 import National from 'components/pages/National';
 import DrinkingWater from 'components/pages/DrinkingWater';
 import Swimming from 'components/pages/Swimming';
-import Fishing from 'components/pages/Fishing';
+import EatingFish from 'components/pages/EatingFish';
+import AquaticLife from 'components/pages/AquaticLife';
 import OrgSelect from 'components/pages/Actions/OrgSelect';
 import Actions from 'components/pages/Actions';
 import WaterbodyReport from 'components/pages/WaterbodyReport';
@@ -56,7 +57,8 @@ function Routes() {
       <National path="/national" />
       <DrinkingWater path="/drinking-water" />
       <Swimming path="/swimming" />
-      <Fishing path="/eating-fish" />
+      <EatingFish path="/eating-fish" />
+      <AquaticLife path="/aquatic-life" />
       {/* TODO: Remove this route once orgId is added to the response of the
           ATTAINS plans web service */}
       <OrgSelect path="/plan-summary/:actionId" />

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -56,7 +56,7 @@ function Routes() {
       <National path="/national" />
       <DrinkingWater path="/drinking-water" />
       <Swimming path="/swimming" />
-      <Fishing path="/fishing" />
+      <Fishing path="/eating-fish" />
       {/* TODO: Remove this route once orgId is added to the response of the
           ATTAINS plans web service */}
       <OrgSelect path="/plan-summary/:actionId" />


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3173656
* https://app.breeze.pm/projects/100762/cards/3178606
* https://app.breeze.pm/projects/100762/cards/3179501

## Main Changes:
* Fishing route is now 'eating-fish' and references to the file are updated to EatingFish
* Eating Fish and Aquatic Life now have their own content from what used to be the Fishing tab
* I've left the main intro text for the Eating Fish tab in the tab itself and not **config.js**. This is because the text is dynamic based on the location and moving that logic into the config file would cause unnecessary clutter.
* EPA has provided new intro text for both tabs
* Adds a new Aquatic Life topic with a layout for 4 topics on the home page
* Renames the Fishing topic to Eating Fish
* Updates community intro page with with separated entries for Eating Fish and Aquatic Life

## Steps To Test:
1. Navigate to Eating Fish and Aquatic Life tabs from the Community page and test locations
2. Navigate to the Eating Fish tab from the Fishing Topic page 

