### PR TITLE
Feature/by the numbers text

### DIFF
--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -139,6 +139,10 @@ const Disclaimer = styled(DisclaimerModal)`
   margin-bottom: 1rem;
 `;
 
+const ByTheNumbersExplanation = styled.p`
+  font-style: italic;
+`;
+
 // --- components ---
 type Props = {
   ...RouteProps,
@@ -268,6 +272,9 @@ function State({ children, ...props }: Props) {
                             ),
                         )}
                       </StyledMetrics>
+                      <ByTheNumbersExplanation>
+                        Waters not assessed do not show up in summaries below.
+                      </ByTheNumbersExplanation>
                     </>
                   )}
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3203077

## Main Changes:
* Add explanation text to by the numbers section.

## Steps To Test:
1. Navigate to state page. 
2. Test multiple states.
3. If By The Numbers section is hidden for a state, the message should be too. (American Samoa)

