### PR TITLE
Bugfix/huc12 mismatch oddly shaped hucs

### DIFF
--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -14,7 +14,6 @@ type State = {
   searchText: string,
   lastSearchText: String,
   huc12: string,
-  lastHuc12: string,
   watershed: string,
   address: string,
   assessmentUnitId: string,
@@ -79,7 +78,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     searchText: '',
     lastSearchText: '',
     huc12: '',
-    lastHuc12: '',
     watershed: '',
     address: '',
     fishingInfo: { status: 'fetching', data: [] },
@@ -182,9 +180,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     },
     setHuc12: (huc12) => {
       this.setState({ huc12 });
-    },
-    setLastHuc12: (lastHuc12) => {
-      this.setState({ lastHuc12 });
     },
     setWatershed: (watershed) => {
       this.setState({ watershed });


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3280175](https://app.breeze.pm/projects/100762/cards/3280175) - Fixed as part of this PR
* [https://app.breeze.pm/projects/100762/cards/3280399](https://app.breeze.pm/projects/100762/cards/3280399) - Fixed as part of this PR

## Background
Some oddly shaped hucs (especially C shaped hucs like 150100150706) would have the pushpin get placed outside of the huc boundaries. This was causing the mismatch because the first watersgeo call would get the correct huc info (150100150706), then it would pass the lat/long of its centroid to processGeocodeServerResults. The processGeocodeServerResults function would then query the esri geocoder and then call watersgeo again with lat/long from the geocoder. This second watersgeo would get the wrong huc (150100150708) because the centroid of the 150100150706 huc is inside of the 150100150708 huc. 

## Main Changes:
* Changed the code to only query watersgeo once for huc 12 searches. The old code was running the huc12 query 3 times for a huc12 search and 2 times for non-huc12 searches.
    * This required moving some of the react callbacks around to avoid the '<name> used before it was defined' warnings.
* Updated the queryGeocodeServer callback so that it used the new centermass_x and centermass_y attributes for placing the pushpin inside of the huc boundaries. 

## Steps To Test:
1. Navigate to [http://localhost:3000/community/150100150706/overview](http://localhost:3000/community/150100150706/overview)
2. Verify the searched huc matches the huc in top of the right hand panel.
3. Check the network tab of the dev tools and make sure the hydrological query only happens once.
4. Try searching for a city and make sure the hydrological query only happens once.

