### PR TITLE
feature/sonarcloud-code-smells

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -1,328 +1,366 @@
 <!DOCTYPE html>
 <html class="js" lang="en" dir="ltr">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="ImageToolbar" content="false" />
-    <meta http-equiv="cleartype" content="on" />
-    <meta name="HandheldFriendly" content="true" />
-    <link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico" type="image/vnd.microsoft.icon" />
-    <meta name="MobileOptimized" content="width" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <!--googleon: all-->
-    <meta name="DC.description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-    <meta name="description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-    <meta name="DC.title" content="How's My Waterway?" />
-    <!--googleoff: snippet-->
-    <meta name="keywords" content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
-    <link rel="canonical" href="" />
-    <link rel="shortlink" href="" />
-    <meta name="DC.language" content="en" />
-    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta name="DC.type" content="Data and Tools" />
-    <meta name="DC.creator" content="US EPA" />
-    <meta name="theme-color" content="#0071bc">
-    <title>How’s My Waterway? | US EPA</title>
-    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" crossorigin="use-credentials">
-    <!--googleoff: all-->
-    <link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab|Source+Sans+Pro:700i&display=swap">
-    <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/css/main.css" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css" integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous" /> 
-    
-    <!-- icons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
-    <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest">
-    <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#ffffff">
-    <meta name="msapplication-TileColor" content="#2b5797">
-    <meta name="theme-color" content="#ffffff">
-    <style>
-      /* bootstrap style overrides */
-      .epa-search .form-text { display: inline-block; margin-top: 0; }
-      /* epa template overrides */
-      .main-footer .region-footer .row { margin: 0; }
-      .main-footer .region-footer .col:first-of-type { padding-left: 0; }
-      .main-footer .region-footer .col:last-of-type { padding-right: 0; }
-    </style>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="//www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-L8ZB");</script>
-    <!-- End Google Tag Manager -->  
-    <!-- Google Analytics -->
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      //Only setup the logging for public sites, ie don't log from localhost
-      window.isIdSet = false;
-      if (document.location.hostname.indexOf("epa.gov") > -1) {
-        ga('create', 'UA-32633028-1', 'auto');  //EPA ACCOUNT (Production)
-        ga('send', 'pageview');
-        isIdSet = true;
-      }
-      else if (document.location.hostname === 'mywaterway-stage.app.cloud.gov') {
-        ga('create', 'UA-37504877-4', 'auto');  //Stage
-        ga('send', 'pageview');
-        isIdSet = true;
-      }
-      else if (
-        document.location.hostname === 'mywaterway-dev.app.cloud.gov' || 
-        document.location.hostname === 'localhost'
-      ) {
-        ga('create', 'UA-37504877-3', 'auto');  //Dev
-        ga('send', 'pageview');
-        isIdSet = true;
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="ImageToolbar" content="false" />
+  <meta http-equiv="cleartype" content="on" />
+  <meta name="HandheldFriendly" content="true" />
+  <link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
+    type="image/vnd.microsoft.icon" />
+  <meta name="MobileOptimized" content="width" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <!--googleon: all-->
+  <meta name="DC.description"
+    content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+  <meta name="description"
+    content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+  <meta name="DC.title" content="How's My Waterway?" />
+  <!--googleoff: snippet-->
+  <meta name="keywords"
+    content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
+  <link rel="canonical" href="" />
+  <link rel="shortlink" href="" />
+  <meta name="DC.language" content="en" />
+  <meta name="DC.Subject.epachannel" content="Learn the Issues" />
+  <meta name="DC.type" content="Data and Tools" />
+  <meta name="DC.creator" content="US EPA" />
+  <meta name="theme-color" content="#0071bc">
+  <title>How’s My Waterway? | US EPA</title>
+  <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest" crossorigin="use-credentials">
+  <!--googleoff: all-->
+  <link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" />
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Slab|Source+Sans+Pro:700i&display=swap">
+  <link rel="stylesheet" href="https://js.arcgis.com/4.12/esri/css/main.css" />
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css"
+    integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ" crossorigin="anonymous" />
+
+  <!-- icons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
+  <link rel="manifest" href="%PUBLIC_URL%/site.webmanifest">
+  <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#ffffff">
+  <meta name="msapplication-TileColor" content="#2b5797">
+  <meta name="theme-color" content="#ffffff">
+  <style>
+    /* bootstrap style overrides */
+    .epa-search .form-text {
+      display: inline-block;
+      margin-top: 0;
+    }
+
+    /* epa template overrides */
+    .main-footer .region-footer .row {
+      margin: 0;
+    }
+
+    .main-footer .region-footer .col:first-of-type {
+      padding-left: 0;
+    }
+
+    .main-footer .region-footer .col:last-of-type {
+      padding-right: 0;
+    }
+  </style>
+  <!-- Google Tag Manager -->
+  <script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != "dataLayer" ? "&l=" + l : ""; j.async = true; j.src = "//www.googletagmanager.com/gtm.js?id=" + i + dl; f.parentNode.insertBefore(j, f); })(window, document, "script", "dataLayer", "GTM-L8ZB");</script>
+  <!-- End Google Tag Manager -->
+  <!-- Google Analytics -->
+  <script>
+    (function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments)
+    }, i[r].l = 1 * new Date(); a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+    //Only setup the logging for public sites, ie don't log from localhost
+    window.isIdSet = false;
+    if (document.location.hostname.indexOf("epa.gov") > -1) {
+      ga('create', 'UA-32633028-1', 'auto');  //EPA ACCOUNT (Production)
+      ga('send', 'pageview');
+      isIdSet = true;
+    }
+    else if (document.location.hostname === 'mywaterway-stage.app.cloud.gov') {
+      ga('create', 'UA-37504877-4', 'auto');  //Stage
+      ga('send', 'pageview');
+      isIdSet = true;
+    }
+    else if (
+      document.location.hostname === 'mywaterway-dev.app.cloud.gov' ||
+      document.location.hostname === 'localhost'
+    ) {
+      ga('create', 'UA-37504877-3', 'auto');  //Dev
+      ga('send', 'pageview');
+      isIdSet = true;
+    }
+
+    //Only setup the logging for public sites, ie don't log from localhost
+    if (isIdSet) {
+      // create the locationChange event 
+      let event;
+      if (typeof Event === 'function') { // used for modern browsers
+        event = new Event('locationchange');
+      } else { // used for supporting internet explorer
+        event = document.createEvent("Event");
+        event.initEvent("locationchange", false, false);
       }
 
-      //Only setup the logging for public sites, ie don't log from localhost
-      if (isIdSet) {
-        // create the locationChange event 
-        let event;
-        if(typeof Event === 'function') { // used for modern browsers
-          event = new Event('locationchange');
-        } else { // used for supporting internet explorer
-          event = document.createEvent("Event");
-          event.initEvent("locationchange", false, false); 
+      // create the location change event listener
+      window.addEventListener("locationchange", function (event) {
+        ga('set', 'page', window.location.pathname)
+        ga('send', 'pageview');
+      });
+
+      // Modify the pushState, replaceState and popState events so they
+      // will trigger the locationchange event.
+      var pushState = history.pushState;
+      history.pushState = function () {
+        pushState.apply(history, arguments);
+        window.dispatchEvent(event);
+      };
+      var replaceState = history.replaceState;
+      history.replaceState = function () {
+        replaceState.apply(this, arguments);
+        window.dispatchEvent(event);
+      };
+      window.addEventListener('popstate', function () {
+        window.dispatchEvent(event);
+      });
+
+      document.addEventListener('click', function (event) {
+        //Button clicks
+        if (event.target.onclick && event.target.textContent) {
+          //Log to Google Analytics
+          const action = event.target.title ?
+            'ow-hmw2-' + event.target.textContent + ' - ' + event.target.title :
+            'ow-hmw2-' + event.target.textContent;
+          ga('send', 'event', 'buttonClick', action, window.location.pathname);
         }
 
-        // create the location change event listener
-        window.addEventListener("locationchange", function(event) {
-          ga('set', 'page', window.location.pathname)
-          ga('send', 'pageview');
-        });
+        //Link clicks
+        if (event.target.tagName.toLowerCase() === 'a' && event.target.target === '_blank') {
+          const href = event.target.href;
+          let category = 'Web-service';
 
-        // Modify the pushState, replaceState and popState events so they
-        // will trigger the locationchange event.
-        var pushState = history.pushState;
-        history.pushState = function () {
-            pushState.apply(history, arguments);
-            window.dispatchEvent(event);
-        };
-        var replaceState = history.replaceState;
-        history.replaceState = function (){
-          replaceState.apply(this, arguments);
-          window.dispatchEvent(event);
-        };
-        window.addEventListener('popstate', function (){
-          window.dispatchEvent(event);
-        });        
-
-        document.addEventListener('click', function(event) {
-          //Button clicks
-          if (event.target.onclick && event.target.textContent){
-            //Log to Google Analytics
-            const action = event.target.title ? 
-              'ow-hmw2-' + event.target.textContent + ' - ' + event.target.title : 
-              'ow-hmw2-' + event.target.textContent;
-            ga('send', 'event', 'buttonClick', action, window.location.pathname);
+          if (document.location.hostname === event.target.hostname) {
+            //Part of the HMW application
+            const extension = href.split('.').pop;
+            if (extension === '.pdf' || extension === '.zip')
+              category = 'Download';
+            else
+              category = 'Internal'
+          } else {
+            //External EPA Hyperlink
+            category = 'External';
           }
 
-          //Link clicks
-          if (event.target.tagName.toLowerCase() === 'a' && event.target.target === '_blank') {
-            const href = event.target.href;
-            let category = 'Web-service';
+          //Log to Google Analytics
+          ga('send', 'event', category, 'ow-hmw2-' + event.target.text, href);
+        }
+      });
+    }
+  </script>
+  <!-- End Google Analytics-->
+</head>
 
-            if (document.location.hostname === event.target.hostname) {
-              //Part of the HMW application
-              const extension = href.split('.').pop;
-              if(extension === '.pdf' || extension === '.zip')
-                category = 'Download';
-              else
-                category = 'Internal'
-            } else {
-              //External EPA Hyperlink
-              category = 'External';
-            }
+<body>
+  <!-- Google Tag Manager -->
+  <noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0"
+      style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager -->
 
-            //Log to Google Analytics
-            ga('send', 'event', category, 'ow-hmw2-' + event.target.text, href);
-          }
-        });
-      }
-    </script>
-    <!-- End Google Analytics-->
-  </head>
-  <body>
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager -->  
-    
-    <div class="skip-links">
-      <a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
+  <div class="skip-links">
+    <a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
+  </div>
+
+  <header class="masthead clearfix" role="banner">
+    <img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png" />
+    <div class="site-name-and-slogan">
+      <h1 class="site-name">
+        <a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US EPA</span></a>
+      </h1>
+      <div class="site-slogan">United States Environmental Protection Agency</div>
     </div>
-    
-    <header class="masthead clearfix" role="banner">
-      <img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png" />
-      <div class="site-name-and-slogan">
-        <h1 class="site-name">
-          <a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US EPA</span></a>
-        </h1>
-        <div class="site-slogan">United States Environmental Protection Agency</div>
-      </div>
-      <div class="region-header">
-        <div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
-          <form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
-            <label class="element-hidden" for="search-box">Search</label>
-            <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="" />
-            <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
-            <input name="areaname" type="hidden" value="" />
-            <input name="areacontacts" type="hidden" value="" />
-            <input name="areasearchurl" type="hidden" value="" />
-            <input name="typeofsearch" type="hidden" value="epa" />
-            <input name="result_template" type="hidden" value="2col.ftl" />
-          </form>
-        </div>
-      </div>
-    </header>
-
-    <nav class="nav main-nav clearfix" role="navigation">
-      <div class="nav__inner">
-        <h2 class="element-invisible">Main menu</h2>
-        <ul class="menu" role="menu">
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a>
-          </li>
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a>
-          </li>
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  
-    <div class="mobile-nav" id="mobile-nav">
-      <div class="mobile-bar clearfix">
-        <label class="menu-button" for="mobile-nav-toggle">Menu</label>
-      </div>
-      <input checked id="mobile-nav-toggle" type="checkbox">
-      <div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
-        <ul class="mobile-menu">
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a>
-          </li>
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a>
-          </li>
-          <li class="menu-item" role="presentation">
-            <a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a>
-          </li>
-        </ul>
+    <div class="region-header">
+      <div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
+        <form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
+          <label class="element-hidden" for="search-box">Search</label>
+          <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext"
+            placeholder="Search EPA.gov" value="" />
+          <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
+          <input name="areaname" type="hidden" value="" />
+          <input name="areacontacts" type="hidden" value="" />
+          <input name="areasearchurl" type="hidden" value="" />
+          <input name="typeofsearch" type="hidden" value="epa" />
+          <input name="result_template" type="hidden" value="2col.ftl" />
+        </form>
       </div>
     </div>
+  </header>
 
-    <section class="clearfix" id="main-content" lang="en" role="main" tabindex="-1">
-      <noscript>You need to enable JavaScript to run this app.</noscript>
-      <div id="root"></div>
-    </section>
+  <nav class="nav main-nav clearfix" role="navigation">
+    <div class="nav__inner">
+      <h2 class="element-invisible">Main menu</h2>
+      <ul class="menu" role="menu">
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem"
+            title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a>
+        </li>
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem"
+            title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+            &amp; Regulations</a>
+        </li>
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem"
+            title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a>
+        </li>
+      </ul>
+    </div>
+  </nav>
 
-    <footer class="main-footer clearfix" role="contentinfo">
-      <div class="main-footer__inner">
-        <div class="region-footer">
-          <div class="block-pane-epa-global-footer" id="block-pane-epa-global-footer">
-            <div class="row cols-3">
-              <div class="col size-1of3">
-                <div class="col__title">Discover.</div>
-                <ul class="menu">
-                  <li>
-                    <a href="https://www.epa.gov/accessibility">Accessibility</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/contracts">Contracting</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
-                  </li>
-                  <li>
-                    <a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No FEAR Act Data</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/privacy">Privacy</a>
-                  </li>
-                </ul>
-              </div>
-              <div class="col size-1of3">
-                <div class="col__title">Connect.</div>
-                <ul class="menu">
-                  <li>
-                    <a href="https://www.data.gov/">Data.gov</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector General</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/careers">Jobs</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/newsroom">Newsroom</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/open">Open Government</a>
-                  </li>
-                  <li>
-                    <a href="https://www.regulations.gov/">Regulations.gov</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a>
-                  </li>
-                  <li>
-                    <a href="https://www.usa.gov/">USA.gov</a>
-                  </li>
-                  <li>
-                    <a href="https://www.whitehouse.gov/">White House</a>
-                  </li>
-                </ul>
-              </div>
-              <div class="col size-1of3">
-                <div class="col__title">Ask.</div>
-                <ul class="menu">
-                  <li>
-                    <a href="https://www.epa.gov/home/forms/contact-us">Contact EPA</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/foia">FOIA Requests</a>
-                  </li>
-                  <li>
-                    <a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent Questions</a>
-                  </li>
-                </ul>
-                <div class="col__title">Follow.</div>
-                <ul class="social-menu">
-                  <li>
-                    <a class="menu-link social-facebook" href="https://www.facebook.com/EPA">EPA's Facebook</a>
-                  </li>
-                  <li>
-                    <a class="menu-link social-twitter" href="https://twitter.com/epa">EPA's Twitter</a>
-                  </li>
-                  <li>
-                    <a class="menu-link social-youtube" href="https://www.youtube.com/user/USEPAgov">EPA's YouTube</a>
-                  </li>
-                  <li>
-                    <a class="menu-link social-flickr" href="https://www.flickr.com/photos/usepagov">EPA's Flickr</a>
-                  </li>
-                  <li>
-                    <a class="menu-link social-instagram" href="https://www.instagram.com/epagov">EPA's Instagram</a>
-                  </li>
-                </ul>
-              </div>
+  <div class="mobile-nav" id="mobile-nav">
+    <div class="mobile-bar clearfix">
+      <label class="menu-button" for="mobile-nav-toggle">Menu</label>
+    </div>
+    <input checked id="mobile-nav-toggle" type="checkbox">
+    <div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
+      <ul class="mobile-menu">
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem"
+            title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a>
+        </li>
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem"
+            title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+            &amp; Regulations</a>
+        </li>
+        <li class="menu-item" role="presentation">
+          <a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem"
+            title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <section class="clearfix" id="main-content" lang="en" role="main" tabindex="-1">
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </section>
+
+  <footer class="main-footer clearfix" role="contentinfo">
+    <div class="main-footer__inner">
+      <div class="region-footer">
+        <div class="block-pane-epa-global-footer" id="block-pane-epa-global-footer">
+          <div class="row cols-3">
+            <div class="col size-1of3">
+              <div class="col__title">Discover.</div>
+              <ul class="menu">
+                <li>
+                  <a href="https://www.epa.gov/accessibility">Accessibility</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/contracts">Contracting</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+                </li>
+                <li>
+                  <a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
+                    FEAR Act Data</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/privacy">Privacy</a>
+                </li>
+              </ul>
+            </div>
+            <div class="col size-1of3">
+              <div class="col__title">Connect.</div>
+              <ul class="menu">
+                <li>
+                  <a href="https://www.data.gov/">Data.gov</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector
+                    General</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/careers">Jobs</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/newsroom">Newsroom</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/open">Open Government</a>
+                </li>
+                <li>
+                  <a href="https://www.regulations.gov/">Regulations.gov</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a>
+                </li>
+                <li>
+                  <a href="https://www.usa.gov/">USA.gov</a>
+                </li>
+                <li>
+                  <a href="https://www.whitehouse.gov/">White House</a>
+                </li>
+              </ul>
+            </div>
+            <div class="col size-1of3">
+              <div class="col__title">Ask.</div>
+              <ul class="menu">
+                <li>
+                  <a href="https://www.epa.gov/home/forms/contact-us">Contact EPA</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/foia">FOIA Requests</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent
+                    Questions</a>
+                </li>
+              </ul>
+              <div class="col__title">Follow.</div>
+              <ul class="social-menu">
+                <li>
+                  <a class="menu-link social-facebook" href="https://www.facebook.com/EPA">EPA's Facebook</a>
+                </li>
+                <li>
+                  <a class="menu-link social-twitter" href="https://twitter.com/epa">EPA's Twitter</a>
+                </li>
+                <li>
+                  <a class="menu-link social-youtube" href="https://www.youtube.com/user/USEPAgov">EPA's YouTube</a>
+                </li>
+                <li>
+                  <a class="menu-link social-flickr" href="https://www.flickr.com/photos/usepagov">EPA's Flickr</a>
+                </li>
+                <li>
+                  <a class="menu-link social-instagram" href="https://www.instagram.com/epagov">EPA's Instagram</a>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
       </div>
-    </footer>
-  </body>
+    </div>
+  </footer>
+</body>
+
 </html>

--- a/app/server/app/public_other_pages/400.html
+++ b/app/server/app/public_other_pages/400.html
@@ -1,57 +1,66 @@
 <!DOCTYPE html>
 <html class="js" lang="en" dir="ltr">
+
 <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="ImageToolbar" content="false" />
-    <meta http-equiv="cleartype" content="on" />
-    <meta name="HandheldFriendly" content="true" />
-    <link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico" type="image/vnd.microsoft.icon" />
-    <meta name="MobileOptimized" content="width" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <!--googleon: all-->
-	<meta name="DC.description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-    <meta name="DC.title" content="How's My Waterway?" />
-    <!--googleoff: snippet-->
-    <meta name="keywords" content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
-    <link rel="canonical" href="" />
-    <link rel="shortlink" href="" />
-    <meta name="DC.language" content="en" />
-    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta name="DC.type" content="Data and Tools" />
-    <meta name="DC.creator" content="US EPA" />
-    <meta name="theme-color" content="#0071bc">
-    <title>How’s My Waterway? | Page Not Found | US EPA</title>
-  <!--googleoff: all-->
-  <link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="//www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-L8ZB");</script>
-  <!-- End Google Tag Manager -->  
+	<meta charset="utf-8" />
+	<meta http-equiv="ImageToolbar" content="false" />
+	<meta http-equiv="cleartype" content="on" />
+	<meta name="HandheldFriendly" content="true" />
+	<link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
+		type="image/vnd.microsoft.icon" />
+	<meta name="MobileOptimized" content="width" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+	<!--googleon: all-->
+	<meta name="DC.description"
+		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+	<meta name="description"
+		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+	<meta name="DC.title" content="How's My Waterway?" />
+	<!--googleoff: snippet-->
+	<meta name="keywords"
+		content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
+	<link rel="canonical" href="" />
+	<link rel="shortlink" href="" />
+	<meta name="DC.language" content="en" />
+	<meta name="DC.Subject.epachannel" content="Learn the Issues" />
+	<meta name="DC.type" content="Data and Tools" />
+	<meta name="DC.creator" content="US EPA" />
+	<meta name="theme-color" content="#0071bc">
+	<title>How’s My Waterway? | Page Not Found | US EPA</title>
+	<!--googleoff: all-->
+	<link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
+	<!-- Google Tag Manager -->
+	<script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != "dataLayer" ? "&l=" + l : ""; j.async = true; j.src = "//www.googletagmanager.com/gtm.js?id=" + i + dl; f.parentNode.insertBefore(j, f); })(window, document, "script", "dataLayer", "GTM-L8ZB");</script>
+	<!-- End Google Tag Manager -->
 </head>
+
 <body class="html">
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager -->  
-  <div class="skip-links">
-    <a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
-  </div>
+	<!-- Google Tag Manager -->
+	<noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0"
+			width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager -->
+	<div class="skip-links">
+		<a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
+	</div>
 	<header class="masthead clearfix" role="banner">
 		<img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png">
 		<div class="site-name-and-slogan">
-			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US EPA</span></a></h1>
+			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US
+						EPA</span></a></h1>
 			<div class="site-slogan">United States Environmental Protection Agency</div>
 		</div>
 		<div class="region-header">
 			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
 				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
 					<label class="element-hidden" for="search-box">Search</label>
-          <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="">
-          <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
-          <input name="areaname" type="hidden" value="">
-          <input name="areacontacts" type="hidden" value="">
-          <input name="areasearchurl" type="hidden" value="">
-          <input name="typeofsearch" type="hidden" value="epa">
-          <input name="result_template" type="hidden" value="2col.ftl">
+					<input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext"
+						placeholder="Search EPA.gov" value="">
+					<button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
+					<input name="areaname" type="hidden" value="">
+					<input name="areacontacts" type="hidden" value="">
+					<input name="areasearchurl" type="hidden" value="">
+					<input name="typeofsearch" type="hidden" value="epa">
+					<input name="result_template" type="hidden" value="2col.ftl">
 				</form>
 			</div>
 		</div>
@@ -60,9 +69,17 @@
 		<div class="nav__inner">
 			<h2 class="element-invisible">Main menu</h2>
 			<ul class="menu" role="menu">
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/environmental-topics" role="menuitem"
+						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/laws-regulations" role="menuitem"
+						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+						&amp; Regulations</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
+						role="menuitem"
+						title="Learn more about our mission and what we do, how we are organized, and our history.">About
+						EPA</a></li>
 			</ul>
 		</div>
 	</nav>
@@ -70,45 +87,47 @@
 		<div class="mobile-bar clearfix">
 			<label class="menu-button" for="mobile-nav-toggle">Menu</label>
 		</div>
-    <input checked id="mobile-nav-toggle" type="checkbox">
+		<input checked id="mobile-nav-toggle" type="checkbox">
 		<div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
 			<ul class="mobile-menu">
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/environmental-topics" role="menuitem"
+						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/laws-regulations" role="menuitem"
+						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+						&amp; Regulations</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
+						role="menuitem"
+						title="Learn more about our mission and what we do, how we are organized, and our history.">About
+						EPA</a></li>
 			</ul>
 		</div>
 	</div>
 	<section class="main-content clearfix" id="main-content" lang="en" role="main" tabindex="-1">
 		<div class="region-preface clearfix">
-			<!-- <div class="block-views-revision-hublinks-block" id="block-views-revision-hublinks-block">
-				<div class="view view-revision-hublinks view-id-revision_hublinks">
-					 <span class="related-info"><strong>Related Topics:</strong></span> 
-					<ul class="menu pipeline">
-						<li class="menu-item"><a href="{HOME PAGE LINK}">Insert your Home Page Link here</a></li>
-					</ul>
-				</div>
-			</div>  -->
 			<div class="block block-pane block-pane-epa-web-area-connect" id="block-pane-epa-web-area-connect">
 				<ul class="menu utility-menu">
 					<li class="menu-item"><a class="menu-link" href="mailto:cgp@epa.gov">Contact Us</a></li>
 				</ul>
 			</div>
 		</div>
-    <div class="main-column clearfix">
-      <!--googleon:all-->
-      <h1  class="page-title">Sorry, but this web page does not exist.</h1>
-      <div class="panel-pane pane-node-content">
-        <div class="pane-content">
-          <div class="node node-page clearfix view-mode-full">
-            <p>
+		<div class="main-column clearfix">
+			<!--googleon:all-->
+			<h1 class="page-title">Sorry, but this web page does not exist.</h1>
+			<div class="panel-pane pane-node-content">
+				<div class="pane-content">
+					<div class="node node-page clearfix view-mode-full">
+						<p>
 							<h2>We want to help you find what you are looking for.</h2>
 
-							<ul><li><a href="https://www.epa.gov/npdes">Browser other NPDES related topics</a></li></p>
-          </div>
-        </div>
-      </div>
-    </div>
+							<ul>
+								<li><a href="https://www.epa.gov/npdes">Browser other NPDES related topics</a></li>
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
 	</section>
 	<footer class="main-footer clearfix" role="contentinfo">
 		<div class="main-footer__inner">
@@ -124,9 +143,13 @@
 								<li><a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a></li>
 								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a></li>
-								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a></li>
-								<li><a href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No FEAR Act Data</a></li>
+								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+								</li>
+								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+								</li>
+								<li><a
+										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
+										FEAR Act Data</a></li>
 								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
 							</ul>
 						</div>
@@ -136,7 +159,9 @@
 							</div>
 							<ul class="menu">
 								<li><a href="https://www.data.gov/">Data.gov</a></li>
-								<li><a href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector General</a></li>
+								<li><a
+										href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector
+										General</a></li>
 								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
 								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
 								<li><a href="https://www.epa.gov/open">Open Government</a></li>
@@ -154,19 +179,23 @@
 								<li><a href="https://www.epa.gov/home/forms/contact-us">Contact Us</a></li>
 								<li><a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a></li>
 								<li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
-								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent Questions</a></li>
+								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent
+										Questions</a></li>
 							</ul>
 							<div class="col__title">
 								Follow.
 							</div>
 							<ul class="social-menu">
-								<li><a class="menu-link social-facebook" href="https://www.facebook.com/EPA">Facebook</a></li>
+								<li><a class="menu-link social-facebook"
+										href="https://www.facebook.com/EPA">Facebook</a></li>
 								<li><a class="menu-link social-twitter" href="https://twitter.com/epa">Twitter</a></li>
-								<li><a class="menu-link social-youtube" href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
-								<li><a class="menu-link social-flickr" href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
-								<li><a class="menu-link social-instagram" href="https://www.instagram.com/epagov">Instagram</a></li>
+								<li><a class="menu-link social-youtube"
+										href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
+								<li><a class="menu-link social-flickr"
+										href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
+								<li><a class="menu-link social-instagram"
+										href="https://www.instagram.com/epagov">Instagram</a></li>
 							</ul>
-							<!-- <p class="last-updated">Last updated on {Month day, YYYY}</p> -->
 						</div>
 					</div>
 				</div>
@@ -174,4 +203,5 @@
 		</div>
 	</footer>
 </body>
+
 </html>

--- a/app/server/app/public_other_pages/500.html
+++ b/app/server/app/public_other_pages/500.html
@@ -1,57 +1,66 @@
 <!DOCTYPE html>
 <html class="js" lang="en" dir="ltr">
+
 <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="ImageToolbar" content="false" />
-    <meta http-equiv="cleartype" content="on" />
-    <meta name="HandheldFriendly" content="true" />
-    <link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico" type="image/vnd.microsoft.icon" />
-    <meta name="MobileOptimized" content="width" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <!--googleon: all-->
-	<meta name="DC.description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="description" content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-    <meta name="DC.title" content="How's My Waterway?" />
-    <!--googleoff: snippet-->
-    <meta name="keywords" content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
-    <link rel="canonical" href="" />
-    <link rel="shortlink" href="" />
-    <meta name="DC.language" content="en" />
-    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta name="DC.type" content="Data and Tools" />
-    <meta name="DC.creator" content="US EPA" />
-    <meta name="theme-color" content="#0071bc">
-    <title>How’s My Waterway? | Internal Server Error | US EPA</title>
-    <!--googleoff: all-->
-  <link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="//www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-L8ZB");</script>
-  <!-- End Google Tag Manager -->  
+	<meta charset="utf-8" />
+	<meta http-equiv="ImageToolbar" content="false" />
+	<meta http-equiv="cleartype" content="on" />
+	<meta name="HandheldFriendly" content="true" />
+	<link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
+		type="image/vnd.microsoft.icon" />
+	<meta name="MobileOptimized" content="width" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+	<!--googleon: all-->
+	<meta name="DC.description"
+		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+	<meta name="description"
+		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
+	<meta name="DC.title" content="How's My Waterway?" />
+	<!--googleoff: snippet-->
+	<meta name="keywords"
+		content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
+	<link rel="canonical" href="" />
+	<link rel="shortlink" href="" />
+	<meta name="DC.language" content="en" />
+	<meta name="DC.Subject.epachannel" content="Learn the Issues" />
+	<meta name="DC.type" content="Data and Tools" />
+	<meta name="DC.creator" content="US EPA" />
+	<meta name="theme-color" content="#0071bc">
+	<title>How’s My Waterway? | Internal Server Error | US EPA</title>
+	<!--googleoff: all-->
+	<link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
+	<!-- Google Tag Manager -->
+	<script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != "dataLayer" ? "&l=" + l : ""; j.async = true; j.src = "//www.googletagmanager.com/gtm.js?id=" + i + dl; f.parentNode.insertBefore(j, f); })(window, document, "script", "dataLayer", "GTM-L8ZB");</script>
+	<!-- End Google Tag Manager -->
 </head>
+
 <body class="html">
-  <!-- Google Tag Manager -->
-  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <!-- End Google Tag Manager -->  
-  <div class="skip-links">
-    <a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
-  </div>
+	<!-- Google Tag Manager -->
+	<noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0"
+			style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager -->
+	<div class="skip-links">
+		<a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
+	</div>
 	<header class="masthead clearfix" role="banner">
 		<img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png">
 		<div class="site-name-and-slogan">
-			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US EPA</span></a></h1>
+			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US
+						EPA</span></a></h1>
 			<div class="site-slogan">United States Environmental Protection Agency</div>
 		</div>
 		<div class="region-header">
 			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
 				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
 					<label class="element-hidden" for="search-box">Search</label>
-          <input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext" placeholder="Search EPA.gov" value="">
-          <button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
-          <input name="areaname" type="hidden" value="">
-          <input name="areacontacts" type="hidden" value="">
-          <input name="areasearchurl" type="hidden" value="">
-          <input name="typeofsearch" type="hidden" value="epa">
-          <input name="result_template" type="hidden" value="2col.ftl">
+					<input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext"
+						placeholder="Search EPA.gov" value="">
+					<button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
+					<input name="areaname" type="hidden" value="">
+					<input name="areacontacts" type="hidden" value="">
+					<input name="areasearchurl" type="hidden" value="">
+					<input name="typeofsearch" type="hidden" value="epa">
+					<input name="result_template" type="hidden" value="2col.ftl">
 				</form>
 			</div>
 		</div>
@@ -60,9 +69,17 @@
 		<div class="nav__inner">
 			<h2 class="element-invisible">Main menu</h2>
 			<ul class="menu" role="menu">
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/environmental-topics" role="menuitem"
+						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/laws-regulations" role="menuitem"
+						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+						&amp; Regulations</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
+						role="menuitem"
+						title="Learn more about our mission and what we do, how we are organized, and our history.">About
+						EPA</a></li>
 			</ul>
 		</div>
 	</nav>
@@ -70,43 +87,45 @@
 		<div class="mobile-bar clearfix">
 			<label class="menu-button" for="mobile-nav-toggle">Menu</label>
 		</div>
-    <input checked id="mobile-nav-toggle" type="checkbox">
+		<input checked id="mobile-nav-toggle" type="checkbox">
 		<div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
 			<ul class="mobile-menu">
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/environmental-topics" role="menuitem" title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/laws-regulations" role="menuitem" title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws &amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa" role="menuitem" title="Learn more about our mission and what we do, how we are organized, and our history.">About EPA</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/environmental-topics" role="menuitem"
+						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link"
+						href="https://www.epa.gov/laws-regulations" role="menuitem"
+						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
+						&amp; Regulations</a></li>
+				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
+						role="menuitem"
+						title="Learn more about our mission and what we do, how we are organized, and our history.">About
+						EPA</a></li>
 			</ul>
 		</div>
 	</div>
 	<section class="main-content clearfix" id="main-content" lang="en" role="main" tabindex="-1">
 		<div class="region-preface clearfix">
-			<!-- <div class="block-views-revision-hublinks-block" id="block-views-revision-hublinks-block">
-				<div class="view view-revision-hublinks view-id-revision_hublinks">
-					 <span class="related-info"><strong>Related Topics:</strong></span> 
-					<ul class="menu pipeline">
-						<li class="menu-item"><a href="{HOME PAGE LINK}">Insert your Home Page Link here</a></li>
-					</ul>
-				</div>
-			</div>  -->
 			<div class="block block-pane block-pane-epa-web-area-connect" id="block-pane-epa-web-area-connect">
 				<ul class="menu utility-menu">
 					<li class="menu-item"><a class="menu-link" href="mailto:cgp@epa.gov">Contact Us</a></li>
 				</ul>
 			</div>
 		</div>
-    <div class="main-column clearfix">
-      <!--googleon:all-->
-      <h1  class="page-title">Sorry, but this web application is not available at this time.</h1>
-      <div class="panel-pane pane-node-content">
-        <div class="pane-content">
-          <div class="node node-page clearfix view-mode-full">
-            <p>
-							<ul><li><a href="mailto:cgp@epa.gov">Contact Us</a> if the problem persists.</li></p>
-          </div>
-        </div>
-      </div>
-    </div>
+		<div class="main-column clearfix">
+			<!--googleon:all-->
+			<h1 class="page-title">Sorry, but this web application is not available at this time.</h1>
+			<div class="panel-pane pane-node-content">
+				<div class="pane-content">
+					<div class="node node-page clearfix view-mode-full">
+						<p>
+							<ul>
+								<li><a href="mailto:cgp@epa.gov">Contact Us</a> if the problem persists.</li>
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
 	</section>
 	<footer class="main-footer clearfix" role="contentinfo">
 		<div class="main-footer__inner">
@@ -122,9 +141,13 @@
 								<li><a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a></li>
 								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a></li>
-								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a></li>
-								<li><a href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No FEAR Act Data</a></li>
+								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+								</li>
+								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+								</li>
+								<li><a
+										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
+										FEAR Act Data</a></li>
 								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
 							</ul>
 						</div>
@@ -134,7 +157,9 @@
 							</div>
 							<ul class="menu">
 								<li><a href="https://www.data.gov/">Data.gov</a></li>
-								<li><a href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector General</a></li>
+								<li><a
+										href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector
+										General</a></li>
 								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
 								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
 								<li><a href="https://www.epa.gov/open">Open Government</a></li>
@@ -152,19 +177,23 @@
 								<li><a href="https://www.epa.gov/home/forms/contact-us">Contact Us</a></li>
 								<li><a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a></li>
 								<li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
-								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent Questions</a></li>
+								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent
+										Questions</a></li>
 							</ul>
 							<div class="col__title">
 								Follow.
 							</div>
 							<ul class="social-menu">
-								<li><a class="menu-link social-facebook" href="https://www.facebook.com/EPA">Facebook</a></li>
+								<li><a class="menu-link social-facebook"
+										href="https://www.facebook.com/EPA">Facebook</a></li>
 								<li><a class="menu-link social-twitter" href="https://twitter.com/epa">Twitter</a></li>
-								<li><a class="menu-link social-youtube" href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
-								<li><a class="menu-link social-flickr" href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
-								<li><a class="menu-link social-instagram" href="https://www.instagram.com/epagov">Instagram</a></li>
+								<li><a class="menu-link social-youtube"
+										href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
+								<li><a class="menu-link social-flickr"
+										href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
+								<li><a class="menu-link social-instagram"
+										href="https://www.instagram.com/epagov">Instagram</a></li>
 							</ul>
-							<!-- <p class="last-updated">Last updated on {Month day, YYYY}</p> -->
 						</div>
 					</div>
 				</div>
@@ -172,4 +201,5 @@
 		</div>
 	</footer>
 </body>
+
 </html>


### PR DESCRIPTION

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3337555

## Main Changes:
* Fixes Sonarcloud issues with iframes missing a title
* deletes commented out HTML in our 400/500.html files

Sonarcloud results here: https://sonarcloud.io/dashboard?id=mywaterway

The rest of the Code Smells don't seem important but I'm open to discuss:
* renaming dozens of files from "fileName" to "fileNameContainer" feels like it doesn't give us any benefits
* renaming 75 variables for already being declared in upper scope, our scoping is not currently causing us any issues

The Security Hotspots are all related to random numbers or regex on the client-side only so they won't pose a risk to the server-side of the app.

## Steps To Test:
1. It's difficult to read the changes on this PR because Prettier overwrote the html files substantially, just check that the Google Tag Manager iframe's have titles and the commented out code is deleted from the 400.html and 500.html files.

## TODO:
- [ ] Deal with other Code Smells or mark them as resolved in Sonarcloud based on discussion
