### PR TITLE
feature/mapping-note-bold

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -472,14 +472,15 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                     </a>
                     .
                   </p>
-
-                  <p>
-                    <strong>Mapping Note: </strong>The map does not display the
-                    actual locations of public water system facility intakes.
-                    Sources of drinking water are often located outside the
-                    mapped area shown, and may include a combination of
-                    different sources.
-                  </p>
+                  <NoteBoxContainer>
+                    <p>
+                      <strong>Mapping Note: </strong>The map does not display
+                      the actual locations of public water system facility
+                      intakes. Sources of drinking water are often located
+                      outside the mapped area shown, and may include a
+                      combination of different sources.
+                    </p>
+                  </NoteBoxContainer>
                 </>
               )}
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3170557

## Main Changes:
* Add some bold background to provider mapping note

## Steps To Test:
1. Navigate to Drinking Water tab and verify mapping note has background

