### PR TITLE
Feature/remove widget scrollbars

### DIFF
--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -18,9 +18,16 @@
   height: 24px;
 }
 
+.esri-basemap-gallery {
+  overflow: visible !important;
+  max-height: 100% !important;
+}
+
 .esri-layer-list {
   padding: 12px 10px 0;
   background-color: inherit;
+  overflow: visible !important;
+  max-height: 100% !important;
 }
 
 .esri-layer-list__item-container {
@@ -145,7 +152,6 @@
 .hmw-map-toggle {
   padding: 10px 0 0;
   background-color: #fff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 .hmw-map-toggle h1 {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3468879

## Main Changes:
* Updated map styles to remove scroll bars from Basemaps and Layers section of map widget.

## Steps To Test:
1. Navigate to Community page and search a location.
2. Open widget in top right corner of map.
3. Verify there are no inner scroll bars for the Basemaps and Layers.
4. Test on different screen sizes (Mobile, Tablet) and verify there are no issues with the widget's responsiveness.
