### PR TITLE
bugfix/identified-issues-black-circle

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -14,6 +14,18 @@ const waterbodyStatuses = {
   notApplicable: { condition: 'hidden', label: 'Not Applicable' },
 };
 
+// Gets the type of symbol using the shape's attributes.
+export function getTypeFromAttributes(graphic) {
+  let type = 'point';
+  if (graphic.attributes.Shape_Length && graphic.attributes.Shape_Area) {
+    type = 'area';
+  } else if (graphic.attributes.Shape_Length) {
+    type = 'line';
+  }
+
+  return type;
+}
+
 export function getWaterbodyCondition(
   attributes: Object,
   fieldName: string,
@@ -165,7 +177,7 @@ export function createWaterbodySymbol({
   selected,
   geometryType = 'point',
 }: {
-  condition: 'good' | 'polluted' | 'unassessed' | 'impaired' | 'hidden',
+  condition: 'good' | 'polluted' | 'unassessed' | 'hidden',
   selected: boolean,
   geometryType: string,
 }) {
@@ -176,10 +188,6 @@ export function createWaterbodySymbol({
     color = selected ? { r: 70, g: 227, b: 159 } : { r: 140, g: 198, b: 63 };
   }
   if (condition === 'polluted') {
-    color = selected ? { r: 124, g: 157, b: 173 } : { r: 249, g: 59, b: 91 };
-  }
-  // handle the identified issues panel
-  if (condition === 'impaired' || condition === 'hidden') {
     color = selected ? { r: 124, g: 157, b: 173 } : { r: 249, g: 59, b: 91 };
   }
 
@@ -289,13 +297,13 @@ export function plotIssues(Graphic: any, features: Array<Object>, layer: any) {
   layer.graphics.removeAll();
   // put graphics on the layer
   features.forEach(waterbody => {
-    const geometryType = waterbody.geometry.type;
+    const geometryType = getTypeFromAttributes(waterbody);
     layer.graphics.add(
       new Graphic({
         geometry: waterbody.geometry,
 
         symbol: createWaterbodySymbol({
-          condition: 'impaired',
+          condition: 'polluted',
           selected: false,
           geometryType,
         }),

--- a/app/client/src/components/pages/State/components/WaterbodyList.js
+++ b/app/client/src/components/pages/State/components/WaterbodyList.js
@@ -17,7 +17,10 @@ import ViewOnMapButton from 'components/shared/ViewOnMapButton';
 
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 // utilities
-import { getWaterbodyCondition } from 'components/pages/LocationMap/MapFunctions';
+import {
+  getTypeFromAttributes,
+  getWaterbodyCondition,
+} from 'components/pages/LocationMap/MapFunctions';
 // contexts
 import { MapHighlightContext } from 'contexts/MapHighlight';
 import { LocationSearchContext } from 'contexts/locationSearch';
@@ -189,12 +192,7 @@ function WaterbodyItems({ sortedWaterbodies, allExpanded, fieldName }) {
     // get the type of symbol for creating a unique key, since it is currently
     // possible for the assessmentunitid and objectid to be duplicated across
     // layers.
-    let type = 'point';
-    if (graphic.attributes.Shape_Length && graphic.attributes.Shape_Area) {
-      type = 'area';
-    } else if (graphic.attributes.Shape_Length) {
-      type = 'line';
-    }
+    const type = getTypeFromAttributes(graphic);
 
     function resizeCell() {
       if (!listRef || !listRef.current) return;


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3342477](https://app.breeze.pm/projects/100762/cards/3342477)

## Main Changes:
* Fixed a bug that was causing black circles to be displayed on the identified issues tab. 
    * The core issue is that some geometry types are now "multipoint" instead of "point". This was likely due to the gispub upgrade that happened a while back (maybe a month ago). Some code structure may have changed as well, because after fixing the geometry type issue triangles were being displayed instead of octagons. 

## Steps To Test:
1. Navigate to [http://localhost:3000/community/030402080305/identified-issues](http://localhost:3000/community/030402080305/identified-issues)
2. Confirm that red stop signs are displayed instead of black circles
3. Test the switch filtering on the identified issues tab
4. Test out other locations to make sure they still work
