### PR TITLE
Feature/add nonfatal ga exceptions

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -673,7 +673,22 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
                           </Disclaimer>
                         </IntroDiv>
 
-                        {!zeroPollutedWaterbodies ? (
+                        {nullPollutedWaterbodies && (
+                          <Text>
+                            Impairment Summary information is not available for
+                            the {watershed} watershed. Please see the Overview
+                            tab for specific impairment information on these
+                            waters.
+                          </Text>
+                        )}
+                        {!nullPollutedWaterbodies &&
+                          zeroPollutedWaterbodies && (
+                            <Text>
+                              There are no impairment categories in the{' '}
+                              {watershed} watershed.
+                            </Text>
+                          )}
+                        {!nullPollutedWaterbodies && !zeroPollutedWaterbodies && (
                           <>
                             <Title>
                               Impairment categories in the {watershed}{' '}
@@ -751,11 +766,6 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
                               </tbody>
                             </Table>
                           </>
-                        ) : (
-                          <Text>
-                            There are no impairment categories in the{' '}
-                            {watershed} watershed.
-                          </Text>
                         )}
                       </>
                     )}


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3334640](https://app.breeze.pm/projects/100762/cards/3334640)

## Main Changes:
* Added a non-fatal Google Analytics exception for when there % impaired waters is greater than 0 and the summaryByParameterImpairments array is empty.
* Added a message to the screen for when there % impaired waters is greater than 0 and the summaryByParameterImpairments array is empty.
* Added a non-fatal Google Analytics exception for when there % impaired waters is 0 and the summaryByParameterImpairments array has data.

## Steps To Test:
Attains has fixed the issues that prompted this change, so to test the code will need to be modified.
1. In the components\pages\LocationMap\index.js component add the following below line 702:
```
results.items[0].summaryByParameterImpairments = [];
results.items[0].containImpairedWatersCatchmentAreaPercent = null;
```
2. In components\pages\Community\components\tabs\IdentifiedIssues.js add the following below line 344: `console.log('The summaryByParameterImpairments[] array is empty');`
3. In components\pages\Community\components\tabs\IdentifiedIssues.js add the following below line 355: `console.log('The "% of assessed waters are impaired" value is 0');`
4. Navigate to [http://localhost:3000/community/02360/identified-issues](http://localhost:3000/community/02360/identified-issues) and make sure that both logs are in the console.
5. Comment out one of the lines in step 1 and make sure the correct message is in the console. 
    * The first line corresponds with the log in step 2 and the second line corresponds with the log in step 3.

