### PR TITLE
Feature/new tab disclaimer updates

### DIFF
--- a/app/client/src/components/pages/National/index.js
+++ b/app/client/src/components/pages/National/index.js
@@ -258,6 +258,11 @@ const Highlights = styled.div`
   }
 `;
 
+const NewTabDisclaimer = styled.p`
+  margin-bottom: 0.5em;
+  font-style: italic;
+`;
+
 // --- components ---
 function WaterConditionsPanel() {
   const narsUrl = 'https://www.epa.gov/national-aquatic-resource-surveys';
@@ -275,9 +280,6 @@ function WaterConditionsPanel() {
         </StyledIntroText>
       </IntroBox>
 
-      <p>
-        <em>Links on this page open in a new browser tab.</em>
-      </p>
       <h3>Nutrient pollution continues to be an issue</h3>
 
       <Article>
@@ -289,19 +291,19 @@ function WaterConditionsPanel() {
           >
             Nutrient Pollution
           </a>{' '}
-          is one of America’s most widespread water quality issues. While
-          nutrients are important, too much of a good thing can become a bad
-          thing. Nutrient pollution can lead to excessive algae growth, which
-          can use up oxygen that aquatic organisms need to survive. Too much
-          algae growth can cause fish to die.{' '}
+          (opens new browser tab) is one of America’s most widespread water
+          quality issues. While nutrients are important, too much of a good
+          thing can become a bad thing. Nutrient pollution can lead to excessive
+          algae growth, which can use up oxygen that aquatic organisms need to
+          survive. Too much algae growth can cause fish to die.{' '}
           <a
             href="https://www.epa.gov/nutrient-policy-data/what-epa-doing-reduce-nutrient-pollution"
             target="_blank"
             rel="noopener noreferrer"
           >
             Learn more about what EPA is doing to reduce nutrient pollution
-          </a>
-          .
+          </a>{' '}
+          (opens new browser tab) .
         </p>
 
         <a
@@ -610,6 +612,10 @@ function WaterConditionsPanel() {
 
       <h3>Learn more about waterbody types</h3>
 
+      <NewTabDisclaimer>
+        Links below open in a new browser tab.
+      </NewTabDisclaimer>
+
       <Links>
         <a
           href={`${narsUrl}/national-rivers-and-streams-assessment-2008-2009-results`}
@@ -671,9 +677,7 @@ function DrinkingWaterPanel() {
           states to report drinking water information periodically to EPA.
         </StyledIntroText>
       </IntroBox>
-      <p>
-        <em>Links on this page open in a new browser tab.</em>
-      </p>
+
       <Highlights>
         <h3>
           <Icon src={drinkingWaterIcon} alt="Drinking Water" />
@@ -710,13 +714,14 @@ function DrinkingWaterPanel() {
             rel="noopener noreferrer"
           >
             Consumer Confidence Report (CCR)
-          </a>
-          . The CCR lists the levels of contaminants that have been detected in
-          the water, including those identified by EPA, and whether the public
-          water system (PWS) meets state and EPA drinking water standards. In
-          addition, the search results in this tool on the community page under
-          the Drinking Water tab pull data from the Safe Drinking Water
-          Information System (SDWIS) Federal Reporting Services.
+          </a>{' '}
+          (opens new browser tab) . The CCR lists the levels of contaminants
+          that have been detected in the water, including those identified by
+          EPA, and whether the public water system (PWS) meets state and EPA
+          drinking water standards. In addition, the search results in this tool
+          on the community page under the Drinking Water tab pull data from the
+          Safe Drinking Water Information System (SDWIS) Federal Reporting
+          Services.
         </p>
       </AltBox>
 

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -912,9 +912,7 @@ function WaterQualityOverview({ ...props }: Props) {
                     Drinking Water Information for{' '}
                     <strong>{activeState.name}</strong>
                   </h3>
-                  <NewTabDisclaimer>
-                    Links on this page open in a new browser tab.
-                  </NewTabDisclaimer>
+
                   <h4>EPA has defined three types of public water systems:</h4>
 
                   {tab.id === 'drinking' && (
@@ -931,7 +929,8 @@ function WaterQualityOverview({ ...props }: Props) {
                       rel="noopener noreferrer"
                     >
                       View detailed drinking water data for {activeState.name}.
-                    </a>
+                    </a>{' '}
+                    (opens new browser tab)
                   </DrinkingWaterText>
                 </DrinkingWaterSection>
               </TabPanel>

--- a/app/client/src/components/shared/DataContent/index.js
+++ b/app/client/src/components/shared/DataContent/index.js
@@ -105,10 +105,10 @@ function Data({ ...props }: Props) {
         other federal agencies through web services. Below is a summary of data
         included in <em>How’s My Waterway</em>.
       </p>
-      <br />
-      <em>Links below open in a new browser tab.</em>
 
       <hr />
+
+      <em>Links below open in a new browser tab.</em>
 
       <Item>
         <i className="fas fa-database" aria-hidden="true" />{' '}

--- a/app/client/src/components/shared/WaterSystemSummary/index.js
+++ b/app/client/src/components/shared/WaterSystemSummary/index.js
@@ -270,8 +270,9 @@ function WaterSystemSummary({ state }: Props) {
           rel="noopener noreferrer"
         >
           EPA’s Drinking Water Performance and Results (GPRA) Report
-        </a>
-        . GPRA results are for <strong>Community Water Systems</strong> for{' '}
+        </a>{' '}
+        (opens new browser tab). GPRA results are for{' '}
+        <strong>Community Water Systems</strong> for{' '}
         <GlossaryTerm term="Drinking Water Health-based Violations">
           Drinking Water Health Based Violations
         </GlossaryTerm>{' '}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3367813

## Main Changes:
* On National page, disclaimers are now next to links instead of page level.
* Data page disclaimer is moved below `<hr>` tag.
* A State page Drinking Water section disclaimer has been changed because this ticket required that disclaimers in the WaterSystemSummary component must be next to the link.

## Steps To Test:
1. Navigate to National, Data, and State pages and check that they match mockups in Breeze ticket.
