### PR TITLE
Bugfix/search label not tied to input

### DIFF
--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -220,8 +220,12 @@ function State({ children, ...props }: Props) {
                 navigate(`/state/${selectedState.code}/water-quality-overview`);
               }}
             >
+              <label htmlFor="hmw-state-select-input" className="sr-only">
+                State
+              </label>
               <SelectStyled
                 id="hmw-state-select"
+                inputId="hmw-state-select-input"
                 classNamePrefix="Select"
                 placeholder="Select a state..."
                 options={states.data.map((state) => {
@@ -241,6 +245,14 @@ function State({ children, ...props }: Props) {
                     name: ev.label,
                   })
                 }
+                styles={{
+                  placeholder: (defaultStyles) => {
+                    return {
+                      ...defaultStyles,
+                      color: '#495057',
+                    };
+                  },
+                }}
               />
 
               <Button type="submit" className="btn">

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -88,9 +88,11 @@ function LocationSearch({ route }: Props) {
         }
       }}
     >
-      <label className="sr-only">Location</label>
-
+      <label htmlFor="hmw-search-input" className="sr-only">
+        Location
+      </label>
       <Input
+        id="hmw-search-input"
         className="form-control"
         placeholder="Search by address, zip code, or place..."
         value={inputText}


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3320925](https://app.breeze.pm/projects/100762/cards/3320925)

## Main Changes:
* Fixed an issue, raised by the lighthouse plugin, where the label was not tied to the input.
* Fixed an issue where there was not enough contrast on the react-select placeholder text.

## Steps To Test:
1. Go to the home page
2. Open Chrome dev tools
3. Click on the audits tab (you may have to install the lighthouse plugin)
4. Check the "Accessibility" option
5. Click "Generate Report"
6. Verify that there is just one `Form elements do not have associated labels` error. This error is in the EPA template.
7. Go to the state tab and repeat steps 2 - 6. 
