### PR TITLE
Bugfixe/site specific year missing

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -7,6 +7,7 @@ import HighchartsReact from 'highcharts-react-official';
 // components
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
+import LoadingSpinner from 'components/shared/LoadingSpinner';
 // contexts
 import { StateTabsContext } from 'contexts/StateTabs';
 // utilities
@@ -33,9 +34,16 @@ const AccordionContent = styled.div`
 `;
 
 const ChartFooter = styled.p`
+  display: flex;
+  align-items: center;
   margin-bottom: 1.5em;
   font-size: 0.75rem;
   padding-bottom: 0;
+
+  svg {
+    margin: 0 -0.875rem;
+    height: 0.6875rem;
+  }
 `;
 
 const Percent = styled.span`
@@ -70,7 +78,7 @@ function SiteSpecific({
   completeUseList,
   useSelected,
 }: Props) {
-  const { currentReportingCycle } = React.useContext(StateTabsContext);
+  const { currentSummary } = React.useContext(StateTabsContext);
 
   const [waterTypeUnits, setWaterTypeUnits] = React.useState('');
   React.useEffect(() => {
@@ -299,7 +307,11 @@ function SiteSpecific({
             />
           </HighchartsContainer>
           <ChartFooter>
-            <strong>Year Last Reported:</strong> {currentReportingCycle}
+            <strong>Year Last Reported:</strong>
+            {currentSummary.status === 'success' && (
+              <>&nbsp;{currentSummary.data.reportingCycle}</>
+            )}
+            {currentSummary.status === 'fetching' && <LoadingSpinner />}
           </ChartFooter>
         </>
       )}

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -80,7 +80,7 @@ function LocationSearch({ route }: Props) {
         if (inputText) {
           setGeolocationError(false);
           // only navigate if search box contains text
-          navigate(encodeURI(route.replace('{urlSearch}', inputText)));
+          navigate(encodeURI(route.replace('{urlSearch}', inputText.trim())));
         }
       }}
     >


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3185184](https://app.breeze.pm/projects/100762/cards/3185184)

## Main Changes:
* Fixed a bug where the last year reported was blank on the state water quality overview page (site specific section). This was a regression from changes related to filtering the parameters on the advanced search page.

## Steps To Test:
1. Navigate to [http://localhost:3000/state/AL/water-quality-overview](http://localhost:3000/state/AL/water-quality-overview)
2. Ensure the year last reported value is there.