### PR TITLE
Feature/add community tabs overlay

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -69,6 +69,7 @@ const TabsOverlay = styled.div`
   width: 100%;
   height: 45px;
   margin-bottom: -45px;
+  pointer-events: none;
 
   ::before,
   ::after {
@@ -78,7 +79,6 @@ const TabsOverlay = styled.div`
     top: 0;
     width: calc(100% / 9); /* .5 tab width */
     height: inherit;
-    pointer-events: none;
 
     @media (min-width: 800px) {
       width: calc(100% / 11); /* .5 tab width */

--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -156,7 +156,7 @@ const StyledTabs = styled(Tabs)`
       &[data-selected],
       &:hover,
       &:focus {
-        z-index: 1
+        z-index: 1;
         background-color: ${colors.purple()};
         box-shadow: inset 0 -5px 0 ${colors.teal()};
       }

--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -54,9 +54,21 @@ const Watershed = styled.p`
   }
 `;
 
+/*
+  - TabsOverlay's height is set to match each tab's initial min-height value
+    (see StyledTabs [data-react-tab] styles below).
+  - TabsOverlays' margin-bottom matches its height, so the overlay visually
+    appears on top of the tabs, which are below the overlay in the DOM.
+  - Though initially set to 45px, these two values (height and margin-bottom)
+    are re-assigned with the actual rendered height of the tabs in case the
+    tab's text contents makes its height greater than 45px
+    (see measuredTabRef and tabsOverlayRef below).
+*/
 const TabsOverlay = styled.div`
   position: relative;
   width: 100%;
+  height: 45px;
+  margin-bottom: -45px;
 
   ::before,
   ::after {
@@ -65,7 +77,7 @@ const TabsOverlay = styled.div`
     position: absolute;
     top: 0;
     width: calc(100% / 9); /* .5 tab width */
-    height: 45px;
+    height: inherit;
     pointer-events: none;
 
     @media (min-width: 800px) {
@@ -359,6 +371,21 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
     }
   }, [tabListRef, activeTabIndex]);
 
+  // keep the tab overlay height in sync with the height of a tab in the tablist
+  const [tabHeight, setTabHeight] = React.useState(45);
+  const measuredTabRef = React.useCallback((node) => {
+    if (!node) return;
+    setTabHeight(node.getBoundingClientRect().height);
+  }, []);
+
+  const tabsOverlayRef = React.useRef();
+  React.useEffect(() => {
+    if (tabsOverlayRef.current) {
+      tabsOverlayRef.current.style.height = `${tabHeight}px`;
+      tabsOverlayRef.current.style.marginBottom = `-${tabHeight}px`;
+    }
+  }, [tabsOverlayRef, tabHeight]);
+
   const resetTabSpecificData = () => {
     // monitoring panel
     setShowAllMonitoring(true);
@@ -390,7 +417,7 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
         </Text>
       </Location>
 
-      <TabsOverlay />
+      <TabsOverlay ref={tabsOverlayRef} />
 
       <StyledTabs
         index={activeTabIndex}
@@ -415,7 +442,9 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
       >
         <TabList ref={tabListRef}>
           {tabs.map((tab) => (
-            <Tab key={tab.title}>{tab.title}</Tab>
+            <Tab key={tab.title} ref={measuredTabRef}>
+              {tab.title}
+            </Tab>
           ))}
         </TabList>
 

--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -54,6 +54,60 @@ const Watershed = styled.p`
   }
 `;
 
+const TabsOverlay = styled.div`
+  position: relative;
+  width: 100%;
+
+  ::before,
+  ::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0;
+    width: calc(100% / 9); /* .5 tab width */
+    height: 45px;
+    pointer-events: none;
+
+    @media (min-width: 800px) {
+      width: calc(100% / 11); /* .5 tab width */
+    }
+
+    @media (min-width: 960px) {
+      width: calc(100% / 9); /* .5 tab width */
+    }
+
+    @media (min-width: 1280px) {
+      width: calc(100% / 11); /* .5 tab width */
+    }
+
+    @media (min-width: 1600px) {
+      width: calc(100% / 9); /* .5 tab width */
+    }
+
+    @media (min-width: 1920px) {
+      width: calc(100% / 11); /* .5 tab width */
+    }
+  }
+
+  ::before {
+    left: 0;
+    background-image: linear-gradient(
+      to right,
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0)
+    );
+  }
+
+  ::after {
+    right: 0;
+    background-image: linear-gradient(
+      to left,
+      rgba(0, 0, 0, 0.5),
+      rgba(0, 0, 0, 0)
+    );
+  }
+`;
+
 const StyledTabs = styled(Tabs)`
   & ::-webkit-scrollbar {
     height: 12px;
@@ -90,7 +144,7 @@ const StyledTabs = styled(Tabs)`
       &[data-selected],
       &:hover,
       &:focus {
-        z-index: 1;
+        z-index: 1
         background-color: ${colors.purple()};
         box-shadow: inset 0 -5px 0 ${colors.teal()};
       }
@@ -108,7 +162,7 @@ const StyledTabs = styled(Tabs)`
       }
 
       @media (min-width: 960px) {
-        flex-basis: calc(2 / 9 * 100%); /* 4.5 tabs before overlow */
+        flex-basis: calc(2 / 9 * 100%); /* 4.5 tabs before overflow */
       }
 
       @media (min-width: 1280px) {
@@ -335,6 +389,8 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
           )}
         </Text>
       </Location>
+
+      <TabsOverlay />
 
       <StyledTabs
         index={activeTabIndex}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3185187

## Main Changes:
* Adds a semi-transparent gradient overlay over the Community Tabs (persistent over the first and last tab shown in the viewport)

## Steps To Test:
1. Visit a specific community page (e.g. /community/22201/overview) and view the community tabs
