### PR TITLE
bugfix/huc-boundaries-display-after-reset

### DIFF
--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -121,6 +121,15 @@ function Community({ children, ...props }: Props) {
     setVisibleLayers(tabs[activeTabIndex].layers);
   }, [activeTabIndex, setVisibleLayers]);
 
+  // reset data when navigating back to /community
+  React.useEffect(() => {
+    if (window.location.pathname === '/community') {
+      resetData();
+      setSearchText('');
+      setLastSearchText('');
+    }
+  }, [atCommunityIntroRoute, resetData, setSearchText, setLastSearchText]);
+
   // jsx
   const activeTabRoute = tabs[activeTabIndex === -1 ? 0 : activeTabIndex].route;
   const searchMarkup = (

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -388,6 +388,15 @@ export class LocationSearchProvider extends React.Component<Props, State> {
         mapView.extent = initialExtent;
         homeWidget.viewpoint = mapView.viewpoint;
       }
+
+      // reset lines, points, and areas layers
+      if (
+        waterbodyLayer &&
+        waterbodyLayer.layers &&
+        waterbodyLayer.layers.items
+      ) {
+        waterbodyLayer.layers.items = [];
+      }
     },
 
     resetData: () => {
@@ -431,7 +440,12 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       });
 
       // remove map content
-      this.state.resetMap();
+      // only zoom out the map if we are on the community intro page at /community
+      if (window.location.pathname === '/community') {
+        this.state.resetMap(true);
+      } else {
+        this.state.resetMap(false);
+      }
     },
 
     setNoDataAvailable: () => {

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -399,6 +399,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
         areasData: null,
         countyBoundaries: '',
         atHucBoundaries: false,
+        hucBoundaries: '',
         monitoringLocations: {
           status: 'fetching',
           data: [],


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3438662

## Main Changes:
* Fix issue where switching between tabs after a Community search would not clear the HUC boundaries on the map.
* Fix issue where navigating back to /community after performing a Community search would not clear any data on the map.

## Steps To Test:
First issue - Switching to National tab after a Community search will not clear the HUC boundaries on the map.
1. Navigate to http://localhost:3000/community
2. Search "DC"
3. Wait for services to load, then click the National tab.
4. Click the Community tab. Verify the map is cleared of all HUC boundaries.

Second issue - navigating back to /community from a Community search will not clear the map. This can be done by clicking the Community tab or the back button in your browser.
1. Navigate to http://localhost:3000/community
2. Search "DC"
3. Wait for services to load in, then click the Community tab.
4. The map zoom should be reset and all map data should be removed.
