### PR TITLE
feature/glossary-prevent-duplicates

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -6862,7 +6862,7 @@
       }
     },
     "glossary-panel": {
-      "version": "github:Eastern-Research-Group/glossary#bb6ecf67af16c6c8f0253a4e63a7ec9082e43fb6",
+      "version": "github:Eastern-Research-Group/glossary#b46d3082a0ccdc6dff34bba53357e158981c460e",
       "from": "github:Eastern-Research-Group/glossary",
       "requires": {
         "aria-accordion": "^1.0.0",

--- a/app/client/src/contexts/Glossary.js
+++ b/app/client/src/contexts/Glossary.js
@@ -35,7 +35,7 @@ function GlossaryProvider({ children }: Props) {
       const fetchTerms = (retryCount: number = 0) => {
         proxyFetch(glossaryURL)
           .then((res) => {
-            const data = res
+            let data = res
               .filter((item) => item['ActiveStatus'] !== 'Deleted')
               .map((item) => {
                 const term = item['Name'];
@@ -44,6 +44,12 @@ function GlossaryProvider({ children }: Props) {
                 })[0]['Value'];
                 return { term, definition };
               });
+
+            // filter out duplicate terms from the web service
+            data = data.filter(
+              (item, index) =>
+                data.findIndex((term) => term.term === item.term) === index,
+            );
 
             resolve({ status: 'success', data });
           })


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3358173
* https://github.com/Eastern-Research-Group/glossary/pull/13 - Glossary component changes

## Main Changes:
I couldn't find any hard proof as to what caused the glossary terms to be duplicated. I updated the code to cover two possible scenarios that could cause this issue. The first is the forked glossary component being initialized more than once and the second is the terminology services web service returning duplicates.

* Modified the forked glossary component to prevent duplicates in the case of the glossary component being initialized more than once (i.e. `new Glossary(terms.data);`). This was done by removing all terms from the DOM prior to adding new terms in the `populate` function.
* Modified the HMW glossary context to filter out duplicates after the fetch completes, just in case the terminology services are sometimes duplicating terms.

## Steps To Test:
1. Open the glossary and verify there are no duplicate terms.
2. In `app\client\src\components\shared\GlossaryPanel\index.js`, add the following code below line 210:
    * Note: This is to test the issue of the glossary being initialized more than once.
```
setTimeout(() => {
  new Glossary(terms.data);
}, 2000);
```
3. Repeat step 1.
4. Remove the code from step 2.
4. In `app\client\src\contexts\Glossary.js`, add the following code below line 46: `data = [...data, ...data, ...data];`
    * Note: This is to test the issue of the TS web service returning duplicates.
5. Repeate step 1.
