### PR TITLE
Changing nocache scheme to work around Helmet deprecating support

### DIFF
--- a/app/server/app/server.js
+++ b/app/server/app/server.js
@@ -11,12 +11,25 @@ const browserSyncPort = 9091;
 let port = process.env.PORT || 9090;
 
 app.use(helmet());
-app.use(helmet.noCache());
 app.use(
   helmet.hsts({
     maxAge: 31536000,
   }),
 );
+
+/****************************************************************
+ Instruct web browsers to disable caching
+ ****************************************************************/
+app.use(function (req, res, next) {
+  res.setHeader('Surrogate-Control', 'no-store');
+  res.setHeader(
+    'Cache-Control',
+    'no-store, no-cache, must-revalidate, proxy-revalidate',
+  );
+  res.setHeader('Pragma', 'no-cache');
+  res.setHeader('Expires', '0');
+  next();
+});
 
 /****************************************************************
  Is Glossary/Terminology Services authorization variable set?


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3362924

## Main Changes:
* Switched to custom nocache middleware as Helmet is dropping support for noCache functionality.

## Steps To Test:
1. Navigate to HMWv2 homepage
2. Looking at network tab in developer toolbar, make sure the following headers are on mywaterway domain delivered assets. 

'Surrogate-Control', 'no-store'
'Cache-Control','no-store, no-cache, must-revalidate, proxy-revalidate'
'Pragma', 'no-cache'
'Expires', '0'

## TODO:
- None.
