### PR TITLE
Bugfix/handle invalid huc after valid search

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -267,7 +267,14 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
     if (activeTabIndex !== tabIndex) {
       setActiveTabIndex(tabIndex === -1 ? 0 : tabIndex);
     }
-  }, [urlSearch, setActiveTabIndex, activeTabIndex]);
+
+    // set the tab index back to -1 if going to community home page
+    // this is to make sure that when the user does another search
+    // the waterbodies will be shown on the screen
+    return function cleanup() {
+      if (window.location.pathname === '/community') setActiveTabIndex(-1);
+    };
+  }, [urlSearch, activeTabIndex, setActiveTabIndex]);
 
   // conditionally set searchText from urlSearch
   // (e.g. when a user visits '/community/20001' directly)

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -1131,9 +1131,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   // was still set to the default of ''. This was because the setHuc12
   // useState setter is async.
   React.useEffect(() => {
-    if (huc12 === '' || huc12 === lastHuc12) return;
+    if (huc12 === lastHuc12) return;
 
     setLastHuc12(huc12);
+
+    if (huc12 === '') return;
+
     setMapLoading(true);
 
     const query = new Query({

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -43,6 +43,10 @@ const Button = styled.button`
     color: ${colors.white()};
     background-color: ${colors.purple()};
   }
+
+  &:disabled {
+    cursor: default;
+  }
 `;
 
 const Text = styled.p`
@@ -93,7 +97,7 @@ function LocationSearch({ route }: Props) {
         onChange={(ev) => setInputText(ev.target.value)}
       />
 
-      <Button className="btn" type="submit">
+      <Button className="btn" type="submit" disabled={inputText === searchText}>
         <i className="fas fa-angle-double-right" /> Go
       </Button>
 

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -456,6 +456,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
             status: 'success',
             data: [],
           },
+          visibleLayers: {},
         },
         () => navigate('/community'),
       );

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -45,6 +45,11 @@ function useWaterbodyFeatures() {
 
   const [lastHuc12, setLastHuc12] = React.useState(null);
   React.useEffect(() => {
+    // Ensure the lastHuc12 is reset when huc12 is reset.
+    // This is to prevent issues of searching for the same huc
+    // causing the waterbodies data to never load in.
+    if (huc12 === '' && lastHuc12 !== '') setLastHuc12(huc12);
+
     // wait until waterbodies data is set in context
     if (!linesData || !areasData || !pointsData) {
       if (features) setFeatures(null);


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3183763](https://app.breeze.pm/projects/100762/cards/3183763)
* [https://app.breeze.pm/projects/100762/cards/3183793](https://app.breeze.pm/projects/100762/cards/3183793)
* [https://app.breeze.pm/projects/100762/cards/3183887](https://app.breeze.pm/projects/100762/cards/3183887)

## Main Changes:
* Fixed an issue where searching for a valid location and then an invalid location would result in the app leaving the valid location's data on the map.
* Fixed an issue where searching for a valid location, then an invalid location and then the original valid location resulted in the app displaying an infinite loading spinner for the waterbodies.
* Fixed an issue where searching for a zip code and then searching for the huc 12 that corresponds to the zip code that was just searched, resulted in the map not loading.
* Fixed an issue where deep linking to an invalid location and then clicking "Go" would result an an infinite loading spinner for the waterbodies.
    * For this issue I just added code to disable the "Go" button if the value in the search box matches the previous search.

## Steps To Test:
1. First issue:
    1. Navigate to [http://localhost:3000/community/stafford,%20va/overview](http://localhost:3000/community/stafford,%20va/overview)
    2. Search for 000000000000 
    3. Verify that the map is blank.
2. Second issue:
    1. Navigate to [http://localhost:3000/community/stafford,%20va/overview](http://localhost:3000/community/stafford,%20va/overview)
    2. Search for 000000000000 
    3. Search for stafford, va
    4. Verify that all of the stafford, va data loaded in correctly.
3. Third issue:
    1. Search for 20020-2002
    2. Search for 020700100301
    3. Verify that everything loaded in. Both searches should result in all of the same data.
4. Fourth issue:
    1. Navigate to [http://localhost:3000/community/fhdsklsd74ngf789w34/overview](http://localhost:3000/community/fhdsklsd74ngf789w34/overview)
    2. Verify that the "Go" button is disabled. 

