### PR TITLE
Feature/img alt attributes

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -468,7 +468,10 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
 
         <TabHeader>
           <div>
-            <img src={tabs[activeTabIndex].icon} alt="" />
+            <img
+              src={tabs[activeTabIndex].icon}
+              alt={tabs[activeTabIndex].title}
+            />
             <p>{tabs[activeTabIndex].title}</p>
           </div>
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 How’s My Waterway is a responsive, map-centric, mobile ready web application that pulls data from several different systems at EPA and beyond via web services to provide a user with an overall picture of water quality on 3 levels: community, state and national.
 
 <p align="center">
-      <img height="50%" width="50%" src="/docs/img/v2.0/Landing-Page.png">
+      <img height="50%" width="50%" src="/docs/img/v2.0/Landing-Page.png" alt="Screenshot of Landing Page">
 </p>
 
 ## Documentation


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3345973](https://app.breeze.pm/projects/100762/cards/3345973)

## Main Changes:
* Added an `alt` attribute to all `<img>` tags across the app. 
    * I also added an `alt` attribute to an `<img>` tag in the github readme. Probably not necessary, but figured it was good practice to do it.
    * I skipped over the EPA Template until we get some direction on what the client wants for those.

## Steps To Test:
1. Do a search on the community page
2. Inspect the icon in the tab header and verify it has an `alt` value that matches the tab name.

