### PR TITLE
Feature/correct waterbody report map color

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -182,20 +182,20 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             let symbol;
             if (type === 'point') {
               symbol = new SimpleMarkerSymbol({
-                color: '#1e72cb',
+                color: [0, 123, 255],
                 style: 'circle',
               });
             }
             if (type === 'line') {
               symbol = new SimpleLineSymbol({
-                color: '#1e72cb',
+                color: [0, 123, 255],
                 style: 'solid',
                 width: '2',
               });
             }
             if (type === 'area') {
               symbol = new SimpleFillSymbol({
-                color: '#1e72cbd1',
+                color: [0, 123, 255, 0.5],
                 style: 'solid',
               });
             }

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -243,7 +243,7 @@ function MapLegendContent({ layer }: CardProps) {
   const actionsWaterbodiesLegend = (
     <LI>
       <ImageContainer>
-        {squareIcon({ color: '#1e72cb', strokeWidth: 0 })}
+        {squareIcon({ color: 'rgb(0, 123, 255)', strokeWidth: 0 })}
       </ImageContainer>
       <LegendLabel>Waterbody</LegendLabel>
     </LI>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3312442

## Main Changes:
* Esri does not allow transparent Hex colors which led to us using the wrong shade of blue to compensate. 
* I've converted the Actions map colors (Waterbody Report too) to RGBA so that transparency works correctly 
* Further reading: https://developers.arcgis.com/javascript/latest/api-reference/esri-Color.html

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/UTAHDWQ/UT16010203-005_00
2. Verify lines are visible through area and area color is the same as lines and points, except for 0.5 transparency.

