### PR TITLE
bugfix/maplegend-react-errors

### DIFF
--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -260,7 +260,9 @@ function MapLegendContent({ layer }: CardProps) {
               >
                 {stops.map((item, index) => {
                   return (
-                    <div className="esriLegendColorRampLabel">{item.label}</div>
+                    <div key={index} className="esriLegendColorRampLabel">
+                      {item.label}
+                    </div>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3469251

## Main Changes:
* Fixed error with React list missing keys in Map Legend.

## Steps To Test:
1. Navigate to Community page and search a location.
2. Verify there are no errors in the console and the map legend is working normally.
