### PR TITLE
feature/geoconnex-schema

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -42,7 +42,7 @@ import {
 // helpers
 import { useWaterbodyHighlight } from 'utils/hooks';
 import { fetchCheck } from 'utils/fetchUtils';
-import { isHuc12 } from 'utils/utils';
+import { isHuc12, updateCanonicalLink, createJsonLD } from 'utils/utils';
 // styles
 import './mapStyles.css';
 // errors
@@ -777,6 +777,10 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           queryPermittedDischargersService(huc12Result);
           queryGrtsHuc12(huc12Result);
           queryAttainsPlans(huc12Result);
+
+          // create canonical link and JSON LD
+          updateCanonicalLink(huc12Result);
+          createJsonLD(huc12Result, response.features[0].attributes.name);
         } catch (err) {
           console.error(err);
           setNoDataAvailable();

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import EsriHelper from 'utils/EsriHelper';
 import { navigate } from '@reach/router';
+import { resetCanonicalLink, removeJsonLD } from 'utils/utils';
 
 export const LocationSearchContext = React.createContext();
 
@@ -433,6 +434,12 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     },
 
     setNoDataAvailable: () => {
+      // reset canonical geoconnex PID link
+      resetCanonicalLink();
+
+      // remove JSON LD context script
+      removeJsonLD();
+
       this.setState(
         {
           huc12: '',

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -23,7 +23,11 @@ import WaterbodyReport from 'components/pages/WaterbodyReport';
 import ErrorPage from 'components/pages/404';
 import InvalidUrl from 'components/pages/InvalidUrl';
 // helpers
-import { containsScriptTag } from 'utils/utils';
+import {
+  containsScriptTag,
+  resetCanonicalLink,
+  removeJsonLD,
+} from 'utils/utils';
 
 // routes provided by Reach Router to each child of the Router component
 export type RouteProps = {
@@ -45,6 +49,18 @@ function Routes() {
           // gets all messed up.
           navigate('/invalid-url');
           window.location.reload();
+        }
+
+        // reset the canonical link and JSON LD:
+        // if the pathname is not on a community page
+        // or if the pathname is the community home page with no location
+        const pathName = window.location.pathname;
+        if (!pathName.includes('/community') || pathName === '/community') {
+          // reset canonical geoconnex PID link
+          resetCanonicalLink();
+
+          // remove JSON LD context script
+          removeJsonLD();
         }
 
         return (

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -95,6 +95,50 @@ function isHuc12(string: string) {
   return /^[0-9]{12}$/.test(string);
 }
 
+function createSchema(huc12, watershed) {
+  return {
+    '@context': ['https://schema.org'],
+    '@id': `https://geoconnex.us/epa/hmw/${huc12}`,
+    '@type': 'WebPage',
+    name: `${watershed} (${huc12})`,
+    provider: 'https://epa.gov',
+    description:
+      "EPA How's My Waterway Community as Twelve-Digit Hydrologic Unit",
+    about: `https://geoconnex.us/nhdplusv2/huc12/${huc12}`,
+  };
+}
+
+function createJsonLD(huc12, watershed) {
+  // try removing any existing JSON-LDs
+  removeJsonLD();
+
+  // create a JSON-LD schema and append it to document head
+  const head = document.getElementsByTagName('head')[0];
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.id = 'jsonLD';
+  script.innerHTML = JSON.stringify(createSchema(huc12, watershed));
+  head.appendChild(script);
+}
+
+function removeJsonLD() {
+  if (document.getElementById('jsonLD')) {
+    document.getElementById('jsonLD').remove();
+  }
+}
+
+function updateCanonicalLink(huc12) {
+  const canonicalLink = document.querySelector('[rel="canonical"]');
+  if (canonicalLink) {
+    canonicalLink.href = `https://geoconnex.us/epa/hmw/${huc12}`;
+  }
+}
+
+function resetCanonicalLink() {
+  const canonicalLink = document.querySelector('[rel="canonical"]');
+  if (canonicalLink) canonicalLink.href = '';
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -103,4 +147,8 @@ export {
   isHuc12,
   titleCase,
   titleCaseWithExceptions,
+  createJsonLD,
+  updateCanonicalLink,
+  resetCanonicalLink,
+  removeJsonLD,
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3416877

## Main Changes:
* Following the instructions at https://github.com/ksonda/geoconnex_prep/blob/master/epa/hmw/jsonld-hmw-template.md the Community page now updates the canonical link and adds a JSON LD schema when performing searches.

## Steps To Test:
The extension https://chrome.google.com/webstore/detail/structured-data-testing-t/kfdjeigpgagildmolfanniafmplnplpl?hl=en is helpful for testing JSON LD schemas but not necessary to test this branch.

1. Navigate to http://localhost:3000/community/dc/overview

Open developer tools and look for the following 2 elements in the head tag.

A link tag with rel="canonical" and an href that should be https://geoconnex.us/epa/hmw/{HUC12} where HUC12 is the current location's HUC12. 
![image](https://user-images.githubusercontent.com/17204883/87081851-051c1c80-c1f8-11ea-805f-7bee3ec630d0.png)

A script tag at the bottom of the head tag with type="application/ld+json"
It should contain information about the current location, including the HUC12, location name, and a geoconnex URL.
![image](https://user-images.githubusercontent.com/17204883/87082232-aacf8b80-c1f8-11ea-9421-a3fe78c3a856.png)

The geoconnex URLs mentioned above should link back to the same location on the mywaterway.epa.gov website.
Note that geoconnex only supports HUC12s, not location names, so the location address will be slightly different but the same HUC12.

2. Search another location in the Community tab and the JSON LD schema and canonical link should update accordingly.
3. Navigate to http://localhost:3000/state. The JSON LD script should be gone and the canonical link href should be "".
4. An invalid Community search should remove the JSON LD and reset the canonical href. Navigate to http://localhost:3000/community/2487c287rcm2 and the JSON LD script should be removed and the canonical href should be "".


