### PR TITLE
Bugfix/assessment units service call

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -42,7 +42,7 @@ import { actionsError, noActionsAvailableCombo } from 'config/errorMessages';
 
 const echoUrl = 'https://echo.epa.gov/detailed-facility-report?fid=';
 
-function getAssessmentUnitNames(action: Object) {
+function getAssessmentUnitNames(orgId: string, action: Object) {
   return new Promise((resolve, reject) => {
     const unitIds = action.associatedWaters.specificWaters.map((water) => {
       return water.assessmentUnitIdentifier;
@@ -57,7 +57,8 @@ function getAssessmentUnitNames(action: Object) {
     chunkedUnitIds.forEach((chunk: Array<string>) => {
       const url =
         `${attains.serviceUrl}` +
-        `assessmentUnits?assessmentUnitIdentifier=${chunk.join(',')}`;
+        `assessmentUnits?organizationId=${orgId}` +
+        `&assessmentUnitIdentifier=${chunk.join(',')}`;
       const request = fetchCheck(url);
       requests.push(request);
     });
@@ -249,7 +250,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
         if (res.items.length >= 1 && res.items[0].actions.length >= 1) {
           const action = res.items[0].actions[0];
 
-          getAssessmentUnitNames(action)
+          getAssessmentUnitNames(orgId, action)
             .then((data) => {
               // process assessment unit data and get key action data
               const {

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -627,113 +627,17 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     [setGrts],
   );
 
-  // Runs a query to get the plans for the selected huc. Since action ids are
-  // not unique across ATTAINS (i.e. the same action id could be used across multiple
-  // states), we need to bump up against the assessmentUnits service to get the
-  // organization id for each action.
-  // Note: The actions page will also attempt to look up the organization id, this
-  //       additional logic allows for faster loading of the action page, if the organization
-  //       id is available.
-  // TODO: This additional logic for looking up the org id needs to be removed
-  //       after attains adds the organization id to the plans web service.
+  // Runs a query to get the plans for the selected huc.
+  // Note: The actions page will attempt to look up the organization id.
   const queryAttainsPlans = React.useCallback(
     (huc12) => {
       // get the plans for the selected huc
       fetchCheck(`${attains.serviceUrl}plans?huc=${huc12}`)
         .then((res) => {
-          // get the first assessment unit id for each plan, this will later be
-          // used to get the org id for each plan.
-          const firstAuIds = [];
-          res.items.forEach((plan) => {
-            let firstAuId;
-            if (
-              plan &&
-              plan.associatedWaters &&
-              plan.associatedWaters.specificWaters &&
-              plan.associatedWaters.specificWaters.length > 0
-            ) {
-              firstAuId =
-                plan.associatedWaters.specificWaters[0]
-                  .assessmentUnitIdentifier;
-            }
-
-            firstAuIds.push(firstAuId);
+          setAttainsPlans({
+            data: res,
+            status: 'success',
           });
-
-          // if there are no plans skip retrieval of orgIds
-          if (firstAuIds.length === 0) {
-            setAttainsPlans({
-              data: [],
-              status: 'success',
-            });
-            return;
-          }
-
-          // call the assessment units service to get the org ids.
-          fetchCheck(
-            `${
-              attains.serviceUrl
-            }assessmentUnits?assessmentUnitIdentifier=${firstAuIds.join(',')}`,
-          )
-            .then((auRes) => {
-              // add the org id to the response of the plans service by matching
-              // the first assessment unit id of the plan with the assessment unit id
-              // of the assessment units service.
-              const items = [];
-              res.items.forEach((plan) => {
-                // get the first assessment unit id
-                let firstAuId;
-                if (
-                  plan &&
-                  plan.associatedWaters &&
-                  plan.associatedWaters.specificWaters &&
-                  plan.associatedWaters.specificWaters.length > 0
-                ) {
-                  firstAuId =
-                    plan.associatedWaters.specificWaters[0]
-                      .assessmentUnitIdentifier;
-                }
-
-                // find the first assessment unit id from assessmentUnits response
-                let orgId;
-                // loop through orgs
-                for (let i = 0; i < auRes.items.length; i++) {
-                  const org = auRes.items[i];
-
-                  // loop through assessment units
-                  for (let j = 0; j < org.assessmentUnits.length; j++) {
-                    const assessmentUnit = org.assessmentUnits[j];
-
-                    if (assessmentUnit.assessmentUnitIdentifier === firstAuId) {
-                      orgId = org.organizationIdentifier;
-                      break;
-                    }
-                  }
-
-                  // org id found no more looping necessary
-                  if (orgId) break;
-                }
-
-                plan['organizationIdentifier'] = orgId;
-                items.push(plan);
-              });
-
-              const data = {
-                items,
-                count: items.length,
-              };
-              setAttainsPlans({
-                data,
-                status: 'success',
-              });
-            })
-            .catch((err) => {
-              console.error(err);
-              setAttainsPlans({
-                data: [],
-                status: 'failure',
-              });
-            });
         })
         .catch((err) => {
           console.error(err);


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3223989](https://app.breeze.pm/projects/100762/cards/3223989)

## Main Changes:
* Updated the locationMap component to not use the assessmentUnits service for looking up the orgId, because the assessmentUnits service now requires the orgId as a parameter. 
  * NOTE: This change means that clicking a plan on the restore tab will result in the app always having to route through the intermediate plan summary page. 
* Fixed the plan summary page by adding the org id to the assessment units service call.

## Steps To Test:
1. Navigate to [http://localhost:3000/community/washington%20dc/restore](http://localhost:3000/community/washington%20dc/restore)
2. Verify that there are plans on the Restoration Plans tab
3. Expand one of the plans and click the "Open Plan Summary" link
4. Verify the app routes to the plan-summary page. Watch the url as it should change while routing (i.e. [http://localhost:3000/plan-summary/26257](http://localhost:3000/plan-summary/26257) to [http://localhost:3000/plan-summary/DOEE/26257](http://localhost:3000/plan-summary/DOEE/26257))
5. Navigate to [http://localhost:3000/plan-summary/1](http://localhost:3000/plan-summary/1).
6. Verify the intermediate plan summary page works and is displaying two plans.
7. Click each 'Open Plan Summary' link and ensure they correctly route to the 'plan-summary' page.
