### PR TITLE
bugfix/esri-fetch-error-infinite-loop

### DIFF
--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -56,7 +56,7 @@ function useWaterbodyFeatures() {
       areasLayer === 'error' ||
       pointsLayer === 'error'
     ) {
-      setFeatures([]);
+      if (!features || features.length !== 0) setFeatures([]);
       return;
     }
     if (huc12 === lastHuc12) return;


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3180505](https://app.breeze.pm/projects/100762/cards/3180505)

## Main Changes:
* Fixed a bug that was causing an infinite loop when one of the gis web services failed. 

## Steps To Test:
1. Open the chrome dev tools
2. Perform a search on the community page
3. Block one of the gispub web service calls
4. Refresh the page
5. Check the console for an infinite loop of "Maximum update depth exceeded" errors.