### PR TITLE
feature/glossary-fetch-retry

### DIFF
--- a/app/client/src/components/shared/GlossaryPanel/index.js
+++ b/app/client/src/components/shared/GlossaryPanel/index.js
@@ -187,9 +187,12 @@ const List = styled.ul`
 
 // --- components ---
 function GlossaryPanel({ path }) {
-  const { initialized, setInitialized } = React.useContext(GlossaryContext);
-
-  const [status, setStatus] = React.useState('fetching');
+  const {
+    initialized,
+    setInitialized,
+    glossaryStatus,
+    setGlossaryStatus,
+  } = React.useContext(GlossaryContext);
 
   // initialize Glossary panel
   React.useEffect(() => {
@@ -203,7 +206,7 @@ function GlossaryPanel({ path }) {
 
       // initialize the glossary
       window.fetchGlossaryTerms.then((terms) => {
-        setStatus(terms.status);
+        setGlossaryStatus(terms.status);
         new Glossary(terms.data);
       });
     }
@@ -232,12 +235,12 @@ function GlossaryPanel({ path }) {
         </Header>
 
         <Content>
-          {status === 'failure' && (
+          {glossaryStatus === 'failure' && (
             <StyledErrorBox>
               <p>{glossaryError}</p>
             </StyledErrorBox>
           )}
-          {status === 'success' && (
+          {glossaryStatus === 'success' && (
             <Input
               className="js-glossary-search form-control"
               type="search"

--- a/app/client/src/components/shared/Page/index.js
+++ b/app/client/src/components/shared/Page/index.js
@@ -153,7 +153,7 @@ type Props = {
 
 function Page({ children }: Props) {
   const { modulesLoaded } = React.useContext(EsriModulesContext);
-  const { initialized } = React.useContext(GlossaryContext);
+  const { initialized, glossaryStatus } = React.useContext(GlossaryContext);
 
   // handles hiding of the data page when the user clicks the browser's back button
   const [dataDisplayed, setDataDisplayed] = React.useState(false);
@@ -185,7 +185,7 @@ function Page({ children }: Props) {
               title="Glossary"
               as="button"
               className="js-glossary-toggle"
-              data-disabled={!initialized}
+              data-disabled={!initialized || glossaryStatus === 'fetching'}
             >
               <i className="fas fa-book" aria-hidden="true" />
               Glossary


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3231515](https://app.breeze.pm/projects/100762/cards/3231515)

## Main Changes:
* Added code to retry fetching glossary terms if the service call fails. The glossary will have 3 retry calls with 1 second between each retry. 

## Steps To Test:
1. Navigate to a page with glossary terms (i.e. [http://localhost:3000/state/AL/advanced-search](http://localhost:3000/state/AL/advanced-search))
2. Verify the glossary terms load in correctly.
3. Open the Chrome dev tools and block the glossary web service from the network tab.
4. Check the console in Chrome dev tools. 
5. Verify that `Failed to fetch Glossary terms. Retrying (X of 3)...` messages show up in the log.
6. After the last retry, verify that glossary shows the error.
7. Verify the glossary buttons are not clickable while the retries are happening.
