### PR TITLE
Bugfix/location change popup fullscreen

### DIFF
--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -144,7 +144,10 @@ function Community({ children, ...props }: Props) {
               <>
                 <LocationMap windowHeight={height} layout="fullscreen" />
 
-                <div style={{ display: 'none' }}>{lowerTab}</div>
+                <div style={{ display: 'none' }}>{children}</div>
+                {!atCommunityIntroRoute && (
+                  <div style={{ display: 'none' }}>{lowerTab}</div>
+                )}
               </>
             );
           }

--- a/app/client/src/components/shared/MapMouseEvents/index.js
+++ b/app/client/src/components/shared/MapMouseEvents/index.js
@@ -62,19 +62,12 @@ function MapMouseEvents({ map, view }: Props) {
       popupContent.innerHTML = renderToStaticMarkup(
         <>
           <br />
-          <div className="row">
-            <div className="col-xs-6 col-sm-6">
-              <p>
-                <strong>Watershed Name:</strong>
-                <br /> {attributes.name}
-              </p>
-            </div>
-            <div className="col-xs-6 col-sm-6">
-              <p>
-                <strong>HUC 12:</strong>
-                <br /> {clickedHuc12}
-              </p>
-            </div>
+          <div>
+            <p>
+              <strong style={{ fontSize: '0.875em' }}>WATERSHED:</strong>
+              <br />
+              {attributes.name} ({clickedHuc12})
+            </p>
           </div>
         </>,
       );

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -331,6 +331,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     resetMap: (useDefaultZoom = false) => {
       const {
         initialExtent,
+        layers,
         pointsLayer,
         linesLayer,
         areasLayer,
@@ -346,24 +347,32 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       } = this.state;
 
       // Clear waterbody layers from state
-      let clear = {};
-      if (pointsLayer) clear['pointsLayer'] = null;
-      if (linesLayer) clear['linesLayer'] = null;
-      if (areasLayer) clear['areasLayer'] = null;
-      if (waterbodyLayer) {
-        clear['waterbodyLayer'] = null;
+      let newState = {};
+      if (pointsLayer) newState['pointsLayer'] = null;
+      if (linesLayer) newState['linesLayer'] = null;
+      if (areasLayer) newState['areasLayer'] = null;
+      if (waterbodyLayer) newState['waterbodyLayer'] = null;
 
-        // Remove the waterbody layer from the map
-        if (mapView) {
-          for (let i = mapView.map.layers.items.length - 1; i >= 0; i--) {
-            const item = mapView.map.layers.items[i];
-            if (item.id === 'waterbodyLayer') {
-              mapView.map.layers.items.splice(i, 1);
-            }
-          }
+      const layersToRemove = [
+        'pointsLayer',
+        'linesLayer',
+        'areasLayer',
+        'waterbodyLayer',
+      ];
+
+      // remove the layers from state layers list
+      let removedLayers = false;
+      for (let i = layers.length - 1; i >= 0; i--) {
+        const item = layers[i];
+        const itemId = item.id;
+        if (layersToRemove.includes(itemId)) {
+          layers.splice(i, 1);
+          removedLayers = true;
         }
       }
-      this.setState(clear);
+      if (removedLayers) newState['layers'] = layers;
+
+      this.setState(newState);
 
       // remove all map content defined in this file
       if (providersLayer) providersLayer.graphics.removeAll();


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3354230](https://app.breeze.pm/projects/100762/cards/3354230)
* [https://app.breeze.pm/projects/100762/cards/3354512](https://app.breeze.pm/projects/100762/cards/3354512)

## Main Changes:
* Updated the text of the "Change Location" popup.
* Fixed an issue where the "Change Location" popup did not work in full screen mode. 
* Fixed an issue where doing multiple searches and triggering a layout change (i.e. going to fullscreen mode, switching to mobile layout, etc.) would result in all of the waterbodies from previous searches being visible.

## Steps To Test:
1. Do a search on the community page. 
2. Click outside of the huc boundaries and verify the "Change location" popup has the updated text.
3. Go into full screen mode. 
4. Use the "Change location" popup to change locations.
5. Repeat step 4 a couple of times using different locations.
6. Verify the location updates and that just the waterbodies from the most recent location are visible.
7. Exit full screen mode
8. Verify that just the waterbodies from the most recent location are visible.

