### PR TITLE
Display the no data error for invalid huc12 values.

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -995,6 +995,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           .then((response) => {
             if (response.features.length === 0) {
               // flag no data available for no response
+              setErrorMessage(noDataAvailableError);
               setNoDataAvailable();
             }
 
@@ -1008,6 +1009,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           })
           .catch((err) => {
             console.error(err);
+            setErrorMessage(noDataAvailableError);
             setNoDataAvailable();
           });
       } else {


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3183763](https://app.breeze.pm/projects/100762/cards/3183763) - Addresses the comments on this ticket.

## Main Changes:
* Updated the code to display the no data error when a user searches for an invalid huc. 

## Steps To Test:
1. Navigate to [http://localhost:3000/community/000000000000/overview](http://localhost:3000/community/000000000000/overview).
2. Verify the no data for this location error is displayed.
