### PR TITLE
feature/state page style fix

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -86,11 +86,11 @@ const Container = styled.div`
   .hmw-accordion-header h3 {
     padding-bottom: 0;
   }
+`;
 
-  em {
-    display: block;
-    margin-bottom: 1.25rem;
-  }
+const NewTabDisclaimer = styled.em`
+  display: block;
+  margin-bottom: 1.25rem;
 `;
 
 const TopicTabs = styled(ContentTabs)`
@@ -912,7 +912,9 @@ function WaterQualityOverview({ ...props }: Props) {
                     Drinking Water Information for{' '}
                     <strong>{activeState.name}</strong>
                   </h3>
-                  <em>Links on this page open in a new browser tab.</em>
+                  <NewTabDisclaimer>
+                    Links on this page open in a new browser tab.
+                  </NewTabDisclaimer>
                   <h4>EPA has defined three types of public water systems:</h4>
 
                   {tab.id === 'drinking' && (
@@ -972,7 +974,9 @@ function WaterQualityOverview({ ...props }: Props) {
           }
         >
           <AccordionContent>
-            <em>Stories below open in a new browser tab.</em>
+            <NewTabDisclaimer>
+              Stories below open in a new browser tab.
+            </NewTabDisclaimer>
             <Stories stories={stories} />
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3367694

## Main Changes:
* Recent new tab disclaimer branch updated the styles of all `<em>` tags on the State page. This caused an issue where there were line breaks in an accordion. I've moved these styles to only target the instances where the styling is needed, not all `<em>` tags on the page.

## Steps To Test:
1. Navigate to State page Water Quality Overview tab http://localhost:3000/state/VA/water-quality-overview
2. Check that accordions and section titles are not broken like the screenshot in the Breeze ticket.
3. Check that new tab disclaimers in the Documents and Water Stories are still styled correctly

