### PR TITLE
feature/left align documents and ATTAINS tables

### DIFF
--- a/app/client/src/components/shared/Table/tableStyles.css
+++ b/app/client/src/components/shared/Table/tableStyles.css
@@ -34,10 +34,14 @@
 .cell-checkbox {
   padding: 2px;
   display: flex;
+  align-items: center;
+  justify-content: center;
   height: 100%;
   width: 100%;
 }
 
 .rt-resizable-header-content {
   text-align: left;
+  align-items: normal;
+  justify-content: normal;
 }

--- a/app/client/src/components/shared/Table/tableStyles.css
+++ b/app/client/src/components/shared/Table/tableStyles.css
@@ -34,8 +34,10 @@
 .cell-checkbox {
   padding: 2px;
   display: flex;
-  align-items: center;
-  justify-content: center;
   height: 100%;
   width: 100%;
+}
+
+.rt-resizable-header-content {
+  text-align: left;
 }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3356638

## Main Changes:
* Update table stylesheet to left-align all headers.
* Affects the State Documents and ATTAINS tables

## Steps To Test:
1. Navigate to http://localhost:3000/state/AL/water-quality-overview
2. Open the {State Name} Documents accordion and check that the headers and columns are all left-aligned.
3. Navigate to http://localhost:3000/attains
4. Check that the headers and columns are all left-aligned

