### PR TITLE
fix conditional where same value was returned regardless of condition…

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -366,8 +366,6 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
           ? 'Impaired'
           : status.good
           ? 'Good'
-          : status.unknown
-          ? 'Condition Unknown'
           : 'Condition Unknown'; // catch all
 
         // Use the status above initially. When looping through the use attainments


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3184751

## Main Changes:
* Followup to the above ticket, this branch fixes the first issue in the screenshot.
* Issue was that a conditional catch-all always returned the same value regardless of it being true or false. It wouldn't cause any issues but we're starting to use SonarCloud and following their clean code recommendations will be helpful

## Steps To Test:
1. Navigate to Waterbody Report page and test various locations, note the icon in the top left corner next to the name of the waterbody.
Test locations:
Condition Unknown: http://localhost:3000/waterbody-report/21AWIC/AL03150106-0204-120
Impaired: http://localhost:3000/waterbody-report/21AWIC/AL03150106-0201-111
Good: http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205-Northeast_Northwest_Branches
