### PR TITLE
Bugfix/keyboard navigation tabs

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -446,12 +446,11 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
           ))}
         </TabList>
 
-        <TabDots>
+        <TabDots aria-hidden="true">
           {tabs.map((tab, index) => {
             return (
               <li key={index}>
                 <TabDot
-                  aria-hidden="true"
                   tabIndex="-1"
                   title={tab.title}
                   data-selected={index === activeTabIndex}

--- a/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityTabs.js
@@ -229,10 +229,9 @@ const TabDots = styled.ul`
   }
 `;
 
-const TabDot = styled.div`
-  cursor: pointer;
-  display: inline-block;
+const TabDot = styled.button`
   margin: 4px;
+  padding: 0;
   border: 1px solid ${colors.black(0.25)};
   border-radius: 50%;
   width: 14px;
@@ -242,7 +241,6 @@ const TabDot = styled.div`
   &[data-selected='true'],
   &:hover,
   &:focus {
-    outline: none;
     border-color: ${colors.blue(0.75)};
     box-shadow: 0 0 0 1px ${colors.blue(0.75)};
   }
@@ -358,7 +356,7 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
     if (tabListRef.current) {
       const tabList = tabListRef.current;
       const activeTab = tabList.children[activeTabIndex];
-      activeTab.focus();
+      setTimeout(() => activeTab.focus(), 0);
 
       const column = document.querySelector('[data-column="right"]');
       if (!column) return;
@@ -453,7 +451,8 @@ function CommunityTabs({ urlSearch, tabName, ...props }: Props) {
             return (
               <li key={index}>
                 <TabDot
-                  tabIndex="0"
+                  aria-hidden="true"
+                  tabIndex="-1"
                   title={tab.title}
                   data-selected={index === activeTabIndex}
                   onClick={(ev) => {

--- a/app/client/src/components/pages/State/components/routes/StateTabs.js
+++ b/app/client/src/components/pages/State/components/routes/StateTabs.js
@@ -94,7 +94,7 @@ function StateTabs({ stateCode, tabName, ...props }: Props) {
   // focus the active tab
   React.useEffect(() => {
     if (tabListRef.current) {
-      tabListRef.current.children[activeTabIndex].focus();
+      setTimeout(() => tabListRef.current.children[activeTabIndex].focus(), 0);
     }
   }, [tabListRef, activeTabIndex]);
 


### PR DESCRIPTION
## Related Issues:
* [https://app.breeze.pm/projects/100762/cards/3355943](https://app.breeze.pm/projects/100762/cards/3355943)

## Main Changes:
* Fixed an issue with top level tabs (community and state page) losing focus when using a keyboard to navigate them (arrow keys). 
    * The issue was the top level tabs use reach router to navigate between the pages (so the url is updated). This navigation caused the tab component to lose focus. To get around this issue I just wrapped the focus setter with a setTimeout (i.e. `setTimeout(() => activeTab.focus(), 0);`). This just makes sure the browser thread has finished before setting the focus. 
    * This issue did not affect the national page, since those tabs don't affect the routing.
* Changed the `TabDot` elements to be buttons elements instead of divs. 
* Put a `tabIndex="-1"` on the `TabDot` elements, so they never get focus. 
    * I spoke with Courtney and we came to the conclusion that since the reach-tabs are navigable with the key board there is no reason to have the TabDots navigable as well. Also this eliminates potential confusion around the reach-tabs using arrow-keys (w3 preferred method) and the TabDots using tab/enter keys.
* Put a `aria-hidden="true"` on the `ul` element surrounding the TabDots. 
    * The reason for this is that it could be confusing to a user with a screen reader, since they would have two sets of the same tabs read to them. 

## Steps To Test:
1. Do a search on the community page
2. Use the arrow keys to navigate between the tabs
3. Click the TabDots and make sure they still work
4. Press the tab key and make sure the TabDots are skipped over and don't get focus
5. Go to the state page
6. Use the arrow keys to navigate between the tabs

