### PR TITLE
bugfix/google-analytics-bad-status-codes

### DIFF
--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -12,7 +12,10 @@ export function fetchCheck(apiUrl: string) {
     })
     .catch((err) => {
       console.error(err);
-      logCallToGoogleAnalytics(apiUrl, err, startTime);
+
+      let status = err;
+      if (err && err.status) status = err.status;
+      logCallToGoogleAnalytics(apiUrl, status, startTime);
     });
 }
 
@@ -22,16 +25,7 @@ export function proxyFetch(apiUrl: string) {
   const proxyUrl = REACT_APP_PROXY_URL || `${window.location.origin}/proxy`;
   const url = `${proxyUrl}?url=${apiUrl}`;
 
-  const startTime = performance.now();
-  return fetch(url)
-    .then((response) => {
-      logCallToGoogleAnalytics(url, response.status, startTime);
-      return checkResponse(response);
-    })
-    .catch((err) => {
-      console.error(err);
-      logCallToGoogleAnalytics(url, err, startTime);
-    });
+  return fetchCheck(url);
 }
 
 export function checkResponse(response) {


### PR DESCRIPTION

## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3184880](https://app.breeze.pm/projects/100762/cards/3184880)

## Main Changes:
* Fixed a bug where `[object Response]` would show up in place of the http status code in the GA logs. This was specific to usage of JS Fetch.
* Fixed a bug where `NaN` would show up in place of execution time in the GA logs. This was specific to usage of Esri Request Interceptors.
* Fixed a bug where `undefined` would show up in place of the http status code in the GA logs. This was specific to usage of Esri Request Interceptors.

## Steps To Test:
1. Look at Google Analytics event logs and check for the bugs listed above.

