### PR TITLE
Feature/persistent basemaps

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -49,6 +49,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
     mapView,
     setActionsLayer,
     setMapView,
+    getBasemap,
   } = React.useContext(LocationSearchContext);
 
   const [layers, setLayers] = React.useState(null);
@@ -314,7 +315,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
           <Map
             style={{ position: 'absolute' }}
             loaderOptions={{ url: esriApiUrl }}
-            mapProperties={{ basemap: 'gray' }}
+            mapProperties={{ basemap: getBasemap() }}
             viewProperties={{ extent: initialExtent, highlightOptions }}
             onLoad={(map: Any, view: Any) => {
               setMapView(view);

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -140,7 +140,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setNoDataAvailable,
     FIPS,
     setFIPS,
-
+    getBasemap,
     layers,
     setLayers,
     pointsLayer,
@@ -1315,7 +1315,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         <Map
           style={{ position: 'absolute' }}
           loaderOptions={{ url: esriApiUrl }}
-          mapProperties={{ basemap: 'gray' }}
+          mapProperties={{ basemap: getBasemap() }}
           viewProperties={{
             extent: initialExtent,
             highlightOptions,

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -373,7 +373,7 @@ function MapWidgets({
     });
 
     setMapEventHandlersSet(true);
-  }, [watchUtils, view, mapEventHandlersSet, basemap, setBasemap]);
+  }, [watchUtils, view, mapEventHandlersSet, basemap, setBasemap, map]);
 
   React.useEffect(() => {
     if (!layers || layers.length === 0) return;

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -151,6 +151,8 @@ function MapWidgets({
     setHomeWidget,
     visibleLayers,
     setVisibleLayers,
+    setBasemap,
+    basemap,
   } = React.useContext(LocationSearchContext);
 
   const {
@@ -362,8 +364,16 @@ function MapWidgets({
       handleMapZoomChange(newVal, target);
     });
 
+    // when basemap changes, update the basemap in context for persistent basemaps
+    // across fullscreen and mobile/desktop layout changes
+    view.map.allLayers.on('change', function (event) {
+      if (map.basemap !== basemap) {
+        setBasemap(map.basemap);
+      }
+    });
+
     setMapEventHandlersSet(true);
-  }, [watchUtils, view, mapEventHandlersSet]);
+  }, [watchUtils, view, mapEventHandlersSet, basemap, setBasemap]);
 
   React.useEffect(() => {
     if (!layers || layers.length === 0) return;

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -86,6 +86,7 @@ function StateMap({
 
     homeWidget,
     resetData,
+    getBasemap,
   } = React.useContext(LocationSearchContext);
 
   const [layers, setLayers] = React.useState(null);
@@ -375,7 +376,7 @@ function StateMap({
         <Map
           style={{ position: 'absolute' }}
           loaderOptions={{ url: esriApiUrl }}
-          mapProperties={{ basemap: 'gray' }}
+          mapProperties={{ basemap: getBasemap() }}
           viewProperties={{
             extent: {
               xmin: -13873570.722124241,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -27,6 +27,7 @@ type State = {
   nonprofits: Object,
   mapView: Object,
   layers: Object[],
+  basemap: Object,
   waterbodyLayer: Object,
   issuesLayer: Object,
   monitoringStationsLayer: Object,
@@ -127,6 +128,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     selWaterBodyLayer: '',
     homeWidget: null,
     visibleLayers: {},
+    basemap: {},
     hucBoundaries: '',
     atHucBoundaries: false,
     countyBoundaries: '',
@@ -261,6 +263,9 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     setVisibleLayers: (visibleLayers) => {
       this.setState({ visibleLayers });
     },
+    setBasemap: (basemap) => {
+      this.setState({ basemap });
+    },
     setWaterbodyData: (waterbodyData) => {
       this.setState({ waterbodyData });
     },
@@ -327,6 +332,13 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       if (pointsData) features = features.concat(pointsData.features);
 
       return features;
+    },
+
+    // default basemap is gray but use basemap in context if it exists
+    getBasemap: () => {
+      return Object.keys(this.state.basemap).length === 0
+        ? 'gray'
+        : this.state.basemap;
     },
 
     resetMap: (useDefaultZoom = false) => {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3468301

## Main Changes:
* Move current basemap to LocationSearch context so that it persists across layout changes and fullscreen toggles.

## Steps To Test:
1. Navigate to Community page. Search a location and then change the Basemap to anything other than the default Light Gray.
2. Switch to full screen and verify the basemap persists. 
3. Reduce screen size to mobile and verify basemap persists.
4. Repeat steps 1-3 on State, Plan-Summary, and Waterbody-Report pages.
