### PR TITLE
Feature/handle ATTAINS usesStateSummary service issues

### DIFF
--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -184,8 +184,6 @@ function State({ children, ...props }: Props) {
   // (e.g. when a user navigates directly to '/state/DC/advanced-search')
   React.useEffect(() => {
     setUsesStateSummaryServiceError(false);
-    console.log('activestate', activeState);
-    // console.log('selcted state', selectedState);
     setSelectedState(activeState);
   }, [activeState, setUsesStateSummaryServiceError]);
 

--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -32,7 +32,11 @@ import introText from 'components/pages/State/lookups/introText';
 // styles
 import { colors, fonts } from 'styles/index.js';
 // errors
-import { stateListError, stateNoDataError } from 'config/errorMessages';
+import {
+  stateListError,
+  stateNoDataError,
+  usesStateSummaryServiceInvalidResponse,
+} from 'config/errorMessages';
 
 // --- styled components ---
 const Container = styled.div`
@@ -158,7 +162,12 @@ function State({ children, ...props }: Props) {
       .catch((err) => setStates({ status: 'failure', data: [] }));
   }, []);
 
-  const { activeState, setActiveState } = React.useContext(StateTabsContext);
+  const {
+    activeState,
+    setActiveState,
+    usesStateSummaryServiceError,
+    setUsesStateSummaryServiceError,
+  } = React.useContext(StateTabsContext);
 
   // reset active state if on state intro page
   React.useEffect(() => {
@@ -174,8 +183,11 @@ function State({ children, ...props }: Props) {
   // update selectedState whenever activeState changes
   // (e.g. when a user navigates directly to '/state/DC/advanced-search')
   React.useEffect(() => {
+    setUsesStateSummaryServiceError(false);
+    console.log('activestate', activeState);
+    // console.log('selcted state', selectedState);
     setSelectedState(activeState);
-  }, [activeState]);
+  }, [activeState, setUsesStateSummaryServiceError]);
 
   // get the state intro and metrics data
   const stateIntro = introText[activeState.code];
@@ -240,79 +252,88 @@ function State({ children, ...props }: Props) {
           </>
         )}
 
-        <Content>
-          {activeState.code !== '' && (
-            <>
-              {!stateIntro ? (
-                <ErrorBox>
-                  <p>{stateNoDataError(activeState.name)}.</p>
-                </ErrorBox>
-              ) : (
-                <>
-                  {stateIntro.metrics.length > 0 && (
-                    <>
-                      <h2>
-                        <i className="fas fa-chart-line" />
-                        <strong>{activeState.name}</strong> by the Numbers
-                      </h2>
+        {usesStateSummaryServiceError ? (
+          <ErrorBox>
+            {usesStateSummaryServiceInvalidResponse(activeState.name)}
+          </ErrorBox>
+        ) : (
+          <Content>
+            {activeState.code !== '' && (
+              <>
+                {!stateIntro ? (
+                  <ErrorBox>
+                    <p>{stateNoDataError(activeState.name)}.</p>
+                  </ErrorBox>
+                ) : (
+                  <>
+                    {stateIntro.metrics.length > 0 && (
+                      <>
+                        <h2>
+                          <i className="fas fa-chart-line" />
+                          <strong>{activeState.name}</strong> by the Numbers
+                        </h2>
 
-                      <StyledMetrics>
-                        {stateIntro.metrics.map(
-                          (metric, index) =>
-                            metric &&
-                            metric.value &&
-                            metric.label && (
-                              <StyledMetric key={index}>
-                                <StyledNumber>{metric.value}</StyledNumber>
-                                <StyledLabel>
-                                  {metric.label}
-                                  <br />
-                                  <em>{metric.unit}</em>
-                                </StyledLabel>
-                              </StyledMetric>
-                            ),
-                        )}
-                      </StyledMetrics>
-                      <ByTheNumbersExplanation>
-                        Waters not assessed do not show up in summaries below.
-                      </ByTheNumbersExplanation>
-                    </>
-                  )}
+                        <StyledMetrics>
+                          {stateIntro.metrics.map(
+                            (metric, index) =>
+                              metric &&
+                              metric.value &&
+                              metric.label && (
+                                <StyledMetric key={index}>
+                                  <StyledNumber>{metric.value}</StyledNumber>
+                                  <StyledLabel>
+                                    {metric.label}
+                                    <br />
+                                    <em>{metric.unit}</em>
+                                  </StyledLabel>
+                                </StyledMetric>
+                              ),
+                          )}
+                        </StyledMetrics>
+                        <ByTheNumbersExplanation>
+                          Waters not assessed do not show up in summaries below.
+                        </ByTheNumbersExplanation>
+                      </>
+                    )}
 
-                  {stateIntro.intro && (
-                    <IntroBox>
+                    {stateIntro.intro && (
+                      <IntroBox>
+                        <p>
+                          <ShowLessMore
+                            text={stateIntro.intro}
+                            charLimit={450}
+                          />
+                        </p>
+                      </IntroBox>
+                    )}
+
+                    <Disclaimer>
                       <p>
-                        <ShowLessMore text={stateIntro.intro} charLimit={450} />
+                        The condition of a waterbody is dynamic and can change
+                        at any time, and the information in How’s My Waterway
+                        should only be used for general reference. If available,
+                        refer to local or state real-time water quality reports.
                       </p>
-                    </IntroBox>
-                  )}
+                      <p>
+                        Furthermore, users of this application should not rely
+                        on information relating to environmental laws and
+                        regulations posted on this application. Application
+                        users are solely responsible for ensuring that they are
+                        in compliance with all relevant environmental laws and
+                        regulations. In addition, EPA cannot attest to the
+                        accuracy of data provided by organizations outside of
+                        the federal government.
+                      </p>
+                    </Disclaimer>
+                  </>
+                )}
+              </>
+            )}
 
-                  <Disclaimer>
-                    <p>
-                      The condition of a waterbody is dynamic and can change at
-                      any time, and the information in How’s My Waterway should
-                      only be used for general reference. If available, refer to
-                      local or state real-time water quality reports.
-                    </p>
-                    <p>
-                      Furthermore, users of this application should not rely on
-                      information relating to environmental laws and regulations
-                      posted on this application. Application users are solely
-                      responsible for ensuring that they are in compliance with
-                      all relevant environmental laws and regulations. In
-                      addition, EPA cannot attest to the accuracy of data
-                      provided by organizations outside of the federal
-                      government.
-                    </p>
-                  </Disclaimer>
-                </>
-              )}
-            </>
-          )}
-
-          {/* children is either StateIntro or StateTabs */}
-          {children}
-        </Content>
+            {/* children is either StateIntro or StateTabs */}
+            {children}
+          </Content>
+        )}
       </Container>
     </Page>
   );

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -88,6 +88,11 @@ export const grpaError =
 
 // State errors //
 
+// for where ATTAINS usesStateSummaryService response is an internal error or missing data for a state
+export const usesStateSummaryServiceInvalidResponse = (stateName) =>
+  `There is no State-level assessment data available${stateName &&
+    ' for ' + stateName}.`; // add conditional check for stateName as it is sometimes undefined
+
 // attains state document service
 export const stateDocumentError = (stateName) =>
   `${stateName} integrated report documents are temporarily unavailable, please try again later.`;

--- a/app/client/src/contexts/StateTabs.js
+++ b/app/client/src/contexts/StateTabs.js
@@ -29,6 +29,8 @@ export class StateTabsProvider extends React.Component<Props, State> {
       data: {},
     },
     activeState: { code: '', name: '' },
+    // in case ATTAINS usesStateSummary service returns invalid data or an internal error
+    usesStateSummaryServiceError: false,
     setActiveTabIndex: (activeTabIndex: number) => {
       this.setState({ activeTabIndex });
     },
@@ -40,6 +42,11 @@ export class StateTabsProvider extends React.Component<Props, State> {
     },
     setActiveState: (activeState: { code: string, name: string }) => {
       this.setState({ activeState });
+    },
+    setUsesStateSummaryServiceError: (
+      usesStateSummaryServiceError: boolean,
+    ) => {
+      this.setState({ usesStateSummaryServiceError });
     },
   };
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3053853

## Main Changes:
* Handle edge cases in ATTAINS usesStateSummary service where some states have no reporting cycles or the ATTAINS server returns a 500 internal server error.
* This currently only occurs on the ATTAINS dev site.

## Steps To Test:
1. The ATTAINS dev site is not CORS enabled so for testing you can change the URL to use our proxy.
In the webServiceConfig.js file, change line 33 to  
`serviceUrl: 'http://localhost:9091/proxy?url=http://54.209.48.156/attains-public/api/',`

2. Navigate to the state page and select some states:
- **Alaska** has an issue where the service returns an empty reportingCycles array.
- **Arkansas** has an issue where the server responds with a 500 error.
- Most other states should be working normally, there are a few others with one of the above problems.

3. States like AL and AK should display an error box with a message.

