### PR TITLE
Bugfix/attains endless map spinner

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -257,6 +257,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
   const handleMapServiceError = React.useCallback(
     (err) => {
+      setMapLoading(false);
       console.error(err);
       setCipSummary({
         data: [],


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3486048

## Main Changes:
* Turns off the map loading spinner when ATTAINS services are down to prevent endless loading.
* Issue only occurs when HUC12Summary service is down.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open Developer Tools and go to the Network tab
3. Search 'huc12summary' and block the huc12summary service call
4. Refresh the page. The spinner should disappear when the request fails instead of loading forever

Follow steps 1-3 on the HMW Dev site to reproduce the infinite spinner issue.




