### PR TITLE
bugfix/waterbody-report-infinite-loading-spinners

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -67,6 +67,11 @@ const Container = styled(StyledContainer)`
   }
 `;
 
+const PageErrorBox = styled(StyledErrorBox)`
+  margin: 1rem;
+  text-align: center;
+`;
+
 const ErrorBox = styled(StyledErrorBox)`
   text-align: center;
 `;
@@ -335,7 +340,30 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
 
     fetchCheck(url).then(
       (res) => {
-        if (res.items.length === 0) return;
+        if (res.items.length === 0) {
+          setWaterbodyStatus({
+            status: 'no-data',
+            data: { condition: '', planForRestoration: '', listed303d: '' },
+          });
+          setReportingCycle({
+            status: 'success',
+            year: '',
+          });
+          setWaterbodyUses({
+            status: 'success',
+            data: [],
+          });
+          setOrganizationName({
+            status: 'success',
+            name: '',
+          });
+          setAllParameterActionIds({
+            status: 'success',
+            data: [],
+          });
+          setWaterbodySources({ status: 'success', data: [] });
+          return;
+        }
 
         const firstItem = res.items[0];
         setReportingCycle({
@@ -839,13 +867,33 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
         <NavBar title={<>Plan Summary</>} />
 
         <Container>
-          <ErrorBox>
+          <PageErrorBox>
             <p>
               No waterbodies available for the provided Organization ID:{' '}
               <strong>{orgId}</strong> and Assessment Unit ID:{' '}
               <strong>{auId}</strong>.
             </p>
-          </ErrorBox>
+          </PageErrorBox>
+        </Container>
+      </Page>
+    );
+  }
+
+  if (waterbodyStatus.status === 'no-data') {
+    return (
+      <Page>
+        <NavBar title={<>Plan Summary</>} />
+
+        <Container>
+          <PageErrorBox>
+            <p>
+              Assessment{' '}
+              <strong>
+                {waterbodyName} ({auId})
+              </strong>{' '}
+              has no data available.
+            </p>
+          </PageErrorBox>
         </Container>
       </Page>
     );


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3271668](https://app.breeze.pm/projects/100762/cards/3271668)

## Main Changes:
* Fixed issues with infinite loading spinners on the waterbody report page. This happens when the attains assessments service and or attains actions service doesn't return any data.
* Added a page level error message that is displayed when the assessments service doesn't return any data. 
* Added some padding around the page level error messages, so that it is consistent with the page level error message on the plan summary page.

## Steps To Test:
1. Navigate to [http://localhost:3000/waterbody-report/OREGONDEQ/OR_WS_170900070304_02_104599](http://localhost:3000/waterbody-report/OREGONDEQ/OR_WS_170900070304_02_104599) and verify the page level error message is there. 
    * Note: The message will say "Assessment **HUC12 Name: Lambert Slough-Willamette River (OR_WS_170900070304_02_104599)** has no data available.". The "HUC12 Name:" part is actually part of the name being returned from the web service call. 
2. To verify the infinite loading spinner part, you can change the 'no-data' status to 'success' on line 345 and go to the link in step 1. This will show that the infinite loading spinner on the actions section has been fixed.

