### PR TITLE
Feature/attains and about pages about accessibility

### DIFF
--- a/app/client/src/components/pages/Attains/index.js
+++ b/app/client/src/components/pages/Attains/index.js
@@ -27,7 +27,7 @@ function compareContextName(objA, objB) {
 }
 
 function getMatchingLabel(ATTAINSContext) {
-  return impairmentFields.filter(field => {
+  return impairmentFields.filter((field) => {
     return field.parameterGroup === ATTAINSContext;
   })[0].label;
 }
@@ -80,11 +80,11 @@ function Attains({ ...props }: Props) {
     const url = attains.serviceUrl + 'domains?domainName=ParameterName';
 
     fetchCheck(url)
-      .then(res => {
+      .then((res) => {
         setLoading(false);
         setAttainsData(res.sort(compareContextName)); // sorted alphabetically by ATTAINS context
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(err);
         setLoading(false);
         setServiceError(true);
@@ -96,7 +96,7 @@ function Attains({ ...props }: Props) {
     // i.e. ["Excess Algae", "ALGAL GROWTH", "EXCESS ALGAL GROWTH"]
     setMatchedMappings(
       attainsData &&
-        attainsData.map(obj => {
+        attainsData.map((obj) => {
           return {
             hmwMapping: getMatchingLabel(obj.context),
             attainsParameterGroup: obj.context,
@@ -133,7 +133,8 @@ function Attains({ ...props }: Props) {
       placeholder="Filter column..."
       style={{ width: '100%' }}
       value={filter ? filter.value : ''}
-      onChange={event => onChange(event.target.value)}
+      onChange={(event) => onChange(event.target.value)}
+      aria-label="Filter column..."
     />
   );
 

--- a/app/client/src/components/shared/AboutContent/index.js
+++ b/app/client/src/components/shared/AboutContent/index.js
@@ -48,7 +48,7 @@ const StyledTabs = styled(Tabs)`
       line-height: 1.375;
     }
 
-    h3 {
+    h1 {
       margin: 2rem 0 0.25rem;
       padding-bottom: 0;
       font-family: ${fonts.primary};
@@ -58,7 +58,7 @@ const StyledTabs = styled(Tabs)`
         margin-top: 0;
       }
     }
-    h5 {
+    .title {
       margin: 1rem 0 0.25rem;
       padding-bottom: 0;
       font-family: ${fonts.primary};
@@ -115,7 +115,7 @@ function AboutContent({ ...props }: Props) {
           <TabPanels>
             <TabPanel>
               <div className="container">
-                <h3>About How’s My Waterway </h3>
+                <h1>About How’s My Waterway </h1>
                 <hr />
                 <p>
                   <em>How's My Waterway</em>  was designed to provide the
@@ -128,7 +128,7 @@ function AboutContent({ ...props }: Props) {
                   is not yet available through EPA databases or other sources.{' '}
                 </p>
 
-                <h3> How’s My Waterway Glossary </h3>
+                <h1> How’s My Waterway Glossary </h1>
                 <hr />
                 <p>
                   <em>How’s My Waterway</em> provides an easily accessible
@@ -139,7 +139,7 @@ function AboutContent({ ...props }: Props) {
                   top of any page in <em>How’s My Waterway</em>.
                 </p>
 
-                <h3>How’s My Waterway Data </h3>
+                <h1>How’s My Waterway Data </h1>
                 <hr />
                 <p>
                   <em>How’s My Waterway </em>provides a{' '}
@@ -149,9 +149,9 @@ function AboutContent({ ...props }: Props) {
                   <em>How’s My Waterway</em>.
                 </p>
 
-                <h3>Community Page </h3>
+                <h1>Community Page </h1>
                 <hr />
-                <h5>About impairment reporting </h5>
+                <div className="subtitle">About impairment reporting </div>
                 <p>
                   The Clean Water Act requires States, Territories and
                   authorized tribes (states for brevity) to monitor water
@@ -172,7 +172,7 @@ function AboutContent({ ...props }: Props) {
                   conditions.
                 </p>
 
-                <h5>About water quality information </h5>
+                <div className="subtitle">About water quality information </div>
                 <p>
                   EPA's water databases are the largest single, national source
                   of information about reported water quality problems and
@@ -188,7 +188,7 @@ function AboutContent({ ...props }: Props) {
                   were measured and reported.
                 </p>
 
-                <h5>About impairment categories </h5>
+                <div className="subtitle">About impairment categories </div>
                 <p>
                   A single waterway can have one or more types of impairments.
                   When States report impaired waters, they put them in different
@@ -206,7 +206,7 @@ function AboutContent({ ...props }: Props) {
                   information. This information can be found in the glossary.
                 </p>
 
-                <h5>About what's being done </h5>
+                <div className="subtitle">About what's being done </div>
                 <p>
                   Identifying and reporting water impairments leads to action
                   for improvement. Two major types of action taken under the
@@ -231,9 +231,9 @@ function AboutContent({ ...props }: Props) {
                   restoration plan or a nonpoint source pollution project.
                 </p>
 
-                <h3>State Page </h3>
+                <h1>State Page </h1>
                 <hr />
-                <h5>State Water Quality Overview </h5>
+                <div className="subtitle">State Water Quality Overview </div>
 
                 <p>
                   You will find basic facts about a state’s waters (by the
@@ -250,7 +250,7 @@ function AboutContent({ ...props }: Props) {
                   stories are also found on this page by state (if applicable).
                 </p>
 
-                <h5>Advanced Search</h5>
+                <div className="subtitle">Advanced Search</div>
 
                 <p>
                   On this page you will be able to find the condition of
@@ -264,7 +264,7 @@ function AboutContent({ ...props }: Props) {
                   list.
                 </p>
 
-                <h3>National Page </h3>
+                <h1>National Page </h1>
                 <hr />
                 <p>
                   You will find information on the condition of water resources
@@ -279,7 +279,7 @@ function AboutContent({ ...props }: Props) {
             </TabPanel>
             <TabPanel>
               <div className="container">
-                <h3>Questions and Answers about How’s My Waterway </h3>
+                <h1>Questions and Answers about How’s My Waterway </h1>
                 <hr />
                 <p>
                   <Question>What is “How’s My Waterway?”</Question>{' '}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3337521

## Main Changes:
* Add aria-labels to ATTAINS table filters
* Improve heading structure of About page 

## Steps To Test:
1. Navigate to http://localhost:3000/about
2. Run axe, Wave, Lighthouse, HTML_CodeSniffer
3. Navigate to http://localhost:3000/data 
4. Repeat step 2
5. Navigate to http://localhost:3000/attains
6. Repeat step 2. Note on the ATTAINS page table: axe and HTML_CodeSniffer detect the table text contrast as being non-compliant because it can't detect the contrast ratio.
I've manually checked this and found it to be AA compliant. Lighthouse and Wave also mark it as passing.
![image](https://user-images.githubusercontent.com/17204883/82247356-3f61ef80-9914-11ea-8db9-6603219b72b9.png)

Extra note: Prettier is adding parenthesis to arrow functions when saving even after running Prettier across all files. Not sure what that's about.



