### PR TITLE
Feature/file extension for download links

### DIFF
--- a/app/client/src/components/pages/State/components/Documents.js
+++ b/app/client/src/components/pages/State/components/Documents.js
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import Table from 'components/shared/Table';
+// utilities
+import { getExtensionFromPath } from 'utils/utils';
 // styled components
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
 // data
@@ -128,7 +130,12 @@ function Documents({
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {props.value}
+                {props.value} (
+                {getExtensionFromPath(
+                  props.original.documentFileName,
+                  props.original.documentURL,
+                )}
+                )
               </a>
             ),
           },

--- a/app/client/src/components/pages/State/components/Stories.js
+++ b/app/client/src/components/pages/State/components/Stories.js
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import ShowLessMore from 'components/shared/ShowLessMore';
+// utilities
+import { getExtensionFromPath } from 'utils/utils';
 // styled components
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
 // styles
@@ -76,7 +78,7 @@ function Stories({ stories }: Props) {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    {story.ss_title}
+                    {story.ss_title} ({getExtensionFromPath(story.web_link)})
                   </a>
                   <p>
                     <ShowLessMore

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -36,6 +36,30 @@ function formatNumber(number: number, digits: number = 0) {
   });
 }
 
+// Gets the file extension from a url or path. The backup parameter was added
+// because the state page documents section sometimes has the file extension
+// on the documentFileName and other times its on the documentURL attribute.
+function getExtensionFromPath(primary: string, backup: string = '') {
+  // Gets the file extension from a url or path
+  function getExtension(path: string) {
+    if (!path) return null;
+
+    const filename = path.split('/').pop();
+    const parts = filename.split('.');
+
+    if (parts.length === 1) {
+      return null;
+    }
+    return parts.pop().toUpperCase();
+  }
+
+  let extension = getExtension(primary);
+  if (!extension) extension = getExtension(backup);
+
+  if (!extension) return 'UNKNOWN';
+  return extension;
+}
+
 require('@gouch/to-title-case');
 
 function titleCase(string: string) {
@@ -69,6 +93,7 @@ export {
   chunkArray,
   containsScriptTag,
   formatNumber,
+  getExtensionFromPath,
   titleCase,
   titleCaseWithExceptions,
 };


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3346468](https://app.breeze.pm/projects/100762/cards/3346468)

## Main Changes:
* Added a file extension to the end of the story and document download links.

## Steps To Test:
1. Navigate to [http://localhost:3000/state/IA/water-quality-overview](http://localhost:3000/state/IA/water-quality-overview) - This one has several different extension types, most other states just have pdfs. 
2. Expand the documents section and verify they all have an extension at the end of the link.
3. Expand the stories section and verify they all have an extension at the end of the link.
4. Navigate to [http://localhost:3000/state/AZ/water-quality-overview](http://localhost:3000/state/AZ/water-quality-overview) - This one has a surveys document where the extension is not on the documentFileName property, but it is on the documentURL property. Most documents have the extension on the documentFileName property, but not on the documentURL property.
5. Repeat steps 2 and 3. 

