### PR TITLE
Bugfix/cloudgov redirect issue

### DIFF
--- a/app/client/src/components/pages/404/index.js
+++ b/app/client/src/components/pages/404/index.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React from 'react';
-import { navigate } from '@reach/router';
 
 // --- components ---
 function PageNotFound() {
@@ -13,7 +12,7 @@ function PageNotFound() {
     if (location.hostname === 'localhost') {
       url = `${location.protocol}//${location.hostname}:9090/404.html`;
     }
-    navigate(url);
+    window.location.assign(url);
   }, []);
 
   return null;


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3345751](https://app.breeze.pm/projects/100762/cards/3345751)

## Main Changes:
After I merged #138, I noticed the redirect wasn't working on cloud.gov. The url changed but the 400.html page didn't load on the screen. However, going directly to the 400.html (i.e. [https://mywaterway-dev.app.cloud.gov/404.html](https://mywaterway-dev.app.cloud.gov/404.html)) page did work.

To fix the issue I updated the redirect code to use `window.location.assign` instead of the `navigate` function provided by reach-router. I think the `navigate` function was just changing the url and not reloading the page. 

## Steps To Test:
1. Follow the steps in #138 just to make sure the redirect still works on localhost.
2. Once this gets merged we'll be able to re-test the cloud.gov redirect.

