### PR TITLE
bugfix/waterbody-report-long-url-spaces

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -31,7 +31,7 @@ import { MapHighlightProvider } from 'contexts/MapHighlight';
 // config
 import { attains, waterQualityPortal } from 'config/webServiceConfig';
 // utilities
-import { fetchCheck } from 'utils/fetchUtils';
+import { fetchCheck, fetchPost } from 'utils/fetchUtils';
 import { titleCaseWithExceptions } from 'utils/utils';
 // styles
 import { colors } from 'styles/index.js';
@@ -245,13 +245,17 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
           locId: station.monitoringLocationIdentifier,
         }));
 
-        const wqpUrl =
-          `${waterQualityPortal.stationSearch}siteid=` +
-          `${stations.map((s) => `${s.orgId}-${s.locId}`).join('&siteid=')}` +
-          `&mimeType=geojson`;
+        // build the post reqest
+        const wqpUrl = `${waterQualityPortal.stationSearch}mimeType=geojson`;
+        const headers = { 'content-type': 'application/json' };
+        const data = {
+          siteid: stations.map((s) => {
+            return `${s.orgId.trim()}-${s.locId.trim()}`;
+          }),
+        };
 
         // fetch monitoring locations from water quality portal 'station search' web service
-        fetchCheck(wqpUrl).then(
+        fetchPost(wqpUrl, data, headers).then(
           (geojson) => {
             // match monitoring stations returned from the attains 'assessmentUnits' web service
             // with features returned in the water quality portal 'station search' web service

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -34,6 +34,23 @@ export function proxyFetch(apiUrl: string) {
     });
 }
 
+export function fetchPost(apiUrl: string, data: object, headers: object) {
+  const startTime = performance.now();
+  return fetch(apiUrl, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(data),
+  })
+    .then((response) => {
+      logCallToGoogleAnalytics(apiUrl, response.status, startTime);
+      return checkResponse(response);
+    })
+    .catch((err) => {
+      console.error(err);
+      logCallToGoogleAnalytics(apiUrl, err, startTime);
+    });
+}
+
 export function checkResponse(response) {
   return new Promise((resolve, reject) => {
     if (response.status === 200) {


### PR DESCRIPTION

## Related Issues:
* [https://app.breeze.pm/projects/100762](https://app.breeze.pm/projects/100762)

## Main Changes:
* Fixes an issue where spaces in the water quality portal station search service call was causing the request to fail. 
* Converted the water quality portal station search service to use a post instead of a get, since the service call url was very long. 

## Steps To Test:
1. Navigate to [http://localhost:3000/waterbody-report/21OHIO/OHLR041100029001](http://localhost:3000/waterbody-report/21OHIO/OHLR041100029001)
2. Open up the chrome dev tools and ensure the water quality portal service calls complete successfully. 
3. Make sure the monitoring locations are displayed on the screen. 
    Note: I noticed in my testing that we were passing in 80 monitoring location ids and we were only getting back about 44 monitoring locations. I went to the water quality portal and pasted in some of the missing ids and the water quality portal couldn't find them either. It looks like the assessments service is returning back monitoring locations that don't exist in the water quality portal. 

