### PR TITLE
Feature/state page accessibility

### DIFF
--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -147,7 +147,7 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
-.hmw-map-toggle h4 {
+.hmw-map-toggle h1 {
   margin: 0 10px;
   padding: 0;
   font-family: 'Source Sans Pro', 'Helvetica Neue', 'Helvetica', 'Roboto',

--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import highchartsAccessibility from 'highcharts/modules/accessibility';
 // components
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
@@ -16,6 +17,9 @@ import { formatNumber } from 'utils/utils';
 import { impairmentFields } from 'config/attainsToHmwMapping';
 // styles
 import { fonts } from 'styles/index.js';
+
+// add accessibility features to highcharts
+highchartsAccessibility(Highcharts);
 
 // --- styled components ---
 const Text = styled.p`
@@ -239,7 +243,7 @@ function SiteSpecific({
                   plotShadow: false,
                 },
                 tooltip: {
-                  formatter: function() {
+                  formatter: function () {
                     return `${this.key}<br/>
                     ${this.series.name}: <b>${formatNumber(this.y)}</b>`;
                   },
@@ -268,7 +272,7 @@ function SiteSpecific({
                         fontSize: responsiveBarChartFontSize,
                         textOutline: false,
                       },
-                      formatter: function() {
+                      formatter: function () {
                         if (!waterTypeUnits) return formatNumber(this.y);
                         const units = waterTypeUnits.toLowerCase();
                         return `${formatNumber(this.y)} ${units}`;

--- a/app/client/src/components/pages/State/components/SurveyResults.js
+++ b/app/client/src/components/pages/State/components/SurveyResults.js
@@ -15,7 +15,7 @@ import { formatNumber, titleCase, titleCaseWithExceptions } from 'utils/utils';
 import { surveyMapping } from 'components/pages/State/lookups/surveyMapping';
 import { waterTypeOptions } from 'components/pages/State/lookups/waterTypeOptions';
 // styles
-import { fonts, colors } from 'styles/index.js';
+import { fonts, colors, reactSelectStyles } from 'styles/index.js';
 
 // --- styled components ---
 const ChartFooter = styled.p`
@@ -410,6 +410,7 @@ function SurveyResults({
               })}
               value={{ value: selectedSubPop, label: selectedSubPop }}
               onChange={(ev) => setUserSelectedSubPop(ev.value)}
+              styles={reactSelectStyles}
             />
             {populationDistance && <small>({populationDistance})</small>}
           </Input>

--- a/app/client/src/components/pages/State/components/SurveyResults.js
+++ b/app/client/src/components/pages/State/components/SurveyResults.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import WindowSize from '@reach/window-size';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import highchartsAccessibility from 'highcharts/modules/accessibility';
 import Select from 'react-select';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
@@ -16,6 +17,9 @@ import { surveyMapping } from 'components/pages/State/lookups/surveyMapping';
 import { waterTypeOptions } from 'components/pages/State/lookups/waterTypeOptions';
 // styles
 import { fonts, colors, reactSelectStyles } from 'styles/index.js';
+
+// add accessibility features to highcharts
+highchartsAccessibility(Highcharts);
 
 // --- styled components ---
 const ChartFooter = styled.p`
@@ -438,7 +442,7 @@ function SurveyResults({
                   plotShadow: false,
                 },
                 tooltip: {
-                  formatter: function() {
+                  formatter: function () {
                     const value = formatNumber(this.y, 1);
                     return `${this.key}<br/><b>${value}%</b>`;
                   },
@@ -449,7 +453,7 @@ function SurveyResults({
                     showInLegend: true,
                     dataLabels: {
                       ...chartOptions.plotOptions.all.dataLabels,
-                      formatter: function() {
+                      formatter: function () {
                         if (!this.point.isConfidenceLevel) {
                           return formatNumber(this.y, 1) + '%';
                         } else {
@@ -470,7 +474,7 @@ function SurveyResults({
                   layout: width >= 992 ? 'vertical' : 'horizontal',
                   align: width >= 992 ? 'right' : 'center',
                   useHTML: true, // display the +/- symbol (&#177;)
-                  labelFormatter: function() {
+                  labelFormatter: function () {
                     if (this.isConfidenceLevel) {
                       // confidence level is not actually a legend item, just text
                       return this.name;
@@ -513,7 +517,7 @@ function SurveyResults({
                       height: xAxisLabels.length * 30 + 90,
                     },
                     tooltip: {
-                      formatter: function() {
+                      formatter: function () {
                         const value = formatNumber(this.y, 1);
                         return `${this.key}<br/>
                     ${this.series.name}: <b>${value}%</b>`;
@@ -527,7 +531,7 @@ function SurveyResults({
                         groupPadding: 0,
                         dataLabels: {
                           ...chartOptions.plotOptions.all.dataLabels,
-                          formatter: function() {
+                          formatter: function () {
                             const value = formatNumber(this.y, 1);
                             return value !== '0' ? `${value}%` : '';
                           },

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -899,19 +899,18 @@ function AdvancedSearch({ ...props }: Props) {
 
       <ResultsInputs data-content="stateinputs">
         <ResultsInput>
-          <label>
+          <ScreenLabel>
             Results:{' '}
             <ResultsItems>
               {waterbodies ? waterbodies.length.toLocaleString() : 0} items
             </ResultsItems>
-          </label>
+          </ScreenLabel>
         </ResultsInput>
 
         <ResultsInput>
           <label htmlFor="display-by">Display Waterbodies by:</label>
           <Select
             inputId="display-by"
-            classNamePrefix="Select"
             options={displayOptions}
             value={selectedDisplayOption}
             onChange={(ev) => setSelectedDisplayOption(ev)}

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -30,6 +30,8 @@ import { impairmentFields, useFields } from 'config/attainsToHmwMapping';
 // config
 import { waterbodyService, wbd } from 'config/mapServiceConfig';
 import { attains } from 'config/webServiceConfig';
+// styles
+import { reactSelectStyles } from 'styles/index.js';
 // errors
 import { stateGeneralError } from 'config/errorMessages';
 
@@ -720,6 +722,7 @@ function AdvancedSearch({ ...props }: Props) {
             options={parameterGroupOptions ? parameterGroupOptions : []}
             value={parameterFilter}
             onChange={(ev) => setParameterFilter(ev)}
+            styles={reactSelectStyles}
           />
         </Input>
 
@@ -733,6 +736,7 @@ function AdvancedSearch({ ...props }: Props) {
             options={useFields}
             value={useFilter}
             onChange={(ev) => setUseFilter(ev)}
+            styles={reactSelectStyles}
           />
         </Input>
       </Inputs>
@@ -761,6 +765,7 @@ function AdvancedSearch({ ...props }: Props) {
             }
             value={watershedFilter}
             onChange={(ev) => setWatershedFilter(ev)}
+            styles={reactSelectStyles}
           />
         </Input>
 
@@ -780,6 +785,7 @@ function AdvancedSearch({ ...props }: Props) {
             }
             value={waterbodyFilter}
             onChange={(ev) => setWaterbodyFilter(ev)}
+            styles={reactSelectStyles}
           />
         </Input>
       </Inputs>
@@ -902,6 +908,7 @@ function AdvancedSearch({ ...props }: Props) {
             options={displayOptions}
             value={selectedDisplayOption}
             onChange={(ev) => setSelectedDisplayOption(ev)}
+            styles={reactSelectStyles}
           />
         </ResultsInput>
 

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -197,6 +197,13 @@ const MapFooter = styled.div`
   }
 `;
 
+const ScreenLabel = styled.span`
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+`;
+
 // --- components ---
 type Props = {};
 
@@ -711,12 +718,12 @@ function AdvancedSearch({ ...props }: Props) {
 
       <Inputs>
         <Input>
-          <label>
+          <ScreenLabel>
             <GlossaryTerm term="Parameter Group">Parameter Groups</GlossaryTerm>
             :
-          </label>
+          </ScreenLabel>
           <Select
-            inputId="parameter-groups"
+            aria-label="Parameter Groups"
             isMulti
             isLoading={!parameterGroupOptions}
             options={parameterGroupOptions ? parameterGroupOptions : []}
@@ -727,11 +734,11 @@ function AdvancedSearch({ ...props }: Props) {
         </Input>
 
         <Input>
-          <label>
+          <ScreenLabel>
             <GlossaryTerm term="Use Group">Use Groups</GlossaryTerm>:
-          </label>
+          </ScreenLabel>
           <Select
-            inputId="use-groups"
+            aria-label="Use Groups"
             isMulti
             options={useFields}
             value={useFilter}
@@ -743,14 +750,14 @@ function AdvancedSearch({ ...props }: Props) {
 
       <Inputs>
         <Input>
-          <label>
+          <ScreenLabel>
             <GlossaryTerm term="Watershed Names (HUC 12)">
               Watershed Names (HUC12)
             </GlossaryTerm>
             :
-          </label>
+          </ScreenLabel>
           <Select
-            inputId="watersheds"
+            aria-label="Watershed Names (HUC12)"
             isMulti
             isLoading={!watersheds}
             disabled={!watersheds}
@@ -792,12 +799,12 @@ function AdvancedSearch({ ...props }: Props) {
 
       <Inputs>
         <Input>
-          <label>
+          <ScreenLabel>
             <GlossaryTerm term="Integrated Reporting (IR) Category">
               Integrated Reporting (IR) Category
             </GlossaryTerm>
             :
-          </label>
+          </ScreenLabel>
           <InputGroup>
             <div>
               <input
@@ -808,55 +815,55 @@ function AdvancedSearch({ ...props }: Props) {
                 checked={waterTypeFilter === 'all'}
                 onChange={(ev) => setWaterTypeFilter(ev.target.value)}
               />
-              <label>All Waters</label>
+              <label htmlFor="ir-category-all">All Waters</label>
             </div>
 
             <div>
               <input
-                id="ir-category-303d"
+                aria-label="303(d) Listed Impaired Waters (Category 5)"
                 type="radio"
                 name="ir-category"
                 value="303d"
                 checked={waterTypeFilter === '303d'}
                 onChange={(ev) => setWaterTypeFilter(ev.target.value)}
               />
-              <label>
+              <ScreenLabel>
                 <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
                   303(d) Listed Impaired Waters (Category 5)
                 </GlossaryTerm>
-              </label>
+              </ScreenLabel>
             </div>
 
             <div>
               <input
-                id="ir-category-impaired"
+                aria-label="Impaired (Category 4 and 5)"
                 type="radio"
                 name="ir-category"
                 value="impaired"
                 checked={waterTypeFilter === 'impaired'}
                 onChange={(ev) => setWaterTypeFilter(ev.target.value)}
               />
-              <label>
+              <ScreenLabel>
                 <GlossaryTerm term="Impaired (Category 4 and 5)">
                   Impaired (Category 4 and 5)
                 </GlossaryTerm>
-              </label>
+              </ScreenLabel>
             </div>
           </InputGroup>
         </Input>
 
         <Input>
-          <label>Additional Filters:</label>
+          <ScreenLabel>Additional Filters:</ScreenLabel>
           <InputGroup>
             <input
-              id="has-tmdl"
+              aria-label="Has TMDL"
               type="checkbox"
               checked={hasTmdlChecked}
               onChange={(ev) => setHasTmdlChecked(!hasTmdlChecked)}
             />
-            <label>
+            <ScreenLabel>
               <GlossaryTerm term="TMDL">Has TMDL</GlossaryTerm>
-            </label>
+            </ScreenLabel>
           </InputGroup>
         </Input>
       </Inputs>

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -791,7 +791,7 @@ function WaterQualityOverview({ ...props }: Props) {
         <strong>{activeState.name}</strong> Water Quality
       </Heading>
 
-      <h4>Choose a Topic:</h4>
+      <h3>Choose a Topic:</h3>
 
       <TopicTabs>
         <Tabs

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -35,6 +35,8 @@ import { reportStatusOptions } from 'components/pages/State/lookups/reportStatus
 import { attains, grts } from 'config/webServiceConfig';
 // images
 import drinkingWaterIcon from 'components/pages/Community/images/drinking-water.png';
+// styles
+import { reactSelectStyles } from 'styles/index.js';
 // errors
 import {
   stateSurveySectionError,
@@ -838,6 +840,7 @@ function WaterQualityOverview({ ...props }: Props) {
                             ? 'No Available Water Types'
                             : 'Select...'
                         }
+                        styles={reactSelectStyles}
                       />
                     </Input>
 
@@ -864,6 +867,7 @@ function WaterQualityOverview({ ...props }: Props) {
                             ? 'No Available Uses'
                             : 'Select...'
                         }
+                        styles={reactSelectStyles}
                       />
                     </Input>
                   </Inputs>

--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -30,7 +30,7 @@ import { fetchCheck } from 'utils/fetchUtils';
 // data
 import introText from 'components/pages/State/lookups/introText';
 // styles
-import { colors, fonts } from 'styles/index.js';
+import { colors, fonts, reactSelectStyles } from 'styles/index.js';
 // errors
 import {
   stateListError,
@@ -245,14 +245,7 @@ function State({ children, ...props }: Props) {
                     name: ev.label,
                   })
                 }
-                styles={{
-                  placeholder: (defaultStyles) => {
-                    return {
-                      ...defaultStyles,
-                      color: '#495057',
-                    };
-                  },
-                }}
+                styles={reactSelectStyles}
               />
 
               <Button type="submit" className="btn">

--- a/app/client/src/components/shared/Accordion/index.js
+++ b/app/client/src/components/shared/Accordion/index.js
@@ -5,7 +5,7 @@ import type { Node } from 'react';
 import styled from 'styled-components';
 import Select from 'react-select';
 // styles
-import { colors } from 'styles/index.js';
+import { colors, reactSelectStyles } from 'styles/index.js';
 
 // --- styled components (AccordionList) ---
 const AccordionListContainer = styled.div`
@@ -103,6 +103,7 @@ function AccordionList({
                 setSortBy(ev);
                 onSortChange(ev);
               }}
+              styles={reactSelectStyles}
             />
           </SelectContainer>
         )}

--- a/app/client/src/components/shared/KeyMetrics/index.js
+++ b/app/client/src/components/shared/KeyMetrics/index.js
@@ -14,7 +14,8 @@ export const StyledMetric = styled.div`
   text-align: center;
 `;
 
-export const StyledNumber = styled.p`
+export const StyledNumber = styled.span`
+  display: block;
   padding-bottom: 0.25rem;
   font-size: 1.875em;
   font-weight: bold;

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -257,10 +257,10 @@ function MapWidgets({
 
     // create the basemap/layers widget
     const basemapsSource = new PortalBasemapsSource({
-      filterFunction: function(basemap) {
+      filterFunction: function (basemap) {
         return basemapNames.indexOf(basemap.portalItem.title) !== -1;
       },
-      updateBasemapsCallback: function(originalBasemaps) {
+      updateBasemapsCallback: function (originalBasemaps) {
         // sort the basemaps based on the ordering of basemapNames
         return originalBasemaps.sort(
           (a, b) =>
@@ -294,7 +294,7 @@ function MapWidgets({
           uniqueParentItems.push(item.title);
           updateVisibleLayers(view, legendNode);
 
-          item.watch('visible', function(event) {
+          item.watch('visible', function (event) {
             updateVisibleLayers(view, legendNode);
             const dict = {
               layerId: item.layer.id,
@@ -317,10 +317,10 @@ function MapWidgets({
     const container = document.createElement('div');
     container.className = 'hmw-map-toggle';
 
-    const basemapHeader = document.createElement('h4');
+    const basemapHeader = document.createElement('h1');
     basemapHeader.innerHTML = 'Basemaps:';
 
-    const layerListHeader = document.createElement('h4');
+    const layerListHeader = document.createElement('h1');
     layerListHeader.innerHTML = 'Layers:';
 
     container.appendChild(basemapHeader);

--- a/app/client/src/components/shared/WaterSystemSummary/index.js
+++ b/app/client/src/components/shared/WaterSystemSummary/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import highchartsAccessibility from 'highcharts/modules/accessibility';
 import WindowSize from '@reach/window-size';
 // components
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
@@ -16,6 +17,9 @@ import { formatNumber } from 'utils/utils';
 import { dwmaps } from 'config/webServiceConfig';
 // errors
 import { grpaError } from 'config/errorMessages';
+
+// add accessibility features to highcharts
+highchartsAccessibility(Highcharts);
 
 function formatValue(value: ?string) {
   return value ? formatNumber(value) : '';
@@ -200,7 +204,7 @@ function WaterSystemSummary({ state }: Props) {
                 type: 'pie',
               },
               tooltip: {
-                formatter: function() {
+                formatter: function () {
                   return `${this.key}<br/><b>${formatNumber(this.y)}</b>`;
                 },
               },
@@ -209,7 +213,7 @@ function WaterSystemSummary({ state }: Props) {
                   showInLegend: true,
                   dataLabels: {
                     enabled: true,
-                    formatter: function() {
+                    formatter: function () {
                       return formatNumber(this.y);
                     },
                   },

--- a/app/client/src/styles/index.js
+++ b/app/client/src/styles/index.js
@@ -23,4 +23,13 @@ const fonts = {
   secondary: `'Roboto Slab', serif`,
 };
 
-export { colors, fonts };
+const reactSelectStyles = {
+  placeholder: (defaultStyles) => {
+    return {
+      ...defaultStyles,
+      color: '#495057',
+    };
+  },
+};
+
+export { colors, fonts, reactSelectStyles };


### PR DESCRIPTION
I used axe, lighthouse, wave and html_codesniffer to test the accessibility. There is quite a bit of noise with these extensions, due to the EPA One Template and the glossary panel. 

I ignored some items that were flagged by wave.  
1. 1 X Missing fieldset - None of the other extensions flagged this one. I don't think we really need to add this to the radio buttons.
2. 11 X Redundant title text - We are doing this to display button tool tips on small screens and esri is doing the same thing. 

## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3333226](https://app.breeze.pm/projects/100762/cards/3333226)

## Main Changes:
* Updated the styles for react-select components to fix contrast errors. I think I got all of the react-select components, without touching the community tabs. 
* Fixed label/input linkage accessibility issues.
* Fixed issues with skipping over headings. 
    * The styles changed slightly for the "Choose a Topic" heading on the water quality overview tab.
* Fixed issues with extensions saying the `<p>` should be headings for the StyledNumber component. 

## Steps To Test:
1. Go to the state page 
2. Run wave and check issues
3. Run axe and check issues
4. Run lighthouse and check issues
5. Select Kansas
6. Click Eating Fish and select "Rivers and Streams" from the "Water Type" drop down
7. Redo steps 2 - 4 
8. Go to the advanced search tab and click search
9. Redo steps 2 - 4
10. Click the list view
11. Redo steps 2 - 4

## TODO:
- [ ] Fix accessibility issues with the EPA One Template
- [ ] Fix accessibility issues with the glossary panel. I think we will be able to do this without touching the forked glossary component 🤞 .
