### PR TITLE
Feature/reporting cycle changes

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -215,6 +215,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
               feature.attributes = {
                 ...feature.attributes,
                 layerType: 'actions',
+                fieldName: 'hmw-extra-content',
               };
 
               content = getPopupContent({

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -175,6 +175,12 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
           ) {
             setFetchStatus('success');
             setNoMapData(true);
+
+            // pass the layer back up to the parent
+            if (typeof onLoad === 'function') {
+              onLoad({ status: 'no-data', layer: actionsLayer });
+            }
+
             return;
           }
 
@@ -201,6 +207,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             }
 
             const auId = feature.attributes.assessmentunitidentifier;
+            const reportingCycle = feature.attributes.reportingcycle;
             let content;
 
             // add additional attributes
@@ -212,7 +219,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
 
               content = getPopupContent({
                 feature,
-                extraContent: unitIds[auId],
+                extraContent: unitIds[auId](reportingCycle, true),
               });
             } else {
               // when no content is provided just display the normal community
@@ -247,11 +254,18 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
           setFetchStatus('success');
 
           // pass the layer back up to the parent
-          if (typeof onLoad === 'function') onLoad(actionsLayer);
+          if (typeof onLoad === 'function') {
+            onLoad({ status: 'success', layer: actionsLayer });
+          }
         })
         .catch((err) => {
           console.error(err);
           setFetchStatus('failure');
+
+          // pass the layer back up to the parent
+          if (typeof onLoad === 'function') {
+            onLoad({ status: 'failure', layer: actionsLayer });
+          }
         });
     }
 

--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -132,7 +132,6 @@ function getPollutantsWaters(action: Object, orgId: string) {
       assessmentUnitName,
       associatedPollutants,
       parameters,
-      assessmentUrl: `/waterbody-report/${orgId}/${assessmentUnitIdentifier}`,
     });
   });
 
@@ -150,6 +149,24 @@ function getPollutantsWaters(action: Object, orgId: string) {
     pollutants: pollutants.sort((a, b) => a.localeCompare(b)),
     waters: sortedWaters,
   };
+}
+
+function hasWaterbodyData(
+  mapLayer: Object,
+  orgId: string,
+  assessmentUnitIdentifier: string,
+) {
+  const graphics = mapLayer.status === 'success' && mapLayer.layer?.graphics;
+  return !graphics
+    ? false
+    : graphics.items.findIndex((graphic) => {
+        const graphicOrgId = graphic.attributes.organizationid;
+        const graphicAuId = graphic.attributes.assessmentunitidentifier;
+
+        return (
+          graphicOrgId === orgId && graphicAuId === assessmentUnitIdentifier
+        );
+      }) !== -1;
 }
 
 // --- styled components ---
@@ -230,6 +247,10 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
   const [loading, setLoading] = React.useState(true);
   const [noActions, setNoActions] = React.useState(false);
   const [error, setError] = React.useState(false);
+  const [mapLayer, setMapLayer] = React.useState({
+    status: 'fetching',
+    layer: null,
+  });
 
   // fetch action data from the attains 'actions' web service
   const [organizationName, setOrganizationName] = React.useState('');
@@ -303,6 +324,21 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
       });
   }, [actionId, orgId]);
 
+  // Get the reporting cycle from the GIS service
+  const [reportingCycle, setReportingCycle] = React.useState(null);
+  React.useEffect(() => {
+    if (mapLayer.status === 'fetching') return;
+
+    // find the first reporting cycle from the gis service
+    let reportingCycle = null;
+    if (mapLayer.status === 'success' && mapLayer.layer.graphics.length > 0) {
+      reportingCycle =
+        mapLayer.layer.graphics.items[0].attributes.reportingcycle;
+    }
+
+    setReportingCycle(reportingCycle);
+  }, [mapLayer]);
+
   // Builds the unitIds dictionary that is used for determining what
   // waters to display on the screen and what the content will be.
   const [unitIds, setUnitIds] = React.useState({});
@@ -315,109 +351,121 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
       const {
         assessmentUnitIdentifier,
         associatedPollutants,
-        assessmentUrl,
         parameters,
       } = water;
 
-      let content = <></>;
-      if (actionTypeCode === 'TMDL' && associatedPollutants.length > 0) {
-        content = (
+      const content = (reportingCycle, hasWaterbody) => {
+        const assessmentUrl =
+          reportingCycle && hasWaterbody
+            ? `/waterbody-report/${orgId}/${assessmentUnitIdentifier}/${reportingCycle}`
+            : null;
+
+        const hasTmdlData =
+          actionTypeCode === 'TMDL' && associatedPollutants.length > 0;
+
+        return (
           <>
-            <strong>Associated Impairments: </strong>
-            <ul>
-              {associatedPollutants
-                .sort((a, b) => a.pollutantName.localeCompare(b.pollutantName))
-                .map((pollutant) => {
-                  const permits = pollutant.permits
-                    .filter((permit) => {
-                      return permit.NPDESIdentifier;
-                    })
-                    .sort((a, b) => {
-                      return a.NPDESIdentifier.localeCompare(b.NPDESIdentifier);
-                    });
+            {hasTmdlData && (
+              <>
+                <strong>Associated Impairments: </strong>
+                <ul>
+                  {associatedPollutants
+                    .sort((a, b) =>
+                      a.pollutantName.localeCompare(b.pollutantName),
+                    )
+                    .map((pollutant) => {
+                      const permits = pollutant.permits
+                        .filter((permit) => {
+                          return permit.NPDESIdentifier;
+                        })
+                        .sort((a, b) => {
+                          return a.NPDESIdentifier.localeCompare(
+                            b.NPDESIdentifier,
+                          );
+                        });
 
-                  return (
-                    <li key={pollutant.pollutantName}>
-                      <strong>{pollutant.pollutantName}</strong>
-                      <br />
-                      <em>TMDL End Point: </em>
-                      <ShowLessMore
-                        text={pollutant.TMDLEndPointText}
-                        charLimit={150}
-                      />
-                      <br />
-                      {permits.length > 0 && (
-                        <em>Links below open in a new browser tab.</em>
-                      )}
-                      <br />
-                      <em>Permits: </em>
+                      return (
+                        <li key={pollutant.pollutantName}>
+                          <strong>{pollutant.pollutantName}</strong>
+                          <br />
+                          <em>TMDL End Point: </em>
+                          <ShowLessMore
+                            text={pollutant.TMDLEndPointText}
+                            charLimit={150}
+                          />
+                          <br />
+                          {permits.length > 0 && (
+                            <em>Links below open in a new browser tab.</em>
+                          )}
+                          <br />
+                          <em>Permits: </em>
 
-                      {permits.length === 0 ? (
-                        <>No permits found.</>
-                      ) : (
-                        permits.map((permit, index) => (
-                          <React.Fragment key={index}>
-                            <a
-                              href={echoUrl + permit.NPDESIdentifier}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {permit.NPDESIdentifier}
-                            </a>
-                            {index === permits.length - 1 ? '' : ', '}
-                          </React.Fragment>
-                        ))
-                      )}
-                    </li>
-                  );
-                })}
-            </ul>
+                          {permits.length === 0 ? (
+                            <>No permits found.</>
+                          ) : (
+                            permits.map((permit, index) => (
+                              <React.Fragment key={index}>
+                                <a
+                                  href={echoUrl + permit.NPDESIdentifier}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  {permit.NPDESIdentifier}
+                                </a>
+                                {index === permits.length - 1 ? '' : ', '}
+                              </React.Fragment>
+                            ))
+                          )}
+                        </li>
+                      );
+                    })}
+                </ul>
+              </>
+            )}
+            {!hasTmdlData && (
+              <>
+                <strong>Parameters Addressed: </strong>
+                <ul>
+                  {parameters
+                    .sort((a, b) =>
+                      a.parameterName.localeCompare(b.parameterName),
+                    )
+                    .map((parameter) => {
+                      return (
+                        <li key={parameter.parameterName}>
+                          <strong>{parameter.parameterName}</strong>
+                        </li>
+                      );
+                    })}
+                </ul>
+              </>
+            )}
 
-            <div>
-              <a href={assessmentUrl} target="_blank" rel="noopener noreferrer">
-                <Icon className="fas fa-file-alt" aria-hidden="true" />
-                View Waterbody Report
-              </a>
-              &nbsp;&nbsp;
-              <NewTabDisclaimerDiv>(opens new browser tab)</NewTabDisclaimerDiv>
-            </div>
+            {assessmentUrl && (
+              <div>
+                <a
+                  href={assessmentUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Icon className="fas fa-file-alt" aria-hidden="true" />
+                  View Waterbody Report
+                </a>
+                &nbsp;&nbsp;
+                <NewTabDisclaimerDiv>
+                  (opens new browser tab)
+                </NewTabDisclaimerDiv>
+              </div>
+            )}
           </>
         );
-      } else {
-        content = (
-          <>
-            <strong>Parameters Addressed: </strong>
-            <ul>
-              {parameters
-                .sort((a, b) => a.parameterName.localeCompare(b.parameterName))
-                .map((parameter) => {
-                  return (
-                    <li key={parameter.parameterName}>
-                      <strong>{parameter.parameterName}</strong>
-                    </li>
-                  );
-                })}
-            </ul>
-
-            <div>
-              <a href={assessmentUrl} target="_blank" rel="noopener noreferrer">
-                <Icon className="fas fa-file-alt" aria-hidden="true" />
-                View Waterbody Report
-              </a>
-              &nbsp;&nbsp;
-              <NewTabDisclaimerDiv>(opens new browser tab)</NewTabDisclaimerDiv>
-            </div>
-          </>
-        );
-      }
+      };
 
       unitIds[assessmentUnitIdentifier] = content;
     });
 
     setUnitIds(unitIds);
-  }, [waters, actionTypeCode]);
-
-  const [mapLayer, setMapLayer] = React.useState(null);
+  }, [waters, actionTypeCode, orgId]);
 
   // calculate height of div holding actions info
   const [infoHeight, setInfoHeight] = React.useState(0);
@@ -638,20 +686,11 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                               assessmentUnitName,
                             } = water;
 
-                            const graphics = mapLayer && mapLayer.graphics;
-                            const hasWaterbody = !graphics
-                              ? false
-                              : graphics.items.findIndex((graphic) => {
-                                  const graphicOrgId =
-                                    graphic.attributes.organizationid;
-                                  const graphicAuId =
-                                    graphic.attributes.assessmentunitidentifier;
-
-                                  return (
-                                    graphicOrgId === orgId &&
-                                    graphicAuId === assessmentUnitIdentifier
-                                  );
-                                }) !== -1;
+                            const hasWaterbody = hasWaterbodyData(
+                              mapLayer,
+                              orgId,
+                              assessmentUnitIdentifier,
+                            );
 
                             return (
                               <AccordionItem
@@ -664,7 +703,11 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                                 subTitle={`ID: ${assessmentUnitIdentifier}`}
                               >
                                 <AccordionContent>
-                                  {unitIds[assessmentUnitIdentifier]}
+                                  {unitIds[assessmentUnitIdentifier] &&
+                                    unitIds[assessmentUnitIdentifier](
+                                      reportingCycle,
+                                      hasWaterbody,
+                                    )}
 
                                   <p>
                                     {hasWaterbody && (
@@ -675,7 +718,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                                             organizationid: orgId,
                                           },
                                         }}
-                                        layers={[mapLayer]}
+                                        layers={[mapLayer.layer]}
                                       />
                                     )}
                                   </p>

--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -716,9 +716,11 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                                           attributes: {
                                             assessmentunitidentifier: assessmentUnitIdentifier,
                                             organizationid: orgId,
+                                            fieldName: 'hmw-extra-content',
                                           },
                                         }}
                                         layers={[mapLayer.layer]}
+                                        fieldName="hmw-extra-content"
                                       />
                                     )}
                                   </p>

--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -358,7 +358,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
         const assessmentUrl =
           reportingCycle && hasWaterbody
             ? `/waterbody-report/${orgId}/${assessmentUnitIdentifier}/${reportingCycle}`
-            : null;
+            : `/waterbody-report/${orgId}/${assessmentUnitIdentifier}`;
 
         const hasTmdlData =
           actionTypeCode === 'TMDL' && associatedPollutants.length > 0;

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -375,7 +375,10 @@ export const openPopup = (view: Object, feature: Object) => {
   const fieldName = feature.attributes && feature.attributes.fieldName;
 
   // set the popup template
-  if (!feature.popupTemplate || fieldName) {
+  if (
+    !feature.popupTemplate ||
+    (fieldName && fieldName !== 'hmw-extra-content')
+  ) {
     feature.popupTemplate = {
       title: getPopupTitle(feature.attributes),
       content: getPopupContent({ feature, fieldName }),

--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -82,7 +82,7 @@ function SiteSpecific({
   completeUseList,
   useSelected,
 }: Props) {
-  const { currentSummary } = React.useContext(StateTabsContext);
+  const { currentReportingCycle } = React.useContext(StateTabsContext);
 
   const [waterTypeUnits, setWaterTypeUnits] = React.useState('');
   React.useEffect(() => {
@@ -310,10 +310,10 @@ function SiteSpecific({
           </HighchartsContainer>
           <ChartFooter>
             <strong>Year Last Reported:</strong>
-            {currentSummary.status === 'success' && (
-              <>&nbsp;{currentSummary.data.reportingCycle}</>
+            {currentReportingCycle.status === 'success' && (
+              <>&nbsp;{currentReportingCycle.reportingCycle}</>
             )}
-            {currentSummary.status === 'fetching' && <LoadingSpinner />}
+            {currentReportingCycle.status === 'fetching' && <LoadingSpinner />}
           </ChartFooter>
         </>
       )}

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -394,7 +394,7 @@ function AdvancedSearch({ ...props }: Props) {
           let waterbodiesList = [];
           let reportingCycle = '';
           data.features.forEach((waterbody, index) => {
-            if (index === 0) {
+            if (waterbody.attributes.reportingcycle > reportingCycle) {
               reportingCycle = waterbody.attributes.reportingcycle;
             }
 

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -14,7 +14,7 @@ import ActionsMap from 'components/pages/Actions/ActionsMap';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import MapVisibilityButton from 'components/shared/MapVisibilityButton';
 // styled components
-import { StyledErrorBox } from 'components/shared/MessageBoxes';
+import { StyledErrorBox, StyledInfoBox } from 'components/shared/MessageBoxes';
 import {
   StyledContainer,
   StyledColumns,
@@ -65,6 +65,11 @@ const Container = styled(StyledContainer)`
     margin-bottom: 0.875rem;
     border-top-color: #aebac3;
   }
+`;
+
+const InfoBoxContainer = styled.div`
+  padding: 1.5em;
+  padding-bottom: 0;
 `;
 
 const PageErrorBox = styled(StyledErrorBox)`
@@ -174,6 +179,14 @@ const DateCell = styled.td`
 
 const Locations = styled.ul`
   padding-bottom: 0;
+`;
+
+const Icon = styled.i`
+  margin-right: 5px;
+`;
+
+const NewTabDisclaimer = styled.div`
+  display: inline-block;
 `;
 
 // --- components ---
@@ -589,6 +602,18 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
     );
   }, [auId, orgId, reportingCycle, mapLayer, assessmentsCalled]);
 
+  // Get the reporting cycle from the map
+  const [mapReportingCycle, setMapReportingCycle] = React.useState('');
+  React.useEffect(() => {
+    let reportingCycle = '';
+    if (mapLayer.status === 'success' && mapLayer.layer.graphics.length > 0) {
+      reportingCycle =
+        mapLayer.layer.graphics.items[0].attributes.reportingcycle;
+    }
+
+    setMapReportingCycle(reportingCycle);
+  }, [mapLayer]);
+
   const [waterbodyActions, setWaterbodyActions] = React.useState({
     status: 'fetching',
     data: [],
@@ -915,7 +940,8 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
               <strong>
                 {waterbodyName} ({auId})
               </strong>{' '}
-              has no data available.
+              has no data available{' '}
+              {reportingCycle ? `for ${reportingCycle}` : ''}.
             </p>
           </PageErrorBox>
         </Container>
@@ -946,6 +972,24 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
       <NavBar title={'Waterbody Report'} />
 
       <Container data-content="container">
+        {mapReportingCycle > reportingCycle && (
+          <InfoBoxContainer>
+            <StyledInfoBox>
+              There is a newer data available for this waterbody. Please use the
+              following link to view the latest information:{' '}
+              <a
+                href={`/waterbody-report/${orgId}/${auId}/${mapReportingCycle}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Icon className="fas fa-file-alt" aria-hidden="true" />
+                View Waterbody Report for 2018
+              </a>
+              &nbsp;&nbsp;
+              <NewTabDisclaimer>(opens new browser tab)</NewTabDisclaimer>
+            </StyledInfoBox>
+          </InfoBoxContainer>
+        )}
         <WindowSize>
           {({ width, height }) => {
             return (

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -940,8 +940,8 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
               <strong>
                 {waterbodyName} ({auId})
               </strong>{' '}
-              has no data available{' '}
-              {reportingCycle ? `for ${reportingCycle}` : ''}.
+              has no data available
+              {reportingCycle ? ` for ${reportingCycle}` : ''}.
             </p>
           </PageErrorBox>
         </Container>

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -342,25 +342,13 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
     if (assessmentsCalled) return;
     if (!reportingCycle && mapLayer.status === 'fetching') return;
 
-    let reportingCycleParam = reportingCycle;
-    if (!reportingCycle) {
+    let reportingCycleParam = '';
+    if (reportingCycle) {
+      reportingCycleParam = reportingCycle;
+    } else {
       if (mapLayer.status === 'success' && mapLayer.layer.graphics.length > 0) {
         reportingCycleParam =
           mapLayer.layer.graphics.items[0].attributes.reportingcycle;
-      } else {
-        setAllParameterActionIds({
-          status: 'failure',
-          data: [],
-        });
-        setReportingCycleFetch({ status: 'failure', year: '' });
-        setWaterbodyStatus({ status: 'failure', data: [] });
-        setWaterbodyUses({ status: 'failure', data: [] });
-        setWaterbodySources({ status: 'failure', data: [] });
-        setOrganizationName({
-          status: 'failure',
-          name: '',
-        });
-        return;
       }
     }
 
@@ -370,7 +358,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
       attains.serviceUrl +
       `assessments?organizationId=${orgId}` +
       `&assessmentUnitIdentifier=${auId}` +
-      `&reportingCycle=${reportingCycleParam}`;
+      (reportingCycleParam ? `&reportingCycle=${reportingCycleParam}` : '');
 
     fetchCheck(url).then(
       (res) => {

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -840,7 +840,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
       </InlineBoxSection>
 
       <InlineBoxSection>
-        <h3>Year Last Reported:</h3>
+        <h3>Year Reported:</h3>
         {reportingCycleFetch.status === 'fetching' && <LoadingSpinner />}
         {reportingCycleFetch.status === 'failure' && (
           <ErrorBox>
@@ -975,8 +975,8 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
         {mapReportingCycle > reportingCycle && (
           <InfoBoxContainer>
             <StyledInfoBox>
-              There is a newer data available for this waterbody. Please use the
-              following link to view the latest information:{' '}
+              There is more recent data available for this waterbody. Please use
+              the following link to view the latest information:{' '}
               <a
                 href={`/waterbody-report/${orgId}/${auId}/${mapReportingCycle}`}
                 target="_blank"

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -184,9 +184,10 @@ type Props = {
   // url params defined in routes.js
   orgId: string, // (organization id)
   auId: string, // (assessment unit id)
+  reportingCycle: number, // (reporting cycle year)
 };
 
-function WaterbodyReport({ fullscreen, orgId, auId }) {
+function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
   const [noWaterbodies, setNoWaterbodies] = React.useState(false);
 
   const [waterbodyName, setWaterbodyName] = React.useState('');
@@ -304,7 +305,7 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
     );
   }, [auId, orgId]);
 
-  const [reportingCycle, setReportingCycle] = React.useState({
+  const [reportingCycleFetch, setReportingCycleFetch] = React.useState({
     status: 'fetching',
     year: '',
   });
@@ -336,7 +337,8 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
     const url =
       attains.serviceUrl +
       `assessments?organizationId=${orgId}` +
-      `&assessmentUnitIdentifier=${auId}`;
+      `&assessmentUnitIdentifier=${auId}` +
+      `&reportingCycle=${reportingCycle}`;
 
     fetchCheck(url).then(
       (res) => {
@@ -345,7 +347,7 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
             status: 'no-data',
             data: { condition: '', planForRestoration: '', listed303d: '' },
           });
-          setReportingCycle({
+          setReportingCycleFetch({
             status: 'success',
             year: '',
           });
@@ -366,7 +368,7 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
         }
 
         const firstItem = res.items[0];
-        setReportingCycle({
+        setReportingCycleFetch({
           status: 'success',
           year: firstItem.reportingCycleText,
         });
@@ -555,7 +557,7 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
           status: 'failure',
           data: [],
         });
-        setReportingCycle({ status: 'failure', year: '' });
+        setReportingCycleFetch({ status: 'failure', year: '' });
         setWaterbodyStatus({ status: 'failure', data: [] });
         setWaterbodyUses({ status: 'failure', data: [] });
         setWaterbodySources({ status: 'failure', data: [] });
@@ -565,7 +567,7 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
         });
       },
     );
-  }, [auId, orgId]);
+  }, [auId, orgId, reportingCycle]);
 
   const [waterbodyActions, setWaterbodyActions] = React.useState({
     status: 'fetching',
@@ -794,26 +796,26 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
 
       <InlineBoxSection>
         <h3>Year Last Reported:</h3>
-        {reportingCycle.status === 'fetching' && <LoadingSpinner />}
-        {reportingCycle.status === 'failure' && (
+        {reportingCycleFetch.status === 'fetching' && <LoadingSpinner />}
+        {reportingCycleFetch.status === 'failure' && (
           <ErrorBox>
             <p>{waterbodyReportError('Assessment')}</p>
           </ErrorBox>
         )}
-        {reportingCycle.status === 'success' && (
-          <p>&nbsp; {reportingCycle.year}</p>
+        {reportingCycleFetch.status === 'success' && (
+          <p>&nbsp; {reportingCycleFetch.year}</p>
         )}
       </InlineBoxSection>
 
       <InlineBoxSection>
         <h3>Organization Name (ID):&nbsp;</h3>
-        {reportingCycle.status === 'fetching' && <LoadingSpinner />}
-        {reportingCycle.status === 'failure' && (
+        {reportingCycleFetch.status === 'fetching' && <LoadingSpinner />}
+        {reportingCycleFetch.status === 'failure' && (
           <ErrorBox>
             <p>{waterbodyReportError('Assessment')}</p>
           </ErrorBox>
         )}
-        {reportingCycle.status === 'success' && (
+        {reportingCycleFetch.status === 'success' && (
           <p>
             {organizationName.name} ({orgId})
           </p>
@@ -964,8 +966,8 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
                   <StyledBox>
                     <StyledBoxHeading>
                       Assessment Information{' '}
-                      {reportingCycle.status === 'success' && (
-                        <>from {reportingCycle.year}</>
+                      {reportingCycleFetch.status === 'success' && (
+                        <>from {reportingCycleFetch.year}</>
                       )}
                     </StyledBoxHeading>
 
@@ -1020,8 +1022,8 @@ function WaterbodyReport({ fullscreen, orgId, auId }) {
                     <StyledBoxSection>
                       <h3>
                         Probable sources contributing to impairment
-                        {reportingCycle.status === 'success' &&
-                          ` from ${reportingCycle.year}`}
+                        {reportingCycleFetch.status === 'success' &&
+                          ` from ${reportingCycleFetch.year}`}
                         :
                       </h3>
                       {waterbodySources.status === 'fetching' && (

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -252,7 +252,8 @@ function WaterbodyInfo({
               href={
                 `/waterbody-report/` +
                 `${attributes.organizationid}/` +
-                `${attributes.assessmentunitidentifier}`
+                `${attributes.assessmentunitidentifier}/` +
+                `${attributes.reportingcycle}`
               }
             >
               <Icon className="fas fa-file-alt" aria-hidden="true" />

--- a/app/client/src/contexts/StateTabs.js
+++ b/app/client/src/contexts/StateTabs.js
@@ -7,6 +7,7 @@ import type { Node } from 'react';
 export const StateTabsContext: Object = React.createContext({
   currentReportStatus: '',
   currentSummary: { status: 'fetching', data: {} },
+  currentReportingCycle: { status: 'fetching', currentReportingCycle: '' },
   activeState: { code: '', name: '' },
 });
 
@@ -17,6 +18,7 @@ type Props = {
 type State = {
   currentReportStatus: string,
   currentSummary: object,
+  currentReportingCycle: object,
   activeState: { code: string, name: string },
 };
 
@@ -27,6 +29,10 @@ export class StateTabsProvider extends React.Component<Props, State> {
     currentSummary: {
       status: 'fetching',
       data: {},
+    },
+    currentReportingCycle: {
+      status: 'fetching',
+      currentReportingCycle: '',
     },
     activeState: { code: '', name: '' },
     // in case ATTAINS usesStateSummary service returns invalid data or an internal error
@@ -39,6 +45,9 @@ export class StateTabsProvider extends React.Component<Props, State> {
     },
     setCurrentSummary: (currentSummary: string) => {
       this.setState({ currentSummary });
+    },
+    setCurrentReportingCycle: (currentReportingCycle: object) => {
+      this.setState({ currentReportingCycle });
     },
     setActiveState: (activeState: { code: string, name: string }) => {
       this.setState({ activeState });

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -75,6 +75,7 @@ function Routes() {
             {/* $FlowFixMe (orgId and actionId props are passed from the path) */}
             <Actions path="/plan-summary/:orgId/:actionId" />
             {/* $FlowFixMe (orgId and auId props are passed from the path) */}
+            <WaterbodyReport path="/waterbody-report/:orgId/:auId" />
             <WaterbodyReport path="/waterbody-report/:orgId/:auId/:reportingCycle" />
             <InvalidUrl path="/invalid-url" />
             <ErrorPage default />

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -75,7 +75,7 @@ function Routes() {
             {/* $FlowFixMe (orgId and actionId props are passed from the path) */}
             <Actions path="/plan-summary/:orgId/:actionId" />
             {/* $FlowFixMe (orgId and auId props are passed from the path) */}
-            <WaterbodyReport path="/waterbody-report/:orgId/:auId" />
+            <WaterbodyReport path="/waterbody-report/:orgId/:auId/:reportingCycle" />
             <InvalidUrl path="/invalid-url" />
             <ErrorPage default />
           </Router>

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -262,7 +262,7 @@ describe('Identified Issues Tab', () => {
   it('Clicking a Discharger accordion item expands it', () => {
     // navigate to Identified Issues tab of Community page
     cy.findByPlaceholderText('Search by address', { exact: false }).type(
-      '020700100102',
+      '071401010403',
     );
     cy.findByText('Go').click();
 
@@ -274,7 +274,7 @@ describe('Identified Issues Tab', () => {
     // switch to Dischargers tab of Identified Issues tab and check that the discharger accordion item exists and expands when clicked
     cy.findByText('Identified Issues').click();
     cy.findByTestId('hmw-dischargers').click();
-    cy.findByText('RED LINE PUMPING STATIONS').click();
+    cy.findByText('ILLINOIS AMERICAN WATER').click();
     cy.findByText('Compliance Status:');
   });
 });

--- a/app/cypress/integration/plan_summary.spec.js
+++ b/app/cypress/integration/plan_summary.spec.js
@@ -45,6 +45,7 @@ describe('Plan Summary (Actions) page', () => {
   it('The "View Waterbody Report" link should navigate to a waterbody report page', () => {
     const orgId = '21AWIC';
     const actionId = '40958';
+    const reportingCycle = '2018';
 
     cy.visit(`/plan-summary/${orgId}/${actionId}`);
 
@@ -61,7 +62,7 @@ describe('Plan Summary (Actions) page', () => {
     cy.findByText(linkText).should(
       'have.attr',
       'href',
-      `/waterbody-report/${orgId}/${auId}`,
+      `/waterbody-report/${orgId}/${auId}/${reportingCycle}`,
     );
     cy.findByText(linkText).should('have.attr', 'target', '_blank');
     cy.findByText(linkText).should('have.attr', 'rel', 'noopener noreferrer');

--- a/app/cypress/integration/waterbody_report.spec.js
+++ b/app/cypress/integration/waterbody_report.spec.js
@@ -43,6 +43,19 @@ describe('Waterbody Report page', () => {
     cy.findByText('has no data available.', { exact: false });
   });
 
+  it('Viewing waterbody report for an older year', () => {
+    const orgId = 'MDNR';
+    const auId = 'MO_1707.02';
+    const year = '2016';
+
+    cy.visit(`/waterbody-report/${orgId}/${auId}/${year}`);
+
+    cy.findByText(
+      'Please use the following link to view the latest information',
+      { exact: false },
+    );
+  });
+
   it('The "View Waterbody Report" link should navigate to a waterbody report page', () => {
     const orgId = '21AWIC';
     const auId = 'AL03150110-0202-200';


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3414821
* https://app.breeze.pm/projects/100762/cards/3420902

## Main Changes:
* Fixed an issue with popups being empty on the waterbody report page if you click the "View On Map" button.
* Updated the waterbody report page to take an optional reportingCycle parameter. If the reporting cycle parameter is provided then the assessments service will be called with the reporting parameter provided in the URL. If the reporting cycle parameter is not provided then the app will determine the reporting cycle from the GIS data (if available) and use that to call the assessments service.
* On the waterbody report page, added an info box with a link to the most current waterbody report data. This new info box and link are only displayed if the reporting cycle in the GIS data is later than the reporting cycle provided in the url. 
* Updated the community page to pass the reporting cycle (from GIS data) into the waterbody report page. 
* Updated the actions page to pass the reporting cycle (from GIS data) into the waterbody report page.
* Updated the state page to obtain the reporting cycle from GIS data for use in the usesStateSummary service call and for display on the site specific charts and footer of the advanced search page map. 
    * Some states like Missouri allow waterbodies to have different reporting cycles. For these scenarios the latest year is chosen
    * American Samoa and Northern Mariana Islands do not have GIS data. For this case the usesStateSummary will be called without the reporting cycle parameter.
    * Note: The reporting cycle displayed below the surveys chart is still independent.
* Fixed one of the community page tests related to the identified issues tab.
* Fixed tests related to the waterbody report links.
* Added a new test for routing to the waterbody report page with a cycle year.

## Steps To Test:
1. Navigate to http://localhost:3000/community/071401010403/overview
2. Make sure the view waterbody report links include a cycle year at the end of the url.
    * Note: The waterbodies have different reporting cycles for this location, so verify the link has the same year as the "Year Last Reported" value. 
3. Navigate to http://localhost:3000/waterbody-report/MDNR/MO_1707.02/2016.
4. Verify the new info box is displayed at the top of the page and links to the latest waterbody report for that assessment http://localhost:3000/waterbody-report/MDNR/MO_1707.02/2018
5. Navigate to http://localhost:3000/plan-summary/21GAEPD/10018
6. Click a "View On Map" button and verify the popup has content.
7. Click on a waterbody on the map and verify the popup has content.
8. Verify that all of the waterbodies listed have the "View Waterbody Report" link. 
9. For waterbodies that have a "View On Map" button, verify the "View Waterbody Report" link has the cycle year parameter. 
10. For waterbodies that do not have a "View On Map" button, verify the "View Waterbody Report" link does not have the cycle year parameter. 
11. Open the Chrome dev tools
12. Navigate to http://localhost:3000/state/FL/water-quality-overview
13. Verify the usesStateSummary service was called with a cycle year.
14. Click "Aquatic Life" and select "Rivers and Streams"
15. Verify the reporting cycle under the pie chart is 2020 and the reporting cycle under the site specific bar chart is 2012. 
16. Navigate to http://localhost:3000/state/AS/water-quality-overview
17. Verify the usesStateSummary service was called without a cycle year. 

