### PR TITLE
Feature/waterbody report map transparency

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -182,13 +182,13 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             let symbol;
             if (type === 'point') {
               symbol = new SimpleMarkerSymbol({
-                color: '#007bff',
+                color: '#1e72cb',
                 style: 'circle',
               });
             }
             if (type === 'line') {
               symbol = new SimpleLineSymbol({
-                color: '#007bff',
+                color: '#1e72cb',
                 style: 'solid',
                 width: '2',
               });

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -195,7 +195,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             }
             if (type === 'area') {
               symbol = new SimpleFillSymbol({
-                color: '#007bff',
+                color: '#1e72cbd1',
                 style: 'solid',
               });
             }

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -243,7 +243,7 @@ function MapLegendContent({ layer }: CardProps) {
   const actionsWaterbodiesLegend = (
     <LI>
       <ImageContainer>
-        {squareIcon({ color: '#007BFF', strokeWidth: 0 })}
+        {squareIcon({ color: '#1e72cb', strokeWidth: 0 })}
       </ImageContainer>
       <LegendLabel>Waterbody</LegendLabel>
     </LI>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3312442

## Main Changes:
* Add transparency to the color of areas on Waterbody Report and Actions maps

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/UTAHDWQ/UT16010203-005_00
2. Verify you can see and select lines underneath the area on the map

