### PR TITLE
Bugfix/service errors not being caught

### DIFF
--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -16,6 +16,7 @@ export function fetchCheck(apiUrl: string) {
       let status = err;
       if (err && err.status) status = err.status;
       logCallToGoogleAnalytics(apiUrl, status, startTime);
+      return checkResponse(err);
     });
 }
 
@@ -42,6 +43,7 @@ export function fetchPost(apiUrl: string, data: object, headers: object) {
     .catch((err) => {
       console.error(err);
       logCallToGoogleAnalytics(apiUrl, err, startTime);
+      return checkResponse(err);
     });
 }
 


### PR DESCRIPTION
## Related Issues:
* While investigating why error boundaries were show in the powerpoint on this ticket: https://app.breeze.pm/projects/100762/cards/3249274 I noticed our service error handling is broken and causes tabs to crash instead of displaying specific error messages.
* This is the ticket for this branch: https://app.breeze.pm/projects/100762/cards/3249320

## Main Changes:
* Added a return to the error catches in our fetch functions

## Steps To Test:
To reproduce the error:
1. Navigate to HMW dev site community page
2. Search a location (Stafford, VA) and block all services with ofmpub in the URL. (The issue isn't with  the ofmpub services but they're good for testing this.)
3. The Overview, Protect, and Restore tabs should be displaying the error boundary message which is `The {tabName} tab data is unavailable at this time. Please notify the site administrator.`

These are not the correct error messages and I did some investigation into what broke our service error handling. It looks like the catches in the fetchUtils functions, fetchCheck and fetchPost, are not returning anything which causes unexpected behavior and leads to a value of undefined instead of an empty array depending on the service. I checked the history of the fetchUtils.js file in the hmw archive and the code changed when we added GA logging to the fetches.

To test my changes:
1. Navigate to localhost:3000/community on this branch
2. Search Stafford, VA and block the ofmpub services
3. Check the Overview, Restore, and Protect tabs, The tabs should be partially functional and displaying a more specific message instead of crashing to the tab error boundary

## TODO:
- Add Cypress tests for verifying the correct error messages are shown when services are down or blocked.

