### PR TITLE
Feature/state page error

### DIFF
--- a/app/client/src/components/pages/State/components/routes/StateTabs.js
+++ b/app/client/src/components/pages/State/components/routes/StateTabs.js
@@ -94,7 +94,9 @@ function StateTabs({ stateCode, tabName, ...props }: Props) {
   // focus the active tab
   React.useEffect(() => {
     if (tabListRef.current) {
-      setTimeout(() => tabListRef.current.children[activeTabIndex].focus(), 0);
+      const tabList = tabListRef.current;
+      const activeTab = tabList.children[activeTabIndex];
+      setTimeout(() => activeTab.focus(), 0);
     }
   }, [tabListRef, activeTabIndex]);
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3369965

## Main Changes:
There is an issue where directly navigating to a state will cause errors to appear in the console.
Navigate to this URL on the dev site and check the console to reproduce the issue: https://mywaterway-dev.app.cloud.gov/state/AL

Some of our Cypress tests navigate directly to a state as well without specifying a tab which causes the same `Cannot read property 'children' of null` error. Cypress sees this React error and fails the test. 

## Steps To Test:
1. Navigate to localhost:3000/state/AL
2. Check that there are no errors in the console
3. Run the Cypress tests (you can just run state.spec.js because those are the only tests affected)
4. Make sure all tests pass


