### PR TITLE
Feature/left align documents table

### DIFF
--- a/app/client/src/components/pages/State/components/Documents.js
+++ b/app/client/src/components/pages/State/components/Documents.js
@@ -117,14 +117,12 @@ function Documents({
           {
             accessor: 'documentTypeLabel',
             Header: 'Document Types',
-            style: { textAlign: 'center' },
             maxWidth: 300,
             Cell: (props) => props.value,
           },
           {
             accessor: 'documentName',
             Header: 'Document',
-            style: { textAlign: 'center' },
             Cell: (props) => (
               <a
                 href={props.original.documentURL}
@@ -143,7 +141,6 @@ function Documents({
           {
             accessor: 'agencyCode',
             Header: 'Agency Code',
-            style: { textAlign: 'center' },
             maxWidth: 125,
             Cell: (props) =>
               props.value === 'S'


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3356027

## Main Changes:
* State documents table is now left-aligned.

## Steps To Test:
1. Navigate to http://localhost:3000/state/AK/water-quality-overview
2. Open the Documents accordion and check that the columns are no longer centered and are left-aligned.

Screenshot of change as time is limited:
![image](https://user-images.githubusercontent.com/17204883/83166262-a7ff5800-a0dc-11ea-9baa-1310670a7845.png)
