### PR TITLE
Feature/increase cypress default timeout

### DIFF
--- a/app/cypress.json
+++ b/app/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3000",
+  "defaultCommandTimeout": 8000,
   "viewportWidth": 1280,
   "viewportHeight":  800
 }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3377657

## Main Changes:
* Increased the cypress default command timeout.

## Steps To Test:
1. Run `npm run coverage`
2. Verify that all tests pass

