### PR TITLE
Bugfix/zoom to single point

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -289,7 +289,20 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
 
     const { Viewpoint } = esriModules;
 
-    mapView.goTo(actionsLayer.graphics).then(() => {
+    let zoomParams = actionsLayer.graphics;
+    if (
+      actionsLayer.graphics.length === 1 &&
+      (actionsLayer.graphics.items[0].geometry.type === 'point' ||
+        actionsLayer.graphics.items[0].geometry.type === 'multipoint')
+    ) {
+      // handle zooming to a single point graphic
+      zoomParams = {
+        target: actionsLayer.graphics,
+        zoom: 16, // set zoom 1 higher since it gets decremented later
+      };
+    }
+
+    mapView.goTo(zoomParams).then(() => {
       // set map zoom and home widget's viewpoint
       mapView.zoom = mapView.zoom - 1;
       homeWidget.viewpoint = new Viewpoint({

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -950,6 +950,7 @@ function AdvancedSearch({ ...props }: Props) {
       layout={fullscreenActive ? 'fullscreen' : 'narrow'}
       filter={currentFilter}
       activeState={activeState}
+      numberOfRecords={numberOfRecords}
     >
       <MapFooter style={{ width: fullscreenActive ? width : '100%' }}>
         <strong>303(d) List Status / Year Last Reported:</strong>

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -50,6 +50,7 @@ type Props = {
   windowWidth: number,
   filter: string,
   activeState: Object,
+  numberOfRecords: number,
   children?: Node,
 };
 
@@ -59,6 +60,7 @@ function StateMap({
   windowWidth,
   filter,
   activeState,
+  numberOfRecords,
   children,
 }: Props) {
   const [view, setView] = React.useState(null);
@@ -241,7 +243,8 @@ function StateMap({
       pointsLayer &&
       linesLayer &&
       areasLayer &&
-      homeWidget
+      homeWidget &&
+      numberOfRecords
     ) {
       setLastFilter(filter);
 
@@ -278,8 +281,18 @@ function StateMap({
 
             // if there is an extent then zoom to it and set the home widget
             if (fullExtent) {
+              let zoomParams = fullExtent;
+              let homeParams = { targetGeometry: fullExtent };
               if (!selectedGraphic) {
-                view.goTo(fullExtent).then(() => {
+                if (numberOfRecords === 1 && pointsExtent.count === 1) {
+                  zoomParams = { target: fullExtent, zoom: 15 };
+                  homeParams = {
+                    targetGeometry: fullExtent,
+                    scale: 18056, // same as zoom 15, viewpoint only takes scale
+                  };
+                }
+
+                view.goTo(zoomParams).then(() => {
                   // only show the waterbody layer after everything has loaded to
                   // cut down on unnecessary service calls
                   waterbodyLayer.listMode = 'hide-children';
@@ -292,9 +305,7 @@ function StateMap({
 
               // only set the home widget if the user selects a different state
               if (!homeWidgetSet) {
-                homeWidget.viewpoint = new Viewpoint({
-                  targetGeometry: fullExtent,
-                });
+                homeWidget.viewpoint = new Viewpoint(homeParams);
                 setHomeWidgetSet(true);
               }
             }
@@ -314,6 +325,7 @@ function StateMap({
     homeWidgetSet,
     selectedGraphic,
     waterbodyLayer,
+    numberOfRecords,
   ]);
 
   // Used to tell if the homewidget has been set to the selected state.


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3319611](https://app.breeze.pm/projects/100762/cards/3319611)

## Main Changes:
* Fixed an issue where the map stayed zoomed out to the continental US when there was only a single point graphic. 

## Steps To Test:
1. Navigate to [http://localhost:3000/waterbody-report/21SC60WQ/SC06A-03](http://localhost:3000/waterbody-report/21SC60WQ/SC06A-03)
2. Verify the map is zoomed in to the point
3. Change the zoom, click the home widget and verify it goes to the original zoom position.
4. Navigate to [http://localhost:3000/state/SC/advanced-search](http://localhost:3000/state/SC/advanced-search)
5. Select a single waterbody from the "Waterbody Names (IDs)" drop down
6. Click search and verify the map zooms to the graphic
7. Change the zoom, click the home widget and verify it goes to the original zoom position.
