### PR TITLE
Feature/state advanced attains service error

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -121,10 +121,6 @@ function retrieveFeatures({
 }
 
 // --- styled components ---
-const ErrorBox = styled(StyledErrorBox)`
-  margin-bottom: 1.5em;
-`;
-
 const Inputs = styled.div`
   display: flex;
   flex-flow: row wrap;
@@ -1042,6 +1038,14 @@ function AdvancedSearch({ ...props }: Props) {
 
   const contentVisible = currentFilter && waterbodyData;
 
+  if (serviceError) {
+    return (
+      <StyledErrorBox>
+        <p>{stateGeneralError}</p>
+      </StyledErrorBox>
+    );
+  }
+
   return (
     <div data-content="stateoverview">
       <ConfirmModal
@@ -1078,12 +1082,6 @@ function AdvancedSearch({ ...props }: Props) {
           <>Please change your filter criteria and try again.</>
         )}
       </ConfirmModal>
-
-      {serviceError && (
-        <ErrorBox>
-          <p>{stateGeneralError}</p>
-        </ErrorBox>
-      )}
 
       {filterControls}
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3495922

## Main Changes:
* Hides the Advanced Search section if the ATTAINS usesStateSummary service is down. 
* Reason for this change: If the content isn't hidden the user can click 'Search' and is then given an infinite loading spinner on the 'Loading...' button.

## Steps To Test:
1. Navigate to http://localhost:3000/state/VA/advanced-search
2. Block the usesStateSummary service call in the dev tools Network tab
3. Reload the page. Verify the Advanced tab content is hidden like the first tab's content is and an error message is displayed.
