### PR TITLE
Feature/remove document description column

### DIFF
--- a/app/client/src/components/pages/State/components/Documents.js
+++ b/app/client/src/components/pages/State/components/Documents.js
@@ -118,6 +118,7 @@ function Documents({
             accessor: 'documentTypeLabel',
             Header: 'Document Types',
             style: { textAlign: 'center' },
+            maxWidth: 300,
             Cell: (props) => props.value,
           },
           {
@@ -143,18 +144,13 @@ function Documents({
             accessor: 'agencyCode',
             Header: 'Agency Code',
             style: { textAlign: 'center' },
-            minWidth: 50,
+            maxWidth: 125,
             Cell: (props) =>
               props.value === 'S'
                 ? 'State'
                 : props.value === 'E'
                 ? 'EPA'
                 : props.value,
-          },
-          {
-            accessor: 'documentDescription',
-            Header: 'Document Description',
-            style: { textAlign: 'center' },
           },
         ]}
       />


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3355145](https://app.breeze.pm/projects/100762/cards/3355145)

## Main Changes:
* Removed the "Document Description" column from the "Documents" section of the state page.
* Adjusted the widths of the remaining columns, so they look decent with the extra space.

## Steps To Test:
1. Navigate to [http://localhost:3000/state/KS/water-quality-overview](http://localhost:3000/state/KS/water-quality-overview)
2. Expand the "Documents" section
3. Verify the "Document Description" column is gone
4. Make sure the table still looks good
