### PR TITLE
Feature/search has full watershed text

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -42,6 +42,7 @@ import {
 // helpers
 import { useWaterbodyHighlight } from 'utils/hooks';
 import { fetchCheck } from 'utils/fetchUtils';
+import { isHuc12 } from 'utils/utils';
 // styles
 import './mapStyles.css';
 // errors
@@ -1044,9 +1045,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       searchText = searchText.trim();
 
       // Get whether HUC 12
-      const isHuc12 = /^[0-9]{12}$/.test(searchText);
-
-      if (isHuc12) {
+      if (isHuc12(searchText)) {
         const query = new Query({
           returnGeometry: true,
           where: "HUC12 = '" + searchText + "'",

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -10,7 +10,7 @@ import { StyledErrorBox } from 'components/shared/MessageBoxes';
 import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // helpers
-import { containsScriptTag } from 'utils/utils';
+import { containsScriptTag, isHuc12 } from 'utils/utils';
 // config
 import { locatorUrl } from 'config/mapServiceConfig';
 // styles
@@ -84,7 +84,9 @@ type Props = {
 
 function LocationSearch({ route, label }: Props) {
   const { Locator, Point } = React.useContext(EsriModulesContext);
-  const { searchText } = React.useContext(LocationSearchContext);
+  const { searchText, watershed, huc12 } = React.useContext(
+    LocationSearchContext,
+  );
 
   // geolocating state for updating the 'Use My Location' button
   const [geolocating, setGeolocating] = React.useState(false);
@@ -129,7 +131,11 @@ function LocationSearch({ route, label }: Props) {
           id="hmw-search-input"
           className="form-control"
           placeholder="Search by address, zip code, or place..."
-          value={inputText}
+          value={
+            inputText === searchText && isHuc12(inputText) && watershed && huc12
+              ? `WATERSHED: ${watershed} (${huc12})`
+              : inputText
+          }
           onChange={(ev) => setInputText(ev.target.value)}
         />
 

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -89,11 +89,18 @@ function titleCaseWithExceptions(string: string) {
   }
 }
 
+// Determines whether or not the input string is a HUC12 or not.
+// Returns true if the string is a HUC12 and false if not.
+function isHuc12(string: string) {
+  return /^[0-9]{12}$/.test(string);
+}
+
 export {
   chunkArray,
   containsScriptTag,
   formatNumber,
   getExtensionFromPath,
+  isHuc12,
   titleCase,
   titleCaseWithExceptions,
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3404832

## Main Changes:
* Updated the location search input box to display the watershed name and huc like what is done on the top of the right hand panel (ex: WATERSHED: Antelope Creek (102002030304)).

## Steps To Test:
1. Do a non huc12 search on the community page.
2. Verify the search input box has the same value that you typed in.
3. On the map, click somewhere outside of the huc boundaries.
4. Verify the search input box says "WATERSHED: <some watershed name> (<huc12>)". 
5. Refresh the page.
6. Repeat step 4.

