### PR TITLE
Remove merge conflict markers in sonarqube config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,2 @@
-<<<<<<< HEAD
 sonar.sources=app
 sonar.exclusions=app/cypress/**/*,app/server/node_modules/**/*,app/client/node_modules/**/*,app/client/src/components/pages/State/lookups/**/*
-=======
-sonar.sources=app/client,app/server
-sonar.exclusions=app/server/node_modules/**/*,app/client/node_modules/**/*,app/client/src/components/pages/State/lookups/**/*
->>>>>>> develop


### PR DESCRIPTION
Remove merge conflict markers that accidentally got merged into sonarqube config.