### PR TITLE
Remove parenthesis from stack trace.

### DIFF
--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -36,8 +36,9 @@ class ErrorBoundary extends React.Component<Props, State> {
 
     // log to google analytics
     if (window.isIdSet) {
+      const stack = errorInfo.componentStack.replace('(', '').replace(')', '');
       window.ga('send', 'exception', {
-        exDescription: `${error}${errorInfo.componentStack}`,
+        exDescription: `${error}${stack}`,
         exFatal: true,
       });
     }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3442284

## Main Changes:
Google analytics was removing the line numbers by removing anything between parenthesis. To work around this I'm trying to remove the parenthesis and see if GA will leave the line number in.

## Steps To Test:
None of these changes can be tested locally. 

## TODO:
- [ ] Merge into the develop branch and test on the dev site.
- [ ] Remove the hidden button for triggering an exception.
