### PR TITLE
Feature/add timeouts to fetch

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -631,7 +631,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   const queryAttainsPlans = React.useCallback(
     (huc12) => {
       // get the plans for the selected huc
-      fetchCheck(`${attains.serviceUrl}plans?huc=${huc12}`)
+      fetchCheck(`${attains.serviceUrl}plans?huc=${huc12}`, 120000)
         .then((res) => {
           setAttainsPlans({
             data: res,

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -3,9 +3,11 @@
 import { mapServiceMapping } from 'config/mapServiceConfig';
 import { webServiceMapping } from 'config/webServiceConfig';
 
-export function fetchCheck(apiUrl: string) {
+const defaultTimeout = 60000;
+
+export function fetchCheck(apiUrl: string, timeout: number = defaultTimeout) {
   const startTime = performance.now();
-  return fetch(apiUrl)
+  return timeoutPromise(timeout, fetch(apiUrl))
     .then((response) => {
       logCallToGoogleAnalytics(apiUrl, response.status, startTime);
       return checkResponse(response);
@@ -20,22 +22,30 @@ export function fetchCheck(apiUrl: string) {
     });
 }
 
-export function proxyFetch(apiUrl: string) {
+export function proxyFetch(apiUrl: string, timeout: number = defaultTimeout) {
   const { REACT_APP_PROXY_URL } = process.env;
   // if environment variable is not set, default to use the current site origin
   const proxyUrl = REACT_APP_PROXY_URL || `${window.location.origin}/proxy`;
   const url = `${proxyUrl}?url=${apiUrl}`;
 
-  return fetchCheck(url);
+  return fetchCheck(url, timeout);
 }
 
-export function fetchPost(apiUrl: string, data: object, headers: object) {
+export function fetchPost(
+  apiUrl: string,
+  data: object,
+  headers: object,
+  timeout: number = defaultTimeout,
+) {
   const startTime = performance.now();
-  return fetch(apiUrl, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(data),
-  })
+  return timeoutPromise(
+    timeout,
+    fetch(apiUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(data),
+    }),
+  )
     .then((response) => {
       logCallToGoogleAnalytics(apiUrl, response.status, startTime);
       return checkResponse(response);
@@ -45,6 +55,28 @@ export function fetchPost(apiUrl: string, data: object, headers: object) {
       logCallToGoogleAnalytics(apiUrl, err, startTime);
       return checkResponse(err);
     });
+}
+
+function timeoutPromise(timeout, promise) {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(
+        new Error(
+          `PROMISE_TIMED_OUT: The promise took more than ${timeout}ms.`,
+        ),
+      );
+    }, timeout);
+
+    promise
+      .then((res) => {
+        clearTimeout(timeoutId);
+        resolve(res);
+      })
+      .catch((err) => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+  });
 }
 
 export function checkResponse(response) {


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3316378](https://app.breeze.pm/projects/100762/cards/3316378)

## Main Changes:
* Updated the fetch functions to have a timeout parameter (default is 1 minute). 
  * Note: In the future we may need to up the timeouts of specific web service requests.
* Set the attains plans fetch timeout to 2 minutes. 

## Steps To Test:
1. Do some searches on the community page and make sure everything works correctly (i.e. no timeouts for services that returned in less than a minute).
2. In the code (line 634 in LocationMap/index.js and line 6 in fetchUtils.js), change the timeouts to something small like 750ms. Check the console log and make sure some of the fetches hit the timeout error.

