### PR TITLE
feature/fix-template-accessability

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -164,7 +164,7 @@
         <div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
           <form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
             <label class="element-hidden" for="search-box">Search</label>
-            <input class="form-text" id="search-box" name="querytext" placeholder="Search EPA.gov" value="" />
+            <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="" />
             <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
             <input name="areaname" type="hidden" value="" />
             <input name="areacontacts" type="hidden" value="" />

--- a/app/server/app/public_other_pages/400.html
+++ b/app/server/app/public_other_pages/400.html
@@ -45,7 +45,7 @@
 			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
 				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
 					<label class="element-hidden" for="search-box">Search</label>
-          <input class="form-text" id="search-box" name="querytext" placeholder="Search EPA.gov" value="">
+          <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="">
           <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
           <input name="areaname" type="hidden" value="">
           <input name="areacontacts" type="hidden" value="">

--- a/app/server/app/public_other_pages/500.html
+++ b/app/server/app/public_other_pages/500.html
@@ -45,7 +45,7 @@
 			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
 				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
 					<label class="element-hidden" for="search-box">Search</label>
-          <input class="form-text" id="search-box" name="querytext" placeholder="Search EPA.gov" value="">
+          <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="">
           <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
           <input name="areaname" type="hidden" value="">
           <input name="areacontacts" type="hidden" value="">


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3333577

## Main Changes:
* Added ARIA labels to EPA template across app

## Steps To Test:
1. Navigate to the app and run AXE, WAVE, and Lighthouse see no errors related to EPA template. Ignore warnings about footer and hero image contrast.

