### PR TITLE
feature/null-catchment-percent-issue

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -486,6 +486,13 @@ class IdentifiedIssues extends React.Component<Props, State> {
         cipSummary.data.items[0].containImpairedWatersCatchmentAreaPercent,
       );
 
+    const nullPollutedWaterbodies =
+      cipServiceReady &&
+      cipSummary.data.items[0].containImpairedWatersCatchmentAreaPercent ===
+        null
+        ? true
+        : false;
+
     let toggleIssuesChecked;
 
     if (zeroPollutedWaterbodies) {
@@ -527,6 +534,8 @@ class IdentifiedIssues extends React.Component<Props, State> {
                   <StyledNumber>
                     {cipSummary.status === 'failure'
                       ? 'N/A'
+                      : nullPollutedWaterbodies
+                      ? 'N/A %'
                       : `${pollutedPercent}%` || 0 + '%'}
                   </StyledNumber>
                   <StyledLabel>of Assessed Waters are impaired</StyledLabel>
@@ -704,7 +713,11 @@ class IdentifiedIssues extends React.Component<Props, State> {
                                                 {mappedParameterName}
                                               </FlexDiv>
                                             </td>
-                                            <td>{percent}%</td>
+                                            <td>
+                                              {nullPollutedWaterbodies === true
+                                                ? 'N/A'
+                                                : percent + '%'}
+                                            </td>
                                           </tr>
                                         );
                                       },


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3280215


## Main Changes:
* Handle locations where ATTAINS returns null for catchment percentage and we cannot display the actual percentages of waterbody pollution on the Identified Issues tab.

## Steps To Test:
Attains has fixed the issue with the locations we were using to test that returned null for the catchment percent value.
In order to verify we correctly handle a null value:
1. On line 489 of IdentifiedIssues.js, change the line to be:
`const nullPollutedWaterbodies = true;`
This will force the app to handle the null value scenario.

2. Navigate to Community page and search any location, then navigate to Identified Issues tab 
http://localhost:3000/community/dc/identified-issues

3. App should match the mockup in the breeze card: displaying information we have and showing actual percentages as N/A 
https://app.breeze.pm/projects/100762/cards/3280215


