### PR TITLE
Bugfix/drinking water search channge

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -928,6 +928,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     if (layers.length === 0 || searchText === lastSearchText) return;
 
     resetData();
+    setHucResponse(null);
     setErrorMessage('');
     setLastSearchText(searchText);
     queryGeocodeServer(searchText);


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3225086](https://app.breeze.pm/projects/100762/cards/3225086)

## Main Changes:
* Fixed an issue where changing the search from the withdrawers weren't being updated when changing the search with the withdrawers tab visible.
* Not a change, but I also went ahead and did a similar test for all of the tabs and it looks like the first two drinking water tabs were the only ones with this issue.

## Steps To Test:
1. Navigate to [http://localhost:3000/community/washington%20dc/drinking-water](http://localhost:3000/community/washington%20dc/drinking-water)
2. Click on the "Who withdraws water for drinking here" tab
3. Search New York
4. Verify the list changes. The list should go from Washington Aqueduct Division (for DC) to Clock Tower Pub & Grill (for New York).

