### PR TITLE
Feature/update tribal layer color

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -365,6 +365,20 @@ export function getSharedLayers(FeatureLayer, MapImageLayer) {
     visible: false,
   });
 
+  const renderer = {
+    type: 'simple',
+    symbol: {
+      type: 'simple-fill',
+      style: 'solid',
+      color: [154, 154, 154, 0.75],
+      outline: {
+        style: 'solid',
+        color: [110, 110, 110, 0.75],
+        width: 1,
+      },
+    },
+  };
+
   const tribalLayer = new MapImageLayer({
     id: 'tribalLayer',
     url: tribal,
@@ -372,9 +386,9 @@ export function getSharedLayers(FeatureLayer, MapImageLayer) {
     sublayers: [
       { id: 0, labelsVisible: false },
       { id: 1, labelsVisible: false },
-      { id: 2, labelsVisible: false },
+      { id: 2, labelsVisible: false, renderer },
       { id: 3, labelsVisible: false },
-      { id: 4, labelsVisible: false },
+      { id: 4, labelsVisible: false, renderer },
     ],
     listMode: 'hide-children',
     visible: false,

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -51,7 +51,6 @@ const LegendLabel = styled.span`
 const ignoreLayers = [
   'mappedWaterLayer',
   'countyLayer',
-  'tribalLayer',
   'watershedsLayer',
   'wsioHealthIndexLayer',
   'searchIconLayer',
@@ -132,6 +131,27 @@ function MapLegendContent({ layer }: CardProps) {
           strokeWidth={strokeWidth}
           stroke={stroke}
           transform={`rotate(45, ${boxSize / 2}, ${boxSize / 2})`}
+        />
+      </svg>
+    );
+  };
+
+  const circleIcon = ({ color, strokeWidth = 1, stroke = 'black' }) => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={boxSize}
+        height={boxSize}
+        viewBox={`0 0 ${boxSize} ${boxSize}`}
+        aria-hidden="true"
+      >
+        <circle
+          cx={boxSize / 2}
+          cy={boxSize / 2}
+          r="10"
+          fill={color}
+          strokeWidth={strokeWidth}
+          stroke={stroke}
         />
       </svg>
     );
@@ -258,6 +278,41 @@ function MapLegendContent({ layer }: CardProps) {
     </LI>
   );
 
+  const tribalLegend = (
+    <>
+      <LI>
+        <ImageContainer>
+          {squareIcon({
+            color: 'rgb(154, 154, 154)',
+            strokeWidth: 1,
+            stroke: '#6e6e6e',
+          })}
+        </ImageContainer>
+        <LegendLabel>Tribal Lands</LegendLabel>
+      </LI>
+      <LI>
+        <ImageContainer>
+          {circleIcon({
+            color: 'rgb(158, 0, 124)',
+            strokeWidth: 1,
+            stroke: '#000000',
+          })}
+        </ImageContainer>
+        <LegendLabel>Alaska Native Villages</LegendLabel>
+      </LI>
+      <LI>
+        <ImageContainer>
+          {squareIcon({
+            color: 'rgb(245, 215, 191)',
+            strokeWidth: 1,
+            stroke: '#6e6e6e',
+          })}
+        </ImageContainer>
+        <LegendLabel>Alaska Native Allotments</LegendLabel>
+      </LI>
+    </>
+  );
+
   if (layer.id === 'waterbodyLayer') return waterbodyLegend;
   if (layer.id === 'issuesLayer') return issuesLegend;
   if (layer.id === 'monitoringStationsLayer') return monitoringStationsLegend;
@@ -266,6 +321,7 @@ function MapLegendContent({ layer }: CardProps) {
   if (layer.id === 'providersLayer') return providersLegend;
   if (layer.id === 'boundariesLayer') return boundariesLegend;
   if (layer.id === 'actionsWaterbodies') return actionsWaterbodiesLegend;
+  if (layer.id === 'tribalLayer') return tribalLegend;
 
   return null;
 }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3291142

## Main Changes:
* Updated the color so that it does not interfere with existing HMW colors.
* Added the tribal layers to the legend. 

## Steps To Test:
1. Go to the community page.
2. Turn on the tribal layer.
3. Open the legend.
4. Verify the graphics in the continental US are gray and match the legend. 
5. Pan over to Alaska and verify the graphics match the legend color.
  * Note: The "Alaska Villages" layer does not always load. This seems to be an issue with the layer itself. If you go to https://geopub.epa.gov/arcgis/rest/services/EMEF/tribal/MapServer and open it in the map viewer, this layer (1) doesn't load every time. 

