### PR TITLE
Added the location pin to the drinking water panel.

### DIFF
--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -193,16 +193,24 @@ function MapLegendContent({ layer }: CardProps) {
 
   // jsx
   const providersLegend = (
-    <LI>
-      <ImageContainer>
-        {squareIcon({
-          color: '#CBCBCB',
-          strokeWidth: 3,
-          stroke: '#ffff00',
-        })}
-      </ImageContainer>
-      <LegendLabel>Providers</LegendLabel>
-    </LI>
+    <>
+      <LI>
+        <ImageContainer>
+          <PinIcon />
+        </ImageContainer>
+        <LegendLabel>Searched Location</LegendLabel>
+      </LI>
+      <LI>
+        <ImageContainer>
+          {squareIcon({
+            color: '#CBCBCB',
+            strokeWidth: 3,
+            stroke: '#ffff00',
+          })}
+        </ImageContainer>
+        <LegendLabel>Providers</LegendLabel>
+      </LI>
+    </>
   );
 
   // jsx


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3225967](https://app.breeze.pm/projects/100762/cards/3225967)

## Main Changes:
* Added the search location pin icon to the legend on the "Who provides the drinking water here" panel.

## Steps To Test:
1. Do a search on the community page.
2. Go to the "Drinking Water" tab and then click on the "Who provides the drinking water here" tab.
2. Open the legend and verify the map pin icon is there.