### PR TITLE
Feature/update community tabs scroll position

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -13973,6 +13973,11 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -64,6 +64,7 @@
     "react-switch": "5.0.1",
     "react-table": "6.11.5",
     "react-virtualized": "9.21.2",
+    "smoothscroll-polyfill": "0.4.4",
     "styled-components": "5.0.0"
   },
   "husky": {

--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -279,10 +279,21 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
 
   const tabListRef = React.useRef();
 
-  // focus the active tab
+  // focus and scroll (horizontally) to the active tab
   React.useEffect(() => {
     if (tabListRef.current) {
-      tabListRef.current.children[activeTabIndex].focus();
+      const tabList = tabListRef.current;
+      const activeTab = tabList.children[activeTabIndex];
+      activeTab.focus();
+
+      const column = document.querySelector('[data-column="right"]');
+      if (!column) return;
+
+      const columnCenter = column.offsetLeft + column.offsetWidth / 2;
+      const tabCenter = activeTab.offsetLeft + activeTab.offsetWidth / 2;
+      const distance = tabCenter - columnCenter - tabList.scrollLeft;
+
+      tabList.scrollBy({ top: 0, left: distance, behavior: 'smooth' });
     }
   }, [tabListRef, activeTabIndex]);
 

--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -177,9 +177,9 @@ function Community({ children, ...props }: Props) {
             // narrow screens
             return (
               <Columns data-content="community">
-                <LeftColumn>
+                <LeftColumn data-column="left">
                   {searchMarkup}
-                  <RightColumn>
+                  <RightColumn data-column="right">
                     {/* children is either CommunityIntro or CommunityTabs (upper tabs) */}
                     {children}
                   </RightColumn>
@@ -206,12 +206,12 @@ function Community({ children, ...props }: Props) {
             // wide screens
             return (
               <Columns data-content="community">
-                <LeftColumn>
+                <LeftColumn data-column="left">
                   <LocationMap windowHeight={height} layout="wide">
                     {searchMarkup}
                   </LocationMap>
                 </LeftColumn>
-                <RightColumn>
+                <RightColumn data-column="right">
                   {/* children is either CommunityIntro or CommunityTabs (upper tabs) */}
                   {children}
                   {!atCommunityIntroRoute && lowerTabs}

--- a/app/client/src/index.js
+++ b/app/client/src/index.js
@@ -2,6 +2,7 @@
 
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
+import smoothscroll from 'smoothscroll-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createGlobalStyle } from 'styled-components';
@@ -15,6 +16,8 @@ import { LocationSearchProvider } from 'contexts/locationSearch';
 import { GlossaryProvider } from 'contexts/Glossary';
 // errors
 import { defaultErrorBoundaryMessage } from 'config/errorMessages';
+
+smoothscroll.polyfill();
 
 // --- styled components ---
 export const GlobalStyle = createGlobalStyle`


### PR DESCRIPTION
## Related Issues:
* Further refines https://app.breeze.pm/projects/100762/cards/3151043

## Main Changes:
* Smoothly scrolls the active tab when it's been clicked (or navigated to via keyboard), or when the corresponding "tab dot" is clicked/navigated to (since those are linked). The active tab will now always be in the exact center of the right column, as scrolling allows.

**IMPORTANT:** This will currently break on IE, as IE doesn't support an options object passed to "scrollBy" (see: https://developer.mozilla.org/en-US/docs/Web/API/ScrollToOptions). Before merging this in, I'll either include a polyfill or IE specific behavior so this doesn't crash the page.

## Steps To Test:
1. Navigate to the community page, and click/select different tabs.

## TODO:
- [ ] Add IE fix (see "IMPORTANT" comment above).
