### PR TITLE
Feature/apply aria hidden to icons

### DIFF
--- a/app/client/src/components/pages/State/components/routes/StateIntro.js
+++ b/app/client/src/components/pages/State/components/routes/StateIntro.js
@@ -43,7 +43,7 @@ function StateIntro({ ...props }: Props) {
     <>
       <StyledIntroBox>
         <Header>
-          <i className="fas fa-tint" />
+          <i className="fas fa-tint" aria-hidden="true" />
           <StyledIntroHeading>
             States Play a Primary Role in Protecting Water Quality
           </StyledIntroHeading>

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -878,12 +878,12 @@ function AdvancedSearch({ ...props }: Props) {
         >
           {searchLoading ? (
             <>
-              <i className="fas fa-spinner fa-pulse" />
+              <i className="fas fa-spinner fa-pulse" aria-hidden="true" />
               &nbsp;&nbsp;Loading...
             </>
           ) : (
             <>
-              <i className="fas fa-search" />
+              <i className="fas fa-search" aria-hidden="true" />
               &nbsp;&nbsp;Search
             </>
           )}
@@ -925,7 +925,7 @@ function AdvancedSearch({ ...props }: Props) {
               className={`btn btn-secondary${showMap ? ' active' : ''}`}
               onClick={(ev) => setShowMap(true)}
             >
-              <i className="fas fa-map-marked-alt" />
+              <i className="fas fa-map-marked-alt" aria-hidden="true" />
               &nbsp;&nbsp;Map
             </Button>
             <Button
@@ -933,7 +933,7 @@ function AdvancedSearch({ ...props }: Props) {
               className={`btn btn-secondary${!showMap ? ' active' : ''}`}
               onClick={(ev) => setShowMap(false)}
             >
-              <i className="fas fa-list" />
+              <i className="fas fa-list" aria-hidden="true" />
               &nbsp;&nbsp;List
             </Button>
           </ButtonGroup>

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -787,7 +787,7 @@ function WaterQualityOverview({ ...props }: Props) {
   return (
     <Container>
       <Heading>
-        <i className="fas fa-tint" />
+        <i className="fas fa-tint" aria-hidden="true" />
         <strong>{activeState.name}</strong> Water Quality
       </Heading>
 
@@ -935,7 +935,9 @@ function WaterQualityOverview({ ...props }: Props) {
 
       <Accordions>
         <AccordionItem
-          icon={<AccordionIcon className="fas fa-file-alt" />}
+          icon={
+            <AccordionIcon className="fas fa-file-alt" aria-hidden="true" />
+          }
           title={
             <Heading>
               <strong>{activeState.name}</strong> Documents
@@ -955,7 +957,9 @@ function WaterQualityOverview({ ...props }: Props) {
           </AccordionContent>
         </AccordionItem>
         <AccordionItem
-          icon={<AccordionIcon className="fas fa-newspaper" />}
+          icon={
+            <AccordionIcon className="fas fa-newspaper" aria-hidden="true" />
+          }
           title={
             <Heading>
               <strong>{activeState.name}</strong> Water Stories

--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -247,7 +247,8 @@ function State({ children, ...props }: Props) {
               />
 
               <Button type="submit" className="btn">
-                <i className="fas fa-angle-double-right" /> Go
+                <i className="fas fa-angle-double-right" aria-hidden="true" />{' '}
+                Go
               </Button>
             </Form>
           </>
@@ -270,7 +271,7 @@ function State({ children, ...props }: Props) {
                     {stateIntro.metrics.length > 0 && (
                       <>
                         <h2>
-                          <i className="fas fa-chart-line" />
+                          <i className="fas fa-chart-line" aria-hidden="true" />
                           <strong>{activeState.name}</strong> by the Numbers
                         </h2>
 

--- a/app/client/src/components/shared/Accordion/index.js
+++ b/app/client/src/components/shared/Accordion/index.js
@@ -111,7 +111,7 @@ function AccordionList({
         {!expandDisabled && (
           <ExpandButton onClick={(ev) => setAllExpanded(!allExpanded)}>
             {buttonText}&nbsp;&nbsp;
-            <i className={iconClass} />
+            <i className={iconClass} aria-hidden="true" />
           </ExpandButton>
         )}
       </Columns>
@@ -267,7 +267,10 @@ function AccordionItem({
           )}
         </Text>
 
-        <Arrow className={`fa fa-angle-${isOpen ? 'down' : 'right'}`} />
+        <Arrow
+          className={`fa fa-angle-${isOpen ? 'down' : 'right'}`}
+          aria-hidden="true"
+        />
       </Header>
 
       {isOpen && children}

--- a/app/client/src/components/shared/DataContent/index.js
+++ b/app/client/src/components/shared/DataContent/index.js
@@ -109,7 +109,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://www.epa.gov/waterdata/attains"
           target="_blank"
@@ -150,7 +150,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://echo.epa.gov/"
           target="_blank"
@@ -179,7 +179,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://iaspub.epa.gov/apex/grts/f?p=grts:95"
           target="_blank"
@@ -209,7 +209,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://www.epa.gov/ground-water-and-drinking-water/safe-drinking-water-information-system-sdwis-federal-reporting"
           target="_blank"
@@ -237,7 +237,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://www.epa.gov/waterdata/waters-watershed-assessment-tracking-environmental-results-system"
           target="_blank"
@@ -261,7 +261,7 @@ function Data({ ...props }: Props) {
       <hr />
 
       <Item>
-        <i className="fas fa-database" />{' '}
+        <i className="fas fa-database" aria-hidden="true" />{' '}
         <a
           href="https://www.waterqualitydata.us/"
           target="_blank"

--- a/app/client/src/components/shared/GlossaryPanel/index.js
+++ b/app/client/src/components/shared/GlossaryPanel/index.js
@@ -278,7 +278,8 @@ function GlossaryTerm({ term, children }: Props) {
       title="Click to define"
       tabIndex="0"
     >
-      <TermIcon className={iconClassName} status={status} /> {children}
+      <TermIcon className={iconClassName} status={status} aria-hidden="true" />{' '}
+      {children}
     </span>
   );
 }

--- a/app/client/src/components/shared/Icons/AquaticLifeIcon.js
+++ b/app/client/src/components/shared/Icons/AquaticLifeIcon.js
@@ -14,6 +14,7 @@ function AquaticLifeIcon({ height = '5rem' }: Props) {
       y="0"
       viewBox="0 0 54 54"
       style={{ height }}
+      aria-hidden="true"
     >
       <path
         fill="#fff"

--- a/app/client/src/components/shared/Icons/DrinkingWaterIcon.js
+++ b/app/client/src/components/shared/Icons/DrinkingWaterIcon.js
@@ -14,6 +14,7 @@ function DrinkingWaterIcon({ height = '5rem' }: Props) {
       y="0"
       viewBox="0 0 54 54"
       style={{ height }}
+      aria-hidden="true"
     >
       <path
         fill="#fff"

--- a/app/client/src/components/shared/Icons/EatingFishIcon.js
+++ b/app/client/src/components/shared/Icons/EatingFishIcon.js
@@ -14,6 +14,7 @@ function EatingFishIcon({ height = '5rem' }: Props) {
       y="0"
       viewBox="0 0 54 54"
       style={{ height }}
+      aria-hidden="true"
     >
       <path
         fill="#fff"

--- a/app/client/src/components/shared/Icons/OtherIcon.js
+++ b/app/client/src/components/shared/Icons/OtherIcon.js
@@ -14,6 +14,7 @@ function OtherIcon({ height = '5rem' }: Props) {
       y="0"
       viewBox="0 0 54 54"
       style={{ height }}
+      aria-hidden="true"
     >
       <path
         fill="#fff"

--- a/app/client/src/components/shared/Icons/PinIcon.js
+++ b/app/client/src/components/shared/Icons/PinIcon.js
@@ -12,6 +12,7 @@ function PinIcon({ ...props }: Props) {
       y="0"
       viewBox="0 0 40 40"
       {...props}
+      aria-hidden="true"
     >
       <path
         fill="#2D72B5"

--- a/app/client/src/components/shared/Icons/SwimmingIcon.js
+++ b/app/client/src/components/shared/Icons/SwimmingIcon.js
@@ -14,6 +14,7 @@ function SwimmingIcon({ height = '5rem' }: Props) {
       y="0"
       viewBox="0 0 54 54"
       style={{ height }}
+      aria-hidden="true"
     >
       <path
         fill="none"

--- a/app/client/src/components/shared/LoadingSpinner/index.js
+++ b/app/client/src/components/shared/LoadingSpinner/index.js
@@ -96,6 +96,7 @@ function LoadingSpinner({ ...props }: Props) {
         height="50"
         viewBox="0 0 50 50"
         {...props}
+        aria-hidden="true"
       >
         <IeCircle cx="25" cy="25" r="20" />
       </IeSvg>
@@ -108,6 +109,7 @@ function LoadingSpinner({ ...props }: Props) {
       width="50"
       height="50"
       viewBox="0 0 50 50"
+      aria-hidden="true"
       {...props}
     >
       <Circle cx="25" cy="25" r="20" />

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -138,7 +138,7 @@ function LocationSearch({ route, label }: Props) {
           type="submit"
           disabled={inputText === searchText}
         >
-          <i className="fas fa-angle-double-right" /> Go
+          <i className="fas fa-angle-double-right" aria-hidden="true" /> Go
         </Button>
 
         {navigator.geolocation && (
@@ -147,7 +147,7 @@ function LocationSearch({ route, label }: Props) {
 
             {geolocationError ? (
               <Button className="btn btn-danger" type="button" disabled>
-                <i className="fas fa-exclamation-triangle" />
+                <i className="fas fa-exclamation-triangle" aria-hidden="true" />
                 &nbsp;&nbsp;Error Getting Location
               </Button>
             ) : (
@@ -191,12 +191,12 @@ function LocationSearch({ route, label }: Props) {
                 {/* don't display the loading indicator in IE11 */}
                 {!geolocating || isIE() ? (
                   <>
-                    <i className="fas fa-crosshairs" />
+                    <i className="fas fa-crosshairs" aria-hidden="true" />
                     &nbsp;&nbsp;Use My Location
                   </>
                 ) : (
                   <>
-                    <i className="fas fa-spinner fa-pulse" />
+                    <i className="fas fa-spinner fa-pulse" aria-hidden="true" />
                     &nbsp;&nbsp;Getting Location...
                   </>
                 )}

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -96,6 +96,7 @@ function MapLegendContent({ layer }: CardProps) {
         width={boxSize}
         height={boxSize}
         viewBox={`0 0 ${boxSize} ${boxSize}`}
+        aria-hidden="true"
       >
         <rect
           x={(boxSize - iconSize) / 2}
@@ -118,6 +119,7 @@ function MapLegendContent({ layer }: CardProps) {
         width={boxSize}
         height={boxSize}
         viewBox={`0 0 ${boxSize} ${boxSize}`}
+        aria-hidden="true"
       >
         <rect
           x={(boxSize - diamondSize) / 2}
@@ -233,6 +235,7 @@ function MapLegendContent({ layer }: CardProps) {
             width="26"
             height="26"
             viewBox="0 0 26 26"
+            aria-hidden="true"
           >
             <rect x="0" y="12" width="10" height="3" fill="#666666" />
             <rect x="16" y="12" width="10" height="3" fill="#666666" />

--- a/app/client/src/components/shared/MapVisibilityButton/index.js
+++ b/app/client/src/components/shared/MapVisibilityButton/index.js
@@ -48,7 +48,7 @@ function MapVisibilityButton({ children }: Props) {
       <MapButton style={{ opacity }}>
         <button onClick={(ev) => setMapShown(!mapShown)}>
           {buttonText}&nbsp;&nbsp;
-          <i className={iconClass} />
+          <i className={iconClass} aria-hidden="true" />
         </button>
       </MapButton>
 

--- a/app/client/src/components/shared/NavBar/index.js
+++ b/app/client/src/components/shared/NavBar/index.js
@@ -45,7 +45,7 @@ function NavBar({ title, onBackClick = null }: Props) {
       <Group>
         {onBackClick && (
           <BackButton onClick={(ev) => onBackClick(ev)}>
-            <i className="fas fa-chevron-left" />
+            <i className="fas fa-chevron-left" aria-hidden="true" />
             &nbsp; Back
           </BackButton>
         )}

--- a/app/client/src/components/shared/ViewOnMapButton/index.js
+++ b/app/client/src/components/shared/ViewOnMapButton/index.js
@@ -115,7 +115,7 @@ function ViewOnMapButton({ feature, fieldName, layers }: Props) {
         }
       }}
     >
-      <i className="fas fa-map-marker-alt" />
+      <i className="fas fa-map-marker-alt" aria-hidden="true" />
       &nbsp;&nbsp;View on Map
     </Button>
   );

--- a/app/client/src/components/shared/WaterbodyIcon/index.js
+++ b/app/client/src/components/shared/WaterbodyIcon/index.js
@@ -72,6 +72,7 @@ function WaterbodyIcon({ condition, selected = false }: Props) {
       width="26"
       height="26"
       viewBox="0 0 26 26"
+      aria-hidden="true"
     >
       {shape}
     </svg>


### PR DESCRIPTION

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3355125

## Main Changes:
* To meet FontAwesome's accessibility recommendations I've added `aria-hidden="true"` to all of our icons and SVGs as discussed with Brad and Caleb. 
https://fontawesome.com/v4.7.0/accessibility/

## Steps To Test:
1. Search the project for all `<i>` tags, SVGs, and other icons and make sure they have the `aria-hidden="true"` attribute.