### PR TITLE
Feature/Identified Issues, Monitoring, and Protect tests

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -585,6 +585,7 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
                     disabled={
                       zeroPollutedWaterbodies || cipSummary.status === 'failure'
                     }
+                    ariaLabel="Toggle Issues Layer"
                   />
                 </SwitchContainer>
               </>
@@ -608,6 +609,7 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
                     checked={toggleDischargersChecked}
                     onChange={() => toggleSwitch('Toggle Dischargers Layer')}
                     disabled={zeroDischargers}
+                    ariaLabel="Toggle Dischargers Layer"
                   />
                 </SwitchContainer>
               </>
@@ -619,7 +621,9 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
           <Tabs>
             <TabList>
               <Tab>Impaired Assessed Waters</Tab>
-              <Tab>Dischargers with Significant Violations</Tab>
+              <Tab data-testid="hmw-dischargers">
+                Dischargers with Significant Violations
+              </Tab>
             </TabList>
 
             <TabPanels>
@@ -711,6 +715,7 @@ function IdentifiedIssues({ esriModules, infoToggleChecked }: Props) {
                                             onChange={() =>
                                               toggleSwitch('Toggle All')
                                             }
+                                            ariaLabel="Toggle all impairment categories"
                                           />
                                         </TableSwitch>
                                         Impairment Category

--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -431,6 +431,7 @@ function Monitoring({ esriModules, infoToggleChecked }: Props) {
                         <Switch
                           checked={allToggled}
                           onChange={(ev) => toggleSwitch('All')}
+                          ariaLabel="Toggle all monitoring locations"
                         />
                         <span>All Monitoring Locations</span>
                       </Toggle>
@@ -449,6 +450,7 @@ function Monitoring({ esriModules, infoToggleChecked }: Props) {
                               <Switch
                                 checked={monitoringLocationToggles[label]}
                                 onChange={(ev) => toggleSwitch(label)}
+                                ariaLabel={`Toggle ${label}`}
                               />
                               <span>{label}</span>
                             </Toggle>

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -209,6 +209,7 @@ describe('Identified Issues Tab', () => {
       'not.exist',
     );
 
+    // switch to Dischargers tab of Identified Issues tab and check that the discharger accordion item exists and expands when clicked
     cy.findByText('Identified Issues').click();
     cy.findByTestId('hmw-dischargers').click();
     cy.findByText('RED LINE PUMPING STATIONS').click();
@@ -331,6 +332,7 @@ describe('Protect Tab', () => {
       'not.exist',
     );
 
+    // check that the Protection Projects in the Protect tab contains a project
     cy.findByText('Protect').click();
     cy.findByText('Protection Projects').click();
     cy.findByText('Cypress Creek WPP Imp - Years 1-3');

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -140,3 +140,200 @@ describe("Community page (small screen)", () => {
     cy.findByTestId("hmw-community-map").should("not.be.visible");
   });
 });
+
+describe('Identified Issues Tab', () => {
+  beforeEach(() => {
+    cy.visit('/community');
+  });
+
+  it('Toggling off the % Assessed Waters switch toggles all of the impairment category switches off', () => {
+    // navigate to Identified Issues tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      '020700100102',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Identified Issues').click();
+
+    cy.findByLabelText('Toggle Issues Layer').click({ force: true });
+    cy.findByLabelText('Toggle Issues Layer').should(
+      'have.attr',
+      'aria-checked',
+      'false',
+    );
+
+    // check that all switches are turned off
+    cy.findByLabelText('Toggle all impairment categories').should(
+      'have.attr',
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('Clicking the Dischargers switch toggles the switch off', () => {
+    // navigate to Identified Issues tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      '020700100102',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Identified Issues').click();
+
+    cy.findByLabelText('Toggle Dischargers Layer').click({ force: true });
+    cy.findByLabelText('Toggle Dischargers Layer').should(
+      'have.attr',
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('Clicking a Discharger accordion item expands it', () => {
+    // navigate to Identified Issues tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      '020700100102',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Identified Issues').click();
+    cy.findByTestId('hmw-dischargers').click();
+    cy.findByText('RED LINE PUMPING STATIONS').click();
+    cy.findByText('Compliance Status:');
+  });
+});
+
+describe('Monitoring Tab', () => {
+  beforeEach(() => {
+    cy.visit('/community');
+  });
+
+  it('Clicking the All Monitoring Locations switch toggles it off and displays 0 locations in the accordion', () => {
+    // navigate to Monitoring tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      'San Antonio, TX',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Monitoring').click();
+
+    // click Toggle All Monitoring Locations switch and check that all switches are toggled off
+    cy.findByLabelText('Toggle all monitoring locations').click({
+      force: true,
+    });
+
+    cy.findByLabelText('Toggle all monitoring locations').should(
+      'have.attr',
+      'aria-checked',
+      'false',
+    );
+    cy.findByLabelText('Toggle Metals').should(
+      'have.attr',
+      'aria-checked',
+      'false',
+    );
+
+    // check that there are no items displayed in accordion
+    cy.findByText('Displaying 0', { exact: false });
+
+    // check that clicking the Toggle All switch again toggles all switches back on
+    cy.findByLabelText('Toggle all monitoring locations').click({
+      force: true,
+    });
+    cy.findByLabelText('Toggle all monitoring locations').should(
+      'have.attr',
+      'aria-checked',
+      'true',
+    );
+    cy.findByLabelText('Toggle Metals').should(
+      'have.attr',
+      'aria-checked',
+      'true',
+    );
+  });
+});
+
+describe('Protect Tab', () => {
+  beforeEach(() => {
+    cy.visit('/community');
+  });
+
+  it('Check that Protection Projects are displayed', () => {
+    // navigate to Protect tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      '121002030202',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Protect').click();
+    cy.findByText('Protection Projects').click();
+    cy.findByText('Cypress Creek WPP Imp - Years 1-3');
+  });
+
+  it('Check that a message is displayed for a location with no Protection Projects', () => {
+    // navigate to Protect tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      'San Antonio, TX',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Protect').click();
+    cy.findByText('Get quick tips for reducing water impairment in your:');
+    cy.findByText('Protection Projects').click();
+    cy.findByText('There are no EPA funded protection projects in the', {
+      exact: false,
+    });
+  });
+});
+
+describe('Protect Tab', () => {
+  beforeEach(() => {
+    cy.visit('/community');
+  });
+
+  it('Check that Protection Projects are displayed', () => {
+    // navigate to Protect tab of Community page
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(
+      '121002030202',
+    );
+    cy.findByText('Go').click();
+
+    // wait for the web services to finish
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
+      'not.exist',
+    );
+
+    cy.findByText('Protect').click();
+    cy.findByText('Protection Projects').click();
+    cy.findByText('Cypress Creek WPP Imp - Years 1-3');
+  });
+
+});

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -289,6 +289,7 @@ describe('Protect Tab', () => {
       'not.exist',
     );
 
+    // check that the Protection Projects in the Protect tab contains a project
     cy.findByText('Protect').click();
     cy.findByText('Protection Projects').click();
     cy.findByText('Cypress Creek WPP Imp - Years 1-3');
@@ -313,29 +314,4 @@ describe('Protect Tab', () => {
       exact: false,
     });
   });
-});
-
-describe('Protect Tab', () => {
-  beforeEach(() => {
-    cy.visit('/community');
-  });
-
-  it('Check that Protection Projects are displayed', () => {
-    // navigate to Protect tab of Community page
-    cy.findByPlaceholderText('Search by address', { exact: false }).type(
-      '121002030202',
-    );
-    cy.findByText('Go').click();
-
-    // wait for the web services to finish
-    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
-      'not.exist',
-    );
-
-    // check that the Protection Projects in the Protect tab contains a project
-    cy.findByText('Protect').click();
-    cy.findByText('Protection Projects').click();
-    cy.findByText('Cypress Creek WPP Imp - Years 1-3');
-  });
-
 });


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3346588

## Main Changes:
* Adds tests for the Identified Issues, Monitoring, and Protect tabs on the Community page.
* Adds aria-labels to some of the Community switches. Our accessibility tools were not finding them to be in error but they are not clearly labeled otherwise and it gives us a way of targeting the switches with Cypress.

Code coverage before:
![image](https://user-images.githubusercontent.com/17204883/82604712-b0a6da00-9b82-11ea-80f2-66a425fe10a7.png)

After:
![image](https://user-images.githubusercontent.com/17204883/82604698-ad135300-9b82-11ea-886d-4ca53a724b23.png)

It seems like the numbers vary slightly between test runs in the range +/- 0.5%
Possibly because services finish faster between runs and that causes more or less code to be affected by the test, even if it's in a different tab? Just a theory.



## Steps To Test:
1. Run `npm run coverage` in the app folder and check that tests pass and the code coverage for the Community tabs has improved for the Identified Issues, Monitoring, and Protect tabs.