### PR TITLE
Feature/use best location candidate

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -872,18 +872,21 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         .then((candidates) => {
           candidates = Array.isArray(candidates) ? candidates : [candidates];
 
+          // find the location with the highest score in the candidate list
+          // if multiple candidates have the same highhest value the first one is chosen
           let location;
-          // break out of loop after first candidate with score > 80 is found
+          let highestCandidateScore = -1;
           for (let i = 0; i < candidates.length; i++) {
-            if (candidates[i].score > 80) {
+            if (candidates[i].score > highestCandidateScore) {
               location = candidates[i];
-              break;
+              highestCandidateScore = candidates[i].score;
             }
           }
 
           if (candidates.length === 0 || !location || !location.attributes) {
             setAddress(searchText); // preserve the user's search so it is displayed
             setNoDataAvailable();
+            setMapLoading(false);
             setErrorMessage(noDataAvailableError);
             return;
           }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3428508

## Main Changes:
* Update logic for selection location candidates to look for the candidate with the highest score. If multiple candidates have the same highest score the first one is chosen.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Search commonly tested places like DC, Auburn AL, Las Vegas, etc. and make sure they return the same location as before this branch. 
3. Search a gibberish or invalid location and check that it displays an invalid location message
4. Search "NTNC system Clock Tower Pub and Grill" and check that it finds a location even though the candidates returned all have a score of less than 80.

