### PR TITLE
Update Page Banner's linear gradient to be darker at the top,

### DIFF
--- a/app/client/src/components/shared/Page/index.js
+++ b/app/client/src/components/shared/Page/index.js
@@ -86,8 +86,12 @@ const Banner = styled.div`
   position: relative;
   z-index: 10;
   height: 10em;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.6)),
-    url(${water});
+  background-image: ${`linear-gradient(
+      ${colors.black(0.875)} 25%,
+      ${colors.black(0.625)} 50%,
+      ${colors.black(0.375)} 75%
+    ),
+    url(${water})`};
   background-size: cover;
   background-position: center;
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3331079

## Main Changes:
* Updates linear gradient to be darker at the top of the banner, so navigation links visually have a higher contrast ratio
* Unfortunately, the axe accessibility plugin can’t determine the contrast ratio due to the background gradient (see screenshot). There may be another accessibility tool that can definitively show the contrast ratio is sufficient, but I suspect we can flag this as a "non-issue".
<img width="1552" alt="Screen Shot 2020-05-12 at 12 57 39 PM" src="https://user-images.githubusercontent.com/16306492/81723628-1db6c300-9451-11ea-9ce6-a1e89fc196a1.png">
