### PR TITLE
Feature/glossary accessibility

### DIFF
--- a/app/client/src/components/shared/GlossaryPanel/index.js
+++ b/app/client/src/components/shared/GlossaryPanel/index.js
@@ -245,6 +245,7 @@ function GlossaryPanel({ path }) {
               className="js-glossary-search form-control"
               type="search"
               placeholder="Search for a term..."
+              aria-label="Search for a glossary term..."
             />
           )}
           <List className="js-glossary-list" />


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3337420

## Main Changes:
* Adds an aria-label to the Glossary search input

## Steps To Test:
1. Navigate to http://localhost:3000/
2. Open the glossary panel. Click on some entries to collapse them to test that as well
3. Run accessibility tools
