### PR TITLE
feature/additional-national-page-changes

### DIFF
--- a/app/client/src/components/pages/National/index.js
+++ b/app/client/src/components/pages/National/index.js
@@ -273,7 +273,7 @@ function WaterConditionsPanel() {
         <StyledIntroHeading>Explore National Water Quality</StyledIntroHeading>
         <StyledIntroText>
           EPA, states, and tribes survey a representative sample of our nation's
-          waters to provide an accurate snapshot of water conditions, and track
+          waters to provide an accurate snapshot of water quality, and track
           changes over time.
         </StyledIntroText>
       </IntroBox>
@@ -422,11 +422,6 @@ function WaterConditionsPanel() {
                       lead to excessive plant growth, nuisance algae, murky
                       water, odor, fish kills, and lower levels of dissolved
                       oxygen.
-                    </p>
-                    <p>
-                      Poor lake health can lead to a loss of fishing and
-                      recreational opportunities and indicate a loss of
-                      ecosystem function.
                     </p>
                   </AccordionContent>
                 </AccordionItem>


### PR DESCRIPTION
## Related Issues:
* National page changes before NCC scan

## Main Changes:
* Change "water conditions" to "water quality" in intro
* Remove paragraph in Algal accordion of Lakes tab


From EPA:

On the top header it currently says:  EPA, states, and tribes survey a representative sample of our nation's waters to provide an accurate snapshot of water conditions, and track changes over time.
We had changed the word ‘conditions’ to ‘quality’ elsewhere, I think this should match.  Change it to be ‘snapshot of water quality’

Lastly,  on the lakes tab under the Algal bullet (the first bullet), there’s an extra paragraph that wasn’t in the review text we got.  It says:  Poor lake health can lead to a loss of fishing and recreational opportunities and indicate a loss of ecosystem function.    I don’t think that paragraph belongs there and we should remove it.  It doesn’t directly relate to the algal bullet necessarily.
