### PR TITLE
Feature/orange dischargers

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -352,7 +352,7 @@ export function plotFacilities({
         },
         symbol: {
           type: 'simple-marker', // autocasts as new SimpleMarkerSymbol()
-          color: colors.gray9,
+          color: colors.orange,
           style: 'diamond',
           size: 15,
         },

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -182,7 +182,7 @@ function MapLegendContent({ layer }: CardProps) {
   // jsx
   const dischargersLegend = (
     <LI>
-      <ImageContainer>{diamondIcon({ color: colors.gray9 })}</ImageContainer>
+      <ImageContainer>{diamondIcon({ color: colors.orange })}</ImageContainer>
       <LegendLabel>Permitted Discharger</LegendLabel>
     </LI>
   );

--- a/app/client/src/styles/index.js
+++ b/app/client/src/styles/index.js
@@ -27,6 +27,7 @@ const colors = {
   grayc: '#ccc',
   grayd: '#ddd',
   graye: '#eee',
+  orange: '#ffa500',
   yellow: '#ffff00',
 };
 


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3344855](https://app.breeze.pm/projects/100762/cards/3344855)

## Main Changes:
* Changed the permitted dischargers to orange instead of the dark gray.

## Steps To Test:
1. Navigate to [http://localhost:3000/community/denver%20co/overview](http://localhost:3000/community/denver%20co/overview)
2. Check the "Permitted Dischargers" switch.
3. Verify they are orange.
4. Open the legend and verify that permitted dischargers are orange there as well.

