### PR TITLE
feature/update WSIO layer name

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -358,7 +358,7 @@ export function getSharedLayers(FeatureLayer, MapImageLayer) {
   const wsioHealthIndexLayer = new FeatureLayer({
     id: 'wsioHealthIndexLayer',
     url: wsio,
-    title: 'Watershed Health Index',
+    title: 'State Watershed Health Index',
     outFields: ['phwa_health_ndx_st_2016'],
     renderer: wsioHealthIndexRenderer,
     listMode: 'show',

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -434,7 +434,7 @@ function MapLegendContent({ layer }: CardProps) {
       <ImageContainer>
         {squareIcon({ color: 'rgb(54, 140, 225)', strokeWidth: 0 })}
       </ImageContainer>
-      <LegendLabel>Watershed Health Index Layer</LegendLabel>
+      <LegendLabel>State Watershed Health Index Layer</LegendLabel>
       {gradientIcon({
         id: 'health-index-gradient',
         stops: [


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3468955

## Main Changes:
* Changes 'Watershed Health Index' to 'State Watershed Health Index'

## Steps To Test:
1. Navigate to Community page
2. Verify the WSIO layer in the map widget Layer list and map Legend has been renamed

