### PR TITLE
Feature/drinking water service change

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -105,7 +105,9 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
   return (
     <AccordionItem
       key={
-        item.water_type_calc ? item.pwsid + item.water_type_calc : item.pwsid
+        item.water_type_calc
+          ? item.pwsid + item.water_type_calc + item.water_type_code
+          : item.pwsid
       }
       title={<strong>{item.pws_name || 'Unknown'}</strong>}
       subTitle={
@@ -113,8 +115,10 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
           Drinking Water Population Served:{' '}
           {Number(item['population_served_count']).toLocaleString()}
           <br />
-          Drinking Water Facility Source:{' '}
-          {isWithdrawer ? item['water_type_calc'] : item['gw_sw']}
+          Drinking Water System Source:{' '}
+          {isWithdrawer
+            ? item.water_type_calc
+            : item.gw_sw.replace('Groundwater', 'Ground water')}
         </>
       }
     >
@@ -155,9 +159,13 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
           </tr>
           <tr>
             <td>
-              <em>Drinking Water Facility Source:</em>
+              <em>Drinking Water System Source:</em>
             </td>
-            <td>{isWithdrawer ? item.water_type_calc : item.gw_sw}</td>
+            <td>
+              {isWithdrawer
+                ? item.water_type_calc
+                : item.gw_sw.replace('Groundwater', 'Ground water')}
+            </td>
           </tr>
           <tr>
             <td>
@@ -642,7 +650,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                             <thead>
                               <tr>
                                 <th>
-                                  <span>Drinking Water Source</span>
+                                  <span>Drinking Water Facility Source</span>
                                 </th>
                                 <th>Count</th>
                               </tr>

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -104,7 +104,9 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
     `${item.pwsid}`;
   return (
     <AccordionItem
-      key={item.pwsid}
+      key={
+        item.water_type_calc ? item.pwsid + item.water_type_calc : item.pwsid
+      }
       title={<strong>{item.pws_name || 'Unknown'}</strong>}
       subTitle={
         <>

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -947,6 +947,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           new QueryTask({ url: `${counties}/query` })
             .execute(countiesQuery)
             .then((countiesRes) => {
+              // not all locations have a State and County code, check for it
               if (
                 countiesRes.features &&
                 countiesRes.features.length > 0 &&
@@ -1183,6 +1184,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         status: 'success',
       });
     } else {
+      // if FIPS codes do not exist we cannot query the drinking water service
       if (
         FIPS.status === 'failure' ||
         FIPS.stateCode === '' ||

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -137,6 +137,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setWatershed,
     resetData,
     setNoDataAvailable,
+    FIPS,
+    setFIPS,
 
     layers,
     setLayers,
@@ -933,11 +935,41 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           const countiesQuery = new Query({
             returnGeometry: true,
             geometry: location.location.clone(),
+            outFields: ['*'],
+          });
+
+          setFIPS({
+            stateCode: '',
+            countyCode: '',
+            status: 'fetching',
           });
 
           new QueryTask({ url: `${counties}/query` })
             .execute(countiesQuery)
             .then((countiesRes) => {
+              if (
+                countiesRes.features &&
+                countiesRes.features.length > 0 &&
+                countiesRes.features[0].attributes
+              ) {
+                const stateCode = countiesRes.features[0].attributes.STFIPS;
+                const countyCode = countiesRes.features[0].attributes.CTFIPS.substring(
+                  2,
+                  5,
+                );
+                setFIPS({
+                  stateCode: stateCode,
+                  countyCode: countyCode,
+                  status: 'success',
+                });
+              } else {
+                setFIPS({
+                  stateCode: '',
+                  countyCode: '',
+                  status: 'failure',
+                });
+              }
+
               setCountyBoundaries(countiesRes);
             })
             .catch((err) => {
@@ -945,6 +977,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               setCountyBoundaries(null);
               setDrinkingWater({
                 data: [],
+                status: 'failure',
+              });
+              setFIPS({
+                stateCode: '',
+                countyCode: '',
                 status: 'failure',
               });
             });
@@ -996,6 +1033,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       setAddress,
       setCountyBoundaries,
       setDrinkingWater,
+      setFIPS,
       setNoDataAvailable,
     ],
   );
@@ -1145,21 +1183,28 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         status: 'success',
       });
     } else {
-      // make sure that territories are using the correct value for
-      // the state/region parameter
-      let region = location.attributes.Region;
-      if (region === 'US Virgin Islands') region = 'Virgin Islands';
+      if (
+        FIPS.status === 'failure' ||
+        FIPS.stateCode === '' ||
+        FIPS.countyCode === ''
+      ) {
+        setDrinkingWater({
+          data: [],
+          status: 'failure',
+        });
+        return;
+      }
 
       const drinkingWaterUrl =
-        `${dwmaps.getPWSHUC12}` +
+        `${dwmaps.GetPWSWMHUC12FIPS}` +
         `${hucResponse.features[0].attributes.huc12}/` +
-        `${countyBoundaries.features[0].attributes.COUNTY}/` +
-        `${region}`;
+        `${FIPS.stateCode}/` +
+        `${FIPS.countyCode}`;
 
       fetchCheck(drinkingWaterUrl)
         .then((drinkingWaterRes) => {
           setDrinkingWater({
-            data: drinkingWaterRes.items.slice(0),
+            data: drinkingWaterRes.items,
             status: 'success',
           });
         })
@@ -1171,7 +1216,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           });
         });
     }
-  }, [countyBoundaries, hucResponse, location, setDrinkingWater]);
+  }, [FIPS, countyBoundaries, hucResponse, location, setDrinkingWater]);
 
   // const queryNonprofits = (boundaries) => {
   //   if (

--- a/app/client/src/config/webServiceConfig.js
+++ b/app/client/src/config/webServiceConfig.js
@@ -19,6 +19,7 @@ export const echoNPDES = {
 
 export const dwmaps = {
   getPWSHUC12: `${ofmpubURL}apex/sfdw_rest/GetPWSWMHUC12/`,
+  GetPWSWMHUC12FIPS: `${ofmpubURL}apex/sfdw_rest/GetPWSWMHUC12FIPS/`,
   getGPRASummary: `${ofmpubURL}apex/sfdw_rest/GetGPRASummary/`,
   getGPRASystemCountsByType: `${ofmpubURL}apex/sfdw_rest/GetGPRASystemCountsByType/`,
 };

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -302,9 +302,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     setDrinkingWaterTabIndex: (drinkingWaterTabIndex) => {
       this.setState({ drinkingWaterTabIndex });
     },
-    setStateCodeFIPS: (stateCodeFIPS) => {
-      this.setState({ stateCodeFIPS });
-    },
     setFIPS: (FIPS) => {
       this.setState({ FIPS });
     },

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -50,8 +50,7 @@ type State = {
   areasLayer: Object,
   summaryLayerMaxRecordCount: ?number,
   watershedsLayerMaxRecordCount: ?number,
-  stateCodeFIPS: string,
-  countyCodeFIPS: string,
+  FIPS: Object,
 
   // monitoring panel
   showAllMonitoring: boolean,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -50,6 +50,8 @@ type State = {
   areasLayer: Object,
   summaryLayerMaxRecordCount: ?number,
   watershedsLayerMaxRecordCount: ?number,
+  stateCodeFIPS: string,
+  countyCodeFIPS: string,
 
   // monitoring panel
   showAllMonitoring: boolean,
@@ -133,6 +135,11 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     areasData: null,
     pointsData: null,
     esriHelper: new EsriHelper(),
+    FIPS: {
+      stateCode: '',
+      countyCode: '',
+      status: 'fetching',
+    },
 
     pointsLayer: '',
     linesLayer: '',
@@ -295,6 +302,12 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     },
     setDrinkingWaterTabIndex: (drinkingWaterTabIndex) => {
       this.setState({ drinkingWaterTabIndex });
+    },
+    setStateCodeFIPS: (stateCodeFIPS) => {
+      this.setState({ stateCodeFIPS });
+    },
+    setFIPS: (FIPS) => {
+      this.setState({ FIPS });
     },
 
     /////// Functions that do more than just set a single state ////////


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3308677

## Main Changes:
* Switch to new drinking water service that uses state and county codes from the NEPAssist county service.
* Withdrawers tab of Community Drinking Water tab now uses water_type_calc property to determine whether withdrawers are Surface Water or Ground Water.

## Steps To Test:
Note: new drinking water service is returning duplicates for some withdrawers where they will have the same pwid and data but the water_type_calc property is different. 

Example of the duplicate issue: 

Las, Vegas. First 2 items in service results https://ofmpub.epa.gov/apex/sfdw_rest/GetPWSWMHUC12FIPS/150100150604/32/003

We have contacted the service to make sure they are aware and HMW is able to handle the duplicate issue.

You may need to clear cache and refresh to fix CORS issues when comparing between localhost and the dev site. This is an old Chromium issue we have run into before and are looking into it in another ticket.

1. On Community, navigate to some test locations listed below, then go to the Withdrawers tab of the Drinking Water tab:
http://localhost:3000/community/las%20vegas/drinking-water 
http://localhost:3000/community/010900020303/drinking-water

2. Verify Withdrawers tab is now using the water_type_calc property instead of the gw_sw property from the drinking water service data:
- Compare these locations to the dev site and verify 'Groundwater' is now 'Ground Water' on the local branch. 
- Compare the number of withdrawers in each category between the dev and live site for Las, Vegas. The numbers should be different.
- Verify the sorts work on the Drinking Water tab

