### PR TITLE
Feature/let epa gtm load ga

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -69,21 +69,23 @@
   <!-- End Google Tag Manager -->
   <!-- Google Analytics -->
   <script>
-    (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+    function addGoogleAnalyticsObject() {
+      (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+    }
 
     //Only setup the logging for public sites, ie don't log from localhost
     window.isIdSet = false;
     if (document.location.hostname.indexOf("epa.gov") > -1) {
-      ga('create', 'UA-32633028-1', 'auto');  //EPA ACCOUNT (Production)
-      ga('send', 'pageview');
+      //EPA (Production) - Just initialize the HMW logs by setting isIdSet
       isIdSet = true;
     }
     else if (document.location.hostname === 'mywaterway-stage.app.cloud.gov') {
+      addGoogleAnalyticsObject();
       ga('create', 'UA-37504877-4', 'auto');  //Stage
       ga('send', 'pageview');
       isIdSet = true;
@@ -92,6 +94,7 @@
       document.location.hostname === 'mywaterway-dev.app.cloud.gov' ||
       document.location.hostname === 'localhost'
     ) {
+      addGoogleAnalyticsObject();
       ga('create', 'UA-37504877-3', 'auto');  //Dev
       ga('send', 'pageview');
       isIdSet = true;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3450962

## Main Changes:
* Updated the initialization of ERG's google analytics so that it does not initialize google analytics on the production site, since EPA's google tag manager already does this.

## Steps To Test:
1. Open index.html in visual studio code.
2. Add a console log inside the locationchange event listener on line 115.
3. Open the app and change pages.
4. Verify the logs show up in the console.
5. On line 83, change "epa.gov" to "localhost". 
6. Change pages.
7. Verify the logs show up in the console.
  * This just makes sure the GA calls are made even though we didn't add the GA scripts.

## TODO:
- [ ] Need to figure out a way to verify if the logs are making it to the EPA google analytics account. @coobr01 Do you have any thoughs on this?
  * We might be able to test this locally, but I'm not sure if EPA has a filter setup to filter out localhost logs.

