### PR TITLE
Fixed issue of waterbodies not always showing up initially.

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -310,6 +310,8 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
     setDrinkingWaterTabIndex(0);
   };
 
+  if (activeTabIndex === -1) return null;
+
   return (
     <>
       <Location>

--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -123,13 +123,15 @@ function Community({ children, ...props }: Props) {
   const { setVisibleLayers } = React.useContext(LocationSearchContext);
   React.useEffect(() => {
     // don't show any tab based layers if on community landing page
-    if (window.location.pathname === '/community') return;
+    if (window.location.pathname === '/community' || activeTabIndex === -1) {
+      return;
+    }
 
     setVisibleLayers(tabs[activeTabIndex].layers);
   }, [activeTabIndex, setVisibleLayers]);
 
   // jsx
-  const activeTabRoute = tabs[activeTabIndex].route;
+  const activeTabRoute = tabs[activeTabIndex === -1 ? 0 : activeTabIndex].route;
   const searchMarkup = (
     <>
       <Prompt>
@@ -147,10 +149,13 @@ function Community({ children, ...props }: Props) {
         // implicitly pass esriModules and infoToggleChecked props to 'lower' tab components
         // (normally we'd get these via useContext, but lower tab components are all class-based
         // components, and this is easier than using render props to use multiple React Contexts)
-        return React.cloneElement(tabs[activeTabIndex].lower, {
-          esriModules,
-          infoToggleChecked,
-        });
+        return React.cloneElement(
+          tabs[activeTabIndex === -1 ? 0 : activeTabIndex].lower,
+          {
+            esriModules,
+            infoToggleChecked,
+          },
+        );
       }}
     </EsriModulesContext.Consumer>
   );

--- a/app/client/src/contexts/CommunityTabs.js
+++ b/app/client/src/contexts/CommunityTabs.js
@@ -20,7 +20,7 @@ type State = {
 
 export class CommunityTabsProvider extends React.Component<Props, State> {
   state: State = {
-    activeTabIndex: 0,
+    activeTabIndex: -1,
     infoToggleChecked: true,
     setActiveTabIndex: (activeTabIndex: number) => {
       this.setState({ activeTabIndex });


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3185357](https://app.breeze.pm/projects/100762/cards/3185357)

## Main Changes:
* Fixed an issue where waterbodies would sometimes not show up until the user switched tabs or toggled the layer on/off.

## Steps To Test:
1. Do a search on the community page.
2. Click community.
3. Do another search. The waterbodies should be visible.
4. Repeat steps 1 - 3 several times. 
5. Do deep linking testing
   1. Do a search from the fishing page
   2. Navigate directly to the community page through a url
6. Test toggling on/off layers and switching between full screen and normal mode.
