### PR TITLE
check length of toggledLayer object because it's an array, remove red…

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -187,7 +187,7 @@ function MapWidgets({
     setLastToggledLayer(toggledLayer);
 
     // exit early if the toggledLayer object is empty
-    if (Object.keys(toggledLayer) === 0) return;
+    if (Object.keys(toggledLayer).length === 0) return;
 
     // make the update of the toggled layer if the visiblity changed
     if (

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -102,7 +102,7 @@ export const stateGeneralError =
 
 // if an invalid state is entered
 export const stateNoDataError = (stateName) =>
-  `No data available ${stateName && 'for'} ${stateName && stateName}.`; // conditionals in case state name is undefined or an empty string
+  `No data available ${stateName && 'for ' + stateName}.`; // conditionals in case state name is undefined or an empty string
 
 // Waterbody Report errors //
 export const waterbodyReportError = (type) =>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3184751
## Main Changes:
* Fixes the second 2 bugs in the screenshot on the Breeze card, we're waiting on the first because the line number seems to be outdated.

## Steps To Test:
1. Block this service on the state page to verify the error message still works:
https://attains.epa.gov/attains-public/api/states/AL/organizations
2. When changing layers on the Community tab there seems to be a performance boost as now the return statement can occur. Infinite loops might have been possible but I didn't notice any bugs with it.

## TODO:
- The first item has not been touched, I believe the line number in the screenshot is incorrect. This PR is for the second two items for now.