### PR TITLE
feature/mapping-note-emphasis

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -11,7 +11,7 @@ import { ContentTabs } from 'components/shared/ContentTabs';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import AssessmentSummary from 'components/shared/AssessmentSummary';
 import WaterbodyList from 'components/shared/WaterbodyList';
-import { StyledErrorBox } from 'components/shared/MessageBoxes';
+import { StyledErrorBox, StyledNoteBox } from 'components/shared/MessageBoxes';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
 // contexts
@@ -39,6 +39,10 @@ const Toggle = styled.div`
   span {
     margin-left: 0.5rem;
   }
+`;
+
+const NoteBoxContainer = styled(StyledNoteBox)`
+  margin-bottom: 0.625em;
 `;
 
 // sort alphabetically by name
@@ -562,10 +566,13 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                     </a>
                     .
                   </p>
-                  <p>
-                    <strong>Mapping Note:</strong> The map does not display the
-                    actual locations of public water system facility intakes.
-                  </p>
+                  <NoteBoxContainer>
+                    <p>
+                      <strong>Mapping Note:</strong> The map does not display
+                      the actual locations of public water system facility
+                      intakes.
+                    </p>
+                  </NoteBoxContainer>
                 </>
               )}
 

--- a/app/client/src/components/shared/MessageBoxes/index.js
+++ b/app/client/src/components/shared/MessageBoxes/index.js
@@ -43,4 +43,16 @@ const StyledErrorBox = styled(Box)`
   background-color: #f8d7da;
 `;
 
-export { StyledTextBox, StyledInfoBox, StyledSuccessBox, StyledErrorBox };
+const StyledNoteBox = styled(Box)`
+  border-color: #d8dfe2;
+  color: #444;
+  background-color: #f0f6f9;
+`;
+
+export {
+  StyledTextBox,
+  StyledInfoBox,
+  StyledSuccessBox,
+  StyledErrorBox,
+  StyledNoteBox,
+};


### PR DESCRIPTION

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3170557

## Main Changes:
* Add new light blue message box for Drinking Water mapping notes

## Steps To Test:
1. Navigate to Drinking Water tab, then to Withdrawers tab. 
2. Check that message box is wrapped around mapping note and that color matches the rest of the tab's styles.

## TODO:
- Update the Mapping Note on the providers tab which will happen in our dev demo
