### PR TITLE
feature/update-surveys-mapping

### DIFF
--- a/app/client/src/components/pages/State/lookups/surveyMapping.js
+++ b/app/client/src/components/pages/State/lookups/surveyMapping.js
@@ -1067,7 +1067,7 @@ export const surveyMapping = [
   {
     "state": "KS",
     "organizationIdentifier": "21KAN001",
-    "year": "2018",
+    "year": "2020",
     "subPopulationCode": "Statewide",
     "waterTypeGroupCode": "STREAM/CREEK/RIVER",
     "surveyUseCode": "AQUATIC LIFE",
@@ -1109,6 +1109,20 @@ export const surveyMapping = [
       },
       {
         "stressor": "BENTHIC MACROINVERTEBRATES BIOASSESSMENTS",
+        "surveyCategoryCode": "PASS",
+        "categoryCode_label": "PASS",
+        "categoryCode_order": "1",
+        "categoryCode_color": "#8cc63f",
+      },
+      {
+        "stressor": "CHLORIDE",
+        "surveyCategoryCode": "FAIL",
+        "categoryCode_label": "FAIL",
+        "categoryCode_order": "2",
+        "categoryCode_color": "#f93b5b",
+      },
+      {
+        "stressor": "CHLORIDE",
         "surveyCategoryCode": "PASS",
         "categoryCode_label": "PASS",
         "categoryCode_order": "1",
@@ -1175,7 +1189,7 @@ export const surveyMapping = [
   {
     "state": "KS",
     "organizationIdentifier": "21KAN001",
-    "year": "2018",
+    "year": "2020",
     "subPopulationCode": "Statewide",
     "waterTypeGroupCode": "STREAM/CREEK/RIVER",
     "surveyUseCode": "CONTACT RECREATION",
@@ -1213,7 +1227,7 @@ export const surveyMapping = [
 {
     "state": "KS",
     "organizationIdentifier": "21KAN001",
-    "year": "2018",
+    "year": "2020",
     "subPopulationCode": "Stream/Creek/River with Harvestable Fish",
     "waterTypeGroupCode": "STREAM/CREEK/RIVER",
     "surveyUseCode": "FOOD PROCUREMENT",


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3279806](https://app.breeze.pm/projects/100762/cards/3279806)

## Main Changes:
* Updated the surveyMapping file with the latest data from EPA. Kansas was the only state with changes. 

## Steps To Test:
1. Navigate to [http://localhost:3000/state/KS/water-quality-overview](http://localhost:3000/state/KS/water-quality-overview)
2. Select Aquatic Life > Rivers and Streams
3. Verify the stressors surveyed section shows green and red bars, instead of blue and red.
4. Verify the stressors surveyed section shows Chloride in the list.

