### PR TITLE
Bugfix/huc geocoder failure

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -950,8 +950,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             });
         })
         .catch((err) => {
-          console.error(err);
           if (!hucRes) {
+            console.error(err);
             setAddress(searchText); // preserve the user's search so it is displayed
             setNoDataAvailable();
             setErrorMessage(geocodeError);

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -958,11 +958,16 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             return;
           }
 
+          // Note: that since the geocoder failed, the lat/long will be displayed
+          //   where the address would normally be.
+          // Go ahead and zoom to the center of the huc
           const { centermass_x, centermass_y } = hucRes.features[0].attributes;
           renderMapAndZoomTo(centermass_x, centermass_y, () =>
             handleHUC12(hucRes),
           );
 
+          // set drinkingWater to an empty array, since we don't have
+          // the necessary parameters for the GetPWSWMHUC12 call
           setDrinkingWater({
             data: [],
             status: 'success',

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -951,12 +951,21 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         })
         .catch((err) => {
           console.error(err);
-          setAddress(searchText); // preserve the user's search so it is displayed
           if (!hucRes) {
+            setAddress(searchText); // preserve the user's search so it is displayed
             setNoDataAvailable();
             setErrorMessage(geocodeError);
             return;
           }
+
+          // get the coordinates, round them and display as search text
+          const coords = searchText.split(', ');
+          const digits = 6;
+          setAddress(
+            parseFloat(coords[0]).toFixed(digits) +
+              ', ' +
+              parseFloat(coords[1]).toFixed(digits),
+          );
 
           // Note: that since the geocoder failed, the lat/long will be displayed
           //   where the address would normally be.

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -952,8 +952,21 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         .catch((err) => {
           console.error(err);
           setAddress(searchText); // preserve the user's search so it is displayed
-          setNoDataAvailable();
-          setErrorMessage(geocodeError);
+          if (!hucRes) {
+            setNoDataAvailable();
+            setErrorMessage(geocodeError);
+            return;
+          }
+
+          const { centermass_x, centermass_y } = hucRes.features[0].attributes;
+          renderMapAndZoomTo(centermass_x, centermass_y, () =>
+            handleHUC12(hucRes),
+          );
+
+          setDrinkingWater({
+            data: [],
+            status: 'success',
+          });
         });
     },
     [


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3302941](https://app.breeze.pm/projects/100762/cards/3302941)

## Main Changes:
* Fixed an issue where the community page displayed a "Location not available" for a valid HUC search where the geocoder failed to find the point. 

## Steps To Test:
1. Navigate to [http://localhost:3000/community/030102051705/overview](http://localhost:3000/community/030102051705/overview)
2. The page should show the HUC boundaries and everything on the community page should work.
    * Drinking water will display the "no drinking water data" error as there is no county/region info, since the geocoder failed.
3. Try other searches and make sure they still work.

