### PR TITLE
Feature/summarize attains services

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -301,49 +301,51 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
     setMapLoading(false);
   }, [fetchStatus, mapView, actionsLayer, esriModules, homeWidget]);
 
-  return (
-    <>
-      {fetchStatus === 'failure' && (
-        <StyledErrorBox>
-          <p>{actionMapError}</p>
-        </StyledErrorBox>
-      )}
-      {noMapData && (
-        <StyledInfoBox>
-          <p>{actionMapNoData}</p>
-        </StyledInfoBox>
-      )}
-      {fetchStatus === 'success' && !noMapData && (
-        <Container data-testid="hmw-actions-map">
-          <Map
-            style={{ position: 'absolute' }}
-            loaderOptions={{ url: esriApiUrl }}
-            mapProperties={{ basemap: getBasemap() }}
-            viewProperties={{ extent: initialExtent, highlightOptions }}
-            onLoad={(map: Any, view: Any) => {
-              setMapView(view);
-            }}
-            onFail={(err: Any) => console.error(err)}
-          >
-            {/* manually passing map and view props to Map component's     */}
-            {/* children to satisfy flow, but map and view props are auto  */}
-            {/* passed from Map component to its children by react-arcgis  */}
-            <MapWidgets
-              map={null}
-              view={null}
-              layers={layers}
-              onHomeWidgetRendered={(homeWidget) => {}}
-            />
+  if (fetchStatus === 'failure') {
+    return (
+      <StyledErrorBox>
+        <p>{actionMapError}</p>
+      </StyledErrorBox>
+    );
+  }
 
-            {/* manually passing map and view props to Map component's         */}
-            {/* children to satisfy flow, but map and view props are auto      */}
-            {/* passed from Map component to its children by react-arcgis      */}
-            <MapMouseEvents map={null} view={null} />
-          </Map>
-          {mapView && mapLoading && <MapLoadingSpinner />}
-        </Container>
-      )}
-    </>
+  if (noMapData) {
+    return (
+      <StyledInfoBox>
+        <p>{actionMapNoData}</p>
+      </StyledInfoBox>
+    );
+  }
+
+  return (
+    <Container data-testid="hmw-actions-map">
+      <Map
+        style={{ position: 'absolute' }}
+        loaderOptions={{ url: esriApiUrl }}
+        mapProperties={{ basemap: getBasemap() }}
+        viewProperties={{ extent: initialExtent, highlightOptions }}
+        onLoad={(map: Any, view: Any) => {
+          setMapView(view);
+        }}
+        onFail={(err: Any) => console.error(err)}
+      >
+        {/* manually passing map and view props to Map component's     */}
+        {/* children to satisfy flow, but map and view props are auto  */}
+        {/* passed from Map component to its children by react-arcgis  */}
+        <MapWidgets
+          map={null}
+          view={null}
+          layers={layers}
+          onHomeWidgetRendered={(homeWidget) => {}}
+        />
+
+        {/* manually passing map and view props to Map component's         */}
+        {/* children to satisfy flow, but map and view props are auto      */}
+        {/* passed from Map component to its children by react-arcgis      */}
+        <MapMouseEvents map={null} view={null} />
+      </Map>
+      {mapView && mapLoading && <MapLoadingSpinner />}
+    </Container>
   );
 }
 

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -606,7 +606,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   const queryAttainsPlans = React.useCallback(
     (huc12) => {
       // get the plans for the selected huc
-      fetchCheck(`${attains.serviceUrl}plans?huc=${huc12}`, 120000)
+      fetchCheck(`${attains.serviceUrl}plans?huc=${huc12}&summarize=Y`, 120000)
         .then((res) => {
           setAttainsPlans({
             data: res,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3497962

## Main Changes:
* Updated the plans service, on the community page, to use the summarized output.
* Fixed a bug on the plan-summary and waterbody report pages. On the plan summary page the map would not display and the waterbody report page would show infinite loading spinners.

## Steps To Test:
1. Open the Chrome dev tools
2. Go to the network tab
3. Type "plans" into the filter box
4. Navigate to https://mywaterway-dev.app.cloud.gov/community/020700050101/restore
5. Verify the attains plans service call has the "&summarized=Y" parameter on the end
6. Verify that all of the data on the "Restoration Plans" tab is there
7. Navigate to https://mywaterway-dev.app.cloud.gov/plan-summary/21VASWCB/7683
8. Verify the map loads
9. Navigate to https://mywaterway-dev.app.cloud.gov/waterbody-report/21VASWCB/VAV-B10R_BAK01A00
10. Verify the map and data loads without any infinite loading spinners

