### PR TITLE
Feature/remove implicit passing of props in community tabs

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
+++ b/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
@@ -17,13 +17,7 @@ const Container = styled.div`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
-
-function AquaticLife({ esriModules, infoToggleChecked }: Props) {
+function AquaticLife() {
   const { watershed } = React.useContext(LocationSearchContext);
 
   const waterbodies = useWaterbodyFeatures();

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -15,6 +15,8 @@ import { StyledErrorBox, StyledNoteBox } from 'components/shared/MessageBoxes';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
 // contexts
+import { EsriModulesContext } from 'contexts/EsriModules';
+import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
@@ -210,13 +212,13 @@ const Text = styled.p`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
+function DrinkingWater() {
+  const { Graphic, Polygon, SimpleFillSymbol } = React.useContext(
+    EsriModulesContext,
+  );
 
-function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
+  const { infoToggleChecked } = React.useContext(CommunityTabsContext);
+
   const {
     waterbodyLayer,
     providersLayer,
@@ -250,7 +252,6 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
       return;
     }
 
-    const { Graphic, Polygon, SimpleFillSymbol } = esriModules;
     const graphic = new Graphic({
       attributes: { name: 'providers' },
       geometry: new Polygon({
@@ -270,7 +271,7 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
     setCountyGraphic(graphic);
     providersLayer.graphics.removeAll();
     providersLayer.graphics.add(graphic);
-  }, [providersLayer, countyBoundaries, esriModules]);
+  }, [providersLayer, countyBoundaries, Graphic, Polygon, SimpleFillSymbol]);
 
   // toggle map layers' visibility when a tab changes
   React.useEffect(() => {
@@ -333,7 +334,6 @@ function DrinkingWater({ esriModules, infoToggleChecked }: Props) {
   }, [
     drinkingWaterTabIndex,
     countyGraphic,
-    esriModules,
     mapView,
     atHucBoundaries,
     previousTabIndex,

--- a/app/client/src/components/pages/Community/components/tabs/EatingFish.js
+++ b/app/client/src/components/pages/Community/components/tabs/EatingFish.js
@@ -9,6 +9,7 @@ import WaterbodyList from 'components/shared/WaterbodyList';
 import DisclaimerModal from 'components/shared/DisclaimerModal';
 import ShowLessMore from 'components/shared/ShowLessMore';
 // contexts
+import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
@@ -42,13 +43,9 @@ const Disclaimer = styled(DisclaimerModal)`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
+function EatingFish() {
+  const { infoToggleChecked } = React.useContext(CommunityTabsContext);
 
-function EatingFish({ esriModules, infoToggleChecked }: Props) {
   const {
     watershed,
     fishingInfo,

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -26,6 +26,8 @@ import {
   StyledLabel,
 } from 'components/shared/KeyMetrics';
 // contexts
+import { EsriModulesContext } from 'contexts/EsriModules';
+import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { formatNumber } from 'utils/utils';
@@ -97,13 +99,11 @@ const IntroDiv = styled.div`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
+function IdentifiedIssues() {
+  const { Graphic } = React.useContext(EsriModulesContext);
 
-function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
+  const { infoToggleChecked } = React.useContext(CommunityTabsContext);
+
   const {
     permittedDischargers,
     dischargersLayer,
@@ -156,8 +156,6 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
 
   const convertFacilityToGraphic = React.useCallback(
     (facility: Object) => {
-      const { Graphic } = esriModules;
-
       return new Graphic({
         geometry: {
           type: 'point', // autocasts as new Point()
@@ -167,12 +165,10 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
         attributes: facility,
       });
     },
-    [esriModules],
+    [Graphic],
   );
 
   const checkDischargersToDisplay = React.useCallback(() => {
-    const { Graphic } = esriModules;
-
     if (!dischargersLayer || !showDischargersLayer) return;
 
     plotFacilities({
@@ -180,12 +176,7 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
       facilities: violatingFacilities,
       layer: dischargersLayer,
     });
-  }, [
-    dischargersLayer,
-    esriModules,
-    showDischargersLayer,
-    violatingFacilities,
-  ]);
+  }, [dischargersLayer, Graphic, showDischargersLayer, violatingFacilities]);
 
   // translate scientific parameter names
   const getMappedParameterName = (
@@ -204,7 +195,6 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
 
   const checkWaterbodiesToDisplay = React.useCallback(() => {
     const waterbodiesToShow = new Set(); // set to prevent duplicates
-    const { Graphic } = esriModules;
     const features = getAllFeatures();
 
     if (!issuesLayer || !waterbodyLayer) return;
@@ -235,7 +225,7 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
       plotIssues(Graphic, Array.from(waterbodiesToShow), issuesLayer);
     }
   }, [
-    esriModules,
+    Graphic,
     getAllFeatures,
     issuesLayer,
     parameterToggleObject,

--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -14,6 +14,7 @@ import {
   AccordionItem,
 } from 'components/shared/Accordion/MapHighlight';
 // contexts
+import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { plotStations } from 'components/pages/LocationMap/MapFunctions';
@@ -85,12 +86,6 @@ const AccordionContent = styled.div`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
-
 type MonitoringLocationData = {
   type: 'FeatureCollection',
   features: Array<{
@@ -116,7 +111,9 @@ type StationGroups = {
   },
 };
 
-function Monitoring({ esriModules, infoToggleChecked }: Props) {
+function Monitoring() {
+  const { Graphic } = React.useContext(EsriModulesContext);
+
   const {
     monitoringLocations,
     monitoringGroups,
@@ -237,8 +234,6 @@ function Monitoring({ esriModules, infoToggleChecked }: Props) {
 
   const drawMap = React.useCallback(() => {
     if (allMonitoringStations.length === 0) return;
-
-    const { Graphic } = esriModules;
     const addedStationUids = [];
     let tempDisplayedMonitoringStations = [];
 
@@ -284,7 +279,7 @@ function Monitoring({ esriModules, infoToggleChecked }: Props) {
     displayedMonitoringStations,
     allMonitoringStations,
     allToggled,
-    esriModules,
+    Graphic,
     monitoringLocationToggles,
     monitoringStationGroups,
     monitoringStationsLayer,

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -16,6 +16,7 @@ import {
   StyledLabel,
 } from 'components/shared/KeyMetrics';
 // contexts
+import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { OverviewFiltersContext } from 'contexts/OverviewFilters';
 // utilities
@@ -52,13 +53,9 @@ const InfoBoxWithMargin = styled(StyledInfoBox)`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
+function Overview() {
+  const { Graphic } = React.useContext(EsriModulesContext);
 
-function Overview({ esriModules, infoToggleChecked }: Props) {
   const {
     monitoringLocations,
     permittedDischargers,
@@ -70,6 +67,7 @@ function Overview({ esriModules, infoToggleChecked }: Props) {
     visibleLayers,
     setVisibleLayers,
   } = React.useContext(LocationSearchContext);
+
   const {
     waterbodiesFilterEnabled,
     monitoringLocationsFilterEnabled,
@@ -102,9 +100,8 @@ function Overview({ esriModules, infoToggleChecked }: Props) {
       };
     });
 
-    const { Graphic } = esriModules;
     plotStations(Graphic, stations, monitoringStationsLayer);
-  }, [monitoringLocations.data, esriModules, monitoringStationsLayer]);
+  }, [monitoringLocations.data, Graphic, monitoringStationsLayer]);
 
   // draw the permitted dischargers on the map
   React.useEffect(() => {
@@ -113,14 +110,13 @@ function Overview({ esriModules, infoToggleChecked }: Props) {
       permittedDischargers.data['Results'] &&
       permittedDischargers.data['Results']['Facilities']
     ) {
-      const { Graphic } = esriModules;
       plotFacilities({
         Graphic: Graphic,
         facilities: permittedDischargers.data['Results']['Facilities'],
         layer: dischargersLayer,
       });
     }
-  }, [permittedDischargers.data, esriModules, dischargersLayer]);
+  }, [permittedDischargers.data, Graphic, dischargersLayer]);
 
   // Syncs the toggles with the visible layers on the map. Mainly
   // used for when the user toggles layers in full screen mode and then

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -39,13 +39,7 @@ const Heading = styled.h3`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
-
-function Protect({ esriModules, infoToggleChecked }: Props) {
+function Protect() {
   const { grts, watershed } = React.useContext(LocationSearchContext);
 
   const sortedGrtsData =
@@ -212,8 +206,9 @@ function Protect({ esriModules, infoToggleChecked }: Props) {
                                   {item['prj_title'] || 'Unknown'}
                                 </strong>
                               }
-                              subTitle={`ID: ${item['prj_seq'] ||
-                                'Unknown ID'}`}
+                              subTitle={`ID: ${
+                                item['prj_seq'] || 'Unknown ID'
+                              }`}
                             >
                               <table className="table">
                                 <tbody>

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -37,13 +37,7 @@ const Text = styled.p`
 `;
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
-
-function Restore({ esriModules, infoToggleChecked }: Props) {
+function Restore() {
   const { attainsPlans, grts, watershed } = React.useContext(
     LocationSearchContext,
   );
@@ -166,8 +160,9 @@ function Restore({ esriModules, infoToggleChecked }: Props) {
                                     {item['prj_title'] || 'Unknown'}
                                   </strong>
                                 }
-                                subTitle={`ID:  ${item['prj_seq'] ||
-                                  'Unknown ID'}`}
+                                subTitle={`ID:  ${
+                                  item['prj_seq'] || 'Unknown ID'
+                                }`}
                               >
                                 <table className="table">
                                   <tbody>

--- a/app/client/src/components/pages/Community/components/tabs/Swimming.js
+++ b/app/client/src/components/pages/Community/components/tabs/Swimming.js
@@ -16,17 +16,11 @@ import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
 import { huc12SummaryError } from 'config/errorMessages';
 
 // --- components ---
-type Props = {
-  // props passed implicitly in Community component
-  esriModules: Object,
-  infoToggleChecked: boolean,
-};
-
 const ErrorBox = styled(StyledErrorBox)`
   margin: 1rem;
 `;
 
-function Swimming({ esriModules, infoToggleChecked }: Props) {
+function Swimming() {
   const { watershed, cipSummary } = React.useContext(LocationSearchContext);
 
   // set the waterbody features

--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -12,7 +12,6 @@ import LocationSearch from 'components/shared/LocationSearch';
 import LocationMap from 'components/pages/LocationMap';
 import MapVisibilityButton from 'components/shared/MapVisibilityButton';
 // contexts
-import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import {
   CommunityTabsContext,
@@ -84,10 +83,7 @@ type Props = {
 */
 
 function Community({ children, ...props }: Props) {
-  const {
-    activeTabIndex,
-    infoToggleChecked, //
-  } = React.useContext(CommunityTabsContext);
+  const { activeTabIndex } = React.useContext(CommunityTabsContext);
 
   const { fullscreenActive } = React.useContext(FullscreenContext);
 
@@ -136,23 +132,7 @@ function Community({ children, ...props }: Props) {
     </>
   );
 
-  // jsx
-  const lowerTabs = (
-    <EsriModulesContext.Consumer>
-      {esriModules => {
-        // implicitly pass esriModules and infoToggleChecked props to 'lower' tab components
-        // (normally we'd get these via useContext, but lower tab components are all class-based
-        // components, and this is easier than using render props to use multiple React Contexts)
-        return React.cloneElement(
-          tabs[activeTabIndex === -1 ? 0 : activeTabIndex].lower,
-          {
-            esriModules,
-            infoToggleChecked,
-          },
-        );
-      }}
-    </EsriModulesContext.Consumer>
-  );
+  const lowerTab = tabs[activeTabIndex === -1 ? 0 : activeTabIndex].lower;
 
   return (
     <Page>
@@ -164,10 +144,7 @@ function Community({ children, ...props }: Props) {
               <>
                 <LocationMap windowHeight={height} layout="fullscreen" />
 
-                {/* Loads the lower tab but does not display it. This is used
-                    for drawing layers that filter out data 
-                    (i.e. Identified Issues panel) */}
-                <div style={{ display: 'none' }}>{lowerTabs}</div>
+                <div style={{ display: 'none' }}>{lowerTab}</div>
               </>
             );
           }
@@ -195,7 +172,7 @@ function Community({ children, ...props }: Props) {
                         )}
                       </MapVisibilityButton>
 
-                      {lowerTabs}
+                      {lowerTab}
                     </>
                   )}
                 </LeftColumn>
@@ -213,7 +190,7 @@ function Community({ children, ...props }: Props) {
                 <RightColumn data-column="right">
                   {/* children is either CommunityIntro or CommunityTabs (upper tabs) */}
                   {children}
-                  {!atCommunityIntroRoute && lowerTabs}
+                  {!atCommunityIntroRoute && lowerTab}
                 </RightColumn>
               </Columns>
             );


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762

## Main Changes:
This change has been a long time coming...on my list of changes I've wanted to make for a long time, but couldn't until all the community tabs were converted to function components (thanks for finishing up that task, @oftheheadland!)

Since all community tab components are now function component, we no longer need* to implicitly pass `esriModules` and `infoToggleChecked` props, as those can be accessed from within each individual tab component explicitly using `React.useContext`.

*Ok, we never _needed_ to pass props implicitly as we were previously doing via `React.cloneElement()`, but at the time that _felt_ like a better solution than wrapping each community tab component in multiple context providers and passing the props down via the React Context provider render props pattern. In retrospect, that would have been much better though, because not all community tab components needed both of those props. Plus almost always – explicit is better than implicit.

## Steps To Test:
1. Navigate to `/community`, perform a search, and click on all community tabs