### PR TITLE
bugfix/change-location-not-showing

### DIFF
--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -209,6 +209,9 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     setMapView: (mapView) => {
       this.setState({ mapView });
     },
+    getMapView: () => {
+      return this.state.mapView;
+    },
     setLayers: (layers) => {
       this.setState({ layers });
     },

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -503,7 +503,7 @@ function useSharedLayers() {
     Query,
     QueryTask,
   } = React.useContext(EsriModulesContext);
-  const { getHucBoundaries, mapView, resetData } = React.useContext(
+  const { getHucBoundaries, getMapView, resetData } = React.useContext(
     LocationSearchContext,
   );
   var hucInfo = {
@@ -577,12 +577,13 @@ function useSharedLayers() {
     });
   }
 
-  if (!mapView || !resetData) return null;
+  if (!resetData) return null;
 
   // Wrapper function for getting the content of the popup
   function getTemplate(graphic) {
     // get the currently selected huc boundaries, if applicable
     const hucBoundaries = getHucBoundaries();
+    const mapView = getMapView();
     const location = mapView?.popup?.location;
     // only look for huc boundaries if no graphics were clicked and the
     // user clicked outside of the selected huc boundaries


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3505952

## Main Changes:
* Fixed issue with popup not displaying the change location button all of the time.
  * Note: An easy way to reproduce this issue is to enable the tribal/congressional layers, click around on the map (should work correctly at this point), go into full screen map mode, click around on the map (should get stuck in a situation where the change location button is either always shown or never shown). 

## Steps To Test:
1. Navigate to http://localhost:3000/community/160201010403/overview
2. Make the tribal and congressional layers visible
3. Click around the map
4. Verify the popup shows the "Change location" button outside of the huc boundaries and doesn't inside the huc boundaries
5. Go into full screen map mode
6. Repeat steps 3 and 4
