### PR TITLE
Bugfix/ie11 polyfill issues

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -2785,15 +2785,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "array.prototype.findindex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-2.1.0.tgz",
-      "integrity": "sha512-25kJHCjXltdtljjwcyKvCTywmbUAeTJVB2ADVe0oP4jcefsd+K9pJJ3IdHPahLICoszcCLoNF+evWpEduzBlng==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      }
-    },
     "array.prototype.flat": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
@@ -4428,11 +4419,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-    },
-    "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",

--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -2785,6 +2785,15 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
+    "array.prototype.findindex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-2.1.0.tgz",
+      "integrity": "sha512-25kJHCjXltdtljjwcyKvCTywmbUAeTJVB2ADVe0oP4jcefsd+K9pJJ3IdHPahLICoszcCLoNF+evWpEduzBlng==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
+      }
+    },
     "array.prototype.flat": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
@@ -3350,6 +3359,13 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+        }
       }
     },
     "babylon": {
@@ -4414,9 +4430,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -49,8 +49,6 @@
     "@reach/router": "1.3.3",
     "@reach/tabs": "0.10.2",
     "@reach/window-size": "0.10.2",
-    "array.prototype.findindex": "2.1.0",
-    "core-js": "3.6.5",
     "eslint-config-react-app": "5.2.1",
     "esri-loader": "2.13.0",
     "glossary-panel": "github:Eastern-Research-Group/glossary",
@@ -81,10 +79,18 @@
       "react-app"
     ]
   },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
-  ]
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all",
+      "ie 11"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version",
+      "ie 11"
+    ]
+  }
 }

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -49,6 +49,8 @@
     "@reach/router": "1.3.3",
     "@reach/tabs": "0.10.2",
     "@reach/window-size": "0.10.2",
+    "array.prototype.findindex": "2.1.0",
+    "core-js": "3.6.5",
     "eslint-config-react-app": "5.2.1",
     "esri-loader": "2.13.0",
     "glossary-panel": "github:Eastern-Research-Group/glossary",

--- a/app/client/src/index.js
+++ b/app/client/src/index.js
@@ -2,10 +2,6 @@
 
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
-import 'core-js/features/array/find';
-import 'core-js/features/array/find-index';
-import 'core-js/features/object/entries';
-import findIndex from 'array.prototype.findindex';
 import smoothscroll from 'smoothscroll-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -21,7 +17,6 @@ import { GlossaryProvider } from 'contexts/Glossary';
 // errors
 import { defaultErrorBoundaryMessage } from 'config/errorMessages';
 
-findIndex.shim();
 smoothscroll.polyfill();
 
 // --- styled components ---

--- a/app/client/src/index.js
+++ b/app/client/src/index.js
@@ -2,6 +2,10 @@
 
 import 'react-app-polyfill/ie11';
 import 'react-app-polyfill/stable';
+import 'core-js/features/array/find';
+import 'core-js/features/array/find-index';
+import 'core-js/features/object/entries';
+import findIndex from 'array.prototype.findindex';
 import smoothscroll from 'smoothscroll-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -17,6 +21,7 @@ import { GlossaryProvider } from 'contexts/Glossary';
 // errors
 import { defaultErrorBoundaryMessage } from 'config/errorMessages';
 
+findIndex.shim();
 smoothscroll.polyfill();
 
 // --- styled components ---


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3342331](https://app.breeze.pm/projects/100762/cards/3342331)

## Main Changes:
* Updated the browser list syntax to include the correct polyfills.

## Steps To Test:
1. Delete the "app\client\node_modules\.cache" to clear your node modules cache
    * This might not be necessary, but I had to do it to get IE 11 working locally
2. Start the app
3. Open the app in IE 11
4. Do a search from the home page. Currently, the cloud.gov sites fail on the community overview page
5. Verify the app works

