### PR TITLE
Feature/ga updates

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -854,6 +854,15 @@ function IdentifiedIssues() {
             </ul>
           </>
         )}
+        <button
+          style={{ display: 'none' }}
+          onClick={() => {
+            const testEx = cipSummary.test.error;
+            console.log('testEx: ', testEx);
+          }}
+        >
+          Log Exception
+        </button>
       </>
     </Container>
   );

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -344,7 +344,7 @@ function IdentifiedIssues() {
     // check for null percent of assess waters impaired
     const nullPollutedWaterbodies =
       containImpairedWatersCatchmentAreaPercent === null ? true : false;
-    if (nullPollutedWaterbodies) {
+    if (nullPollutedWaterbodies && summaryByParameterImpairments.length > 0) {
       window.ga('send', 'exception', {
         exDescription: `The "% of assessed waters are impaired" value is 0, even though there are ${summaryByParameterImpairments.length} items in the summaryByParameterImpairments[] array.`,
         exFatal: false,

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -31,13 +31,13 @@ class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.warn(error);
 
     // log to google analytics
     if (window.isIdSet) {
       window.ga('send', 'exception', {
-        exDescription: error,
+        exDescription: `${error}${errorInfo.componentStack}`,
         exFatal: true,
       });
     }

--- a/app/client/src/config/webServiceConfig.js
+++ b/app/client/src/config/webServiceConfig.js
@@ -42,6 +42,13 @@ export const fishingInformationService = {
     '%29&outFields=*&returnGeometry=false&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentsOnly=false&f=json',
 };
 
+// get origin for mapping proxy calls
+const loc = window.location;
+const origin =
+  loc.hostname === 'localhost'
+    ? `${loc.protocol}//${loc.hostname}:9091`
+    : loc.origin;
+
 export const webServiceMapping = [
   //attains
   {
@@ -167,5 +174,34 @@ export const webServiceMapping = [
   {
     wildcardUrl: `${fishingInformationService.serviceUrl}*`,
     name: 'fishing info',
+  },
+  // lookup files
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/national/NARS.json`,
+    name: 's3 lookup - national NARS',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/notifications/messages.json`,
+    name: 's3 lookup - notification messages',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/state/documentOrder.json`,
+    name: 's3 lookup - state documentOrder',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/state/reportStatusMapping.json`,
+    name: 's3 lookup - state reportStatusMapping',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/state/stateNationalUses.json`,
+    name: 's3 lookup - state stateNationalUses',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/state/surveyMapping.json`,
+    name: 's3 lookup - state surveyMapping',
+  },
+  {
+    wildcardUrl: `${origin}/proxy?url=${origin}/data/state/waterTypeOptions.json`,
+    name: 's3 lookup - state waterTypeOptions',
   },
 ];


### PR DESCRIPTION
One of the changes with this PR was to update the Google Analytics exception log so that it includes the stack trace. I was unable to find a way to test this locally, it seems like GA does not log any exceptions that come from localhost. To test this I added a hidden button to the identified issues tab that we can make visible through the dev tools. I'll create another PR to remove this hidden button after I test the updated exception log on the dev site.

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3442284

## Main Changes:
* Updated webServiceMapping to include all of the new S3 lookup file calls.
* Updated the "The "% of assessed waters are impaired" value is 0..." exception so that it is only fired if nullPollutedWaterbodies is true and the summaryByParameterImpairments array has data. Before we were getting false hits on this exception when the summaryByParameterImpairements array was empty.
* Added the stack trace to exceptions fired from the ErrorBoundary component.
    * I created a hidden button on the identified issues tab for testing this change on the dev site. 

## Steps To Test:
None of these changes can be tested locally. 

## TODO:
- [ ] Merge into the develop branch and test on the dev site.
- [ ] Remove the hidden button for triggering an exception.
