### PR TITLE
feature/GA-log-trim-whitespace

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -133,10 +133,13 @@
       document.addEventListener('click', function (event) {
         //Button clicks
         if (event.target.onclick && event.target.textContent) {
+          const text = event.target.textContent.trim();
+          const title = event.target.title.trim();
+
           //Log to Google Analytics
-          const action = event.target.title ?
-            'ow-hmw2-' + event.target.textContent + ' - ' + event.target.title :
-            'ow-hmw2-' + event.target.textContent;
+          const action = title ?
+            'ow-hmw2-' + text + ' - ' + title :
+            'ow-hmw2-' + text;
           ga('send', 'event', 'buttonClick', action, window.location.pathname);
         }
 
@@ -158,7 +161,7 @@
           }
 
           //Log to Google Analytics
-          ga('send', 'event', category, 'ow-hmw2-' + event.target.text, href);
+          ga('send', 'event', category, 'ow-hmw2-' + event.target.text.trim(), href);
         }
       });
     }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3392090

## Main Changes:
* Added code to trim off leading/trailing white space when logging button/link clicks to GA.

## Steps To Test:
1. In the index.html file add a console log above line 143. `console.log('action: ', action);`
2. In the index.html file add a console log above line 164. `console.log('action: ', 'ow-hmw2-' + event.target.text.trim());`
3. Start the app and open the dev tools in Chrome.
4. Click various buttons and links
5. Verify the console logs above don't have any spaces between the 'ow-hmw2-' text and the button text.
