### PR TITLE
Bugfix/trim whitespace of searches

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -80,7 +80,7 @@ function LocationSearch({ route }: Props) {
         if (inputText) {
           setGeolocationError(false);
           // only navigate if search box contains text
-          navigate(encodeURI(route.replace('{urlSearch}', inputText)));
+          navigate(encodeURI(route.replace('{urlSearch}', inputText.trim())));
         }
       }}
     >


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3183909

## Main Changes:
* Use .trim() on search text to strip leading and trailing spaces. Compatible in all browsers

## Steps To Test:
1. Test searching something like "       dc       " in a modern browser and IE11. The url should trim any spaces and not have %20's like the screenshot in the card.
