### PR TITLE
Feature/zero assessed waterbodies message

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import Switch from 'components/shared/Switch';
 import WaterbodyList from 'components/shared/WaterbodyList';
-import { StyledErrorBox } from 'components/shared/MessageBoxes';
+import { StyledErrorBox, StyledInfoBox } from 'components/shared/MessageBoxes';
 import TabErrorBoundary from 'components/shared/ErrorBoundary/TabErrorBoundary';
 // styled components
 import {
@@ -30,6 +30,7 @@ import {
   echoError,
   monitoringError,
   huc12SummaryError,
+  zeroAssessedWaterbodies,
 } from 'config/errorMessages';
 
 // --- styled components ---
@@ -42,6 +43,10 @@ const SwitchContainer = styled.div`
 `;
 
 const ErrorBoxWithMargin = styled(StyledErrorBox)`
+  margin: 1em;
+`;
+
+const InfoBoxWithMargin = styled(StyledInfoBox)`
   margin: 1em;
 `;
 
@@ -158,6 +163,7 @@ function Overview({ esriModules, infoToggleChecked }: Props) {
     permittedDischargers.data.Results &&
     permittedDischargers.data.Results.Facilities &&
     permittedDischargers.data.Results.Facilities.length;
+
   return (
     <Container>
       {cipSummary.status === 'failure' && (
@@ -296,6 +302,13 @@ function Overview({ esriModules, infoToggleChecked }: Props) {
           )}
         </StyledMetric>
       </StyledMetrics>
+      {cipSummary.status === 'success' &&
+        waterbodies !== null &&
+        waterbodyCount === 0 && (
+          <InfoBoxWithMargin>
+            {zeroAssessedWaterbodies(watershed)}
+          </InfoBoxWithMargin>
+        )}
       {cipSummary.status !== 'failure' && (
         <WaterbodyList
           waterbodies={waterbodies}

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -14,6 +14,10 @@ export const monitoringError =
 export const huc12SummaryError =
   'Waterbody information is temporarily unavailable, please try again later.';
 
+// message show on the Community page when number of assessed waterbodies is 0
+export const zeroAssessedWaterbodies = (watershed) =>
+  `There are no waterbodies assessed in the ${watershed} watershed.`;
+
 // geocode.arcgis.com - Geolocation Service
 export const geocodeError =
   'Location information is temporarily unavailable, please try again later. ';


### PR DESCRIPTION

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3185243

## Main Changes:
* Add StyledInfoBox to Community Overview tab when number of assessed waterbodies is 0. 

## Steps To Test:
1. Search several locations while on Community Overview to make sure message is not display when it's not applicable.
2. Dallas is a good place to test 0 waterbodies.

