### PR TITLE
Feature/consistent capitalization and corrected labels

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -492,7 +492,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
   };
 
   // options for the selects on the Providers and Withdrawers tabs
-  const drinkingWaterSorts = [
+  const withdrawerSorts = [
     {
       value: 'population',
       label: 'Public Water System Population Served',
@@ -500,6 +500,21 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
     {
       value: 'source',
       label: 'Drinking Water Facility Source',
+    },
+    {
+      value: 'alphabetical',
+      label: 'Name',
+    },
+  ];
+
+  const providerSorts = [
+    {
+      value: 'population',
+      label: 'Public Water System Population Served',
+    },
+    {
+      value: 'source',
+      label: 'Drinking Water System Source',
     },
     {
       value: 'alphabetical',
@@ -625,7 +640,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                           onSortChange={(sortBy) =>
                             setProvidersSortBy(sortBy.value)
                           }
-                          sortOptions={drinkingWaterSorts}
+                          sortOptions={providerSorts}
                         >
                           {sortWaterSystems(
                             providers,
@@ -796,7 +811,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                             onSortChange={(sortBy) =>
                               setWithdrawersSortBy(sortBy.value)
                             }
-                            sortOptions={drinkingWaterSorts}
+                            sortOptions={withdrawerSorts}
                           >
                             {sortWaterSystems(
                               displayedWithdrawers,

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -55,6 +55,14 @@ function sortByPopulation(objA, objB) {
   return objB.population_served_count - objA.population_served_count;
 }
 
+// correct capitalization and spacing inconsistencies with ATTAINS Drinking Water service
+function fixCapitalization(type) {
+  return type
+    .replace('Groundwater', 'Ground Water')
+    .replace('Ground water', 'Ground Water')
+    .replace('Surface water', 'Surface Water');
+}
+
 // group by drinking water source and alphabetize the groups
 function groupProvidersBySource(systems) {
   const groundWaterSystems = systems
@@ -115,10 +123,11 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
           Public Water System Population Served:{' '}
           {Number(item['population_served_count']).toLocaleString()}
           <br />
-          Drinking Water Facility Source:{' '}
           {isWithdrawer
-            ? item.water_type_calc
-            : item.gw_sw.replace('Groundwater', 'Ground water')}
+            ? `Drinking Water Facility Source: ${fixCapitalization(
+                item.water_type_calc,
+              )}`
+            : `Drinking Water System Source: ${fixCapitalization(item.gw_sw)}`}
         </>
       }
     >
@@ -158,14 +167,21 @@ function createAccordionItem(item: Object, isWithdrawer: boolean) {
             <td>{item.violations === 'Y' ? 'Yes' : 'No'}</td>
           </tr>
           <tr>
-            <td>
-              <em>Drinking Water Facility Source:</em>
-            </td>
-            <td>
-              {isWithdrawer
-                ? item.water_type_calc
-                : item.gw_sw.replace('Groundwater', 'Ground water')}
-            </td>
+            {isWithdrawer ? (
+              <>
+                <td>
+                  <em>Drinking Water Facility Source:</em>
+                </td>
+                <td>{fixCapitalization(item.water_type_calc)}</td>
+              </>
+            ) : (
+              <>
+                <td>
+                  <em>Drinking Water System Source:</em>
+                </td>
+                <td>{fixCapitalization(item.gw_sw)}</td>
+              </>
+            )}
           </tr>
           <tr>
             <td>
@@ -765,7 +781,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
                                         }
                                       />
                                       <span>
-                                        Ground water &amp; Surface water
+                                        Ground Water &amp; Surface Water
                                       </span>
                                     </Toggle>
                                   </td>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3324024

## Main Changes:
* Make sure capitalization of 'water' is consistent throughout Drinking Water Provider and Withdrawers tabs
* Change Source label based on whether the system is a withdrawer or a provider

## Steps To Test:
1. Navigate to http://localhost:3000/community/auburn%20al/drinking-water
2. Check that the Source labels in the accordions (both expanded and un-expanded) and sort dropdowns are different between the Provider and Withdrawer tabs:
- Providers should be "Drinking Water **System** Source"
- Withdrawers should be "Drinking Water **Facility** Source"
3. Verify the word 'Water' is capitalized everywhere in the accordions and filters for the Provider and Withdrawer tabs.
