### PR TITLE
feature/new congressional districts service

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -409,7 +409,7 @@ export const openPopup = (view: Object, feature: Object) => {
 
 export function getPopupTitle(attributes: Object) {
   let title = 'Unknown';
-
+  console.log(attributes);
   if (!attributes) return title;
 
   // line, area, point for waterbody
@@ -433,8 +433,8 @@ export function getPopupTitle(attributes: Object) {
   }
 
   // congressional district
-  else if (attributes.CONG_DIST) {
-    title = `${attributes.STATE} District ${attributes.CONG_DIST}`;
+  else if (attributes.DISTRICTID) {
+    title = `${attributes.STATE_ABBR} District ${attributes.CDFIPS}`;
   }
 
   // want to display name for Alaska Native Villages

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -409,7 +409,7 @@ export const openPopup = (view: Object, feature: Object) => {
 
 export function getPopupTitle(attributes: Object) {
   let title = 'Unknown';
-  console.log(attributes);
+
   if (!attributes) return title;
 
   // line, area, point for waterbody

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -510,7 +510,7 @@ export function getPopupContent({
   }
 
   // congressional district
-  else if (attributes.CONG_DIST) {
+  else if (attributes.DISTRICTID) {
     type = 'Congressional District';
   }
 

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -395,6 +395,24 @@ function MapLegendContent({ layer }: CardProps) {
   );
 
   // jsx
+  const congressionalDistrictsLegend = (
+    <LI>
+      <ImageContainer>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="26"
+          height="26"
+          viewBox="0 0 26 26"
+          aria-hidden="true"
+        >
+          <rect x="0" y="12" width="26" height="3" fill="#FF00C5" />
+        </svg>
+      </ImageContainer>
+      <LegendLabel>Congressional Districts</LegendLabel>
+    </LI>
+  );
+
+  // jsx
   const tribalLegend = (
     <>
       <LI>
@@ -460,6 +478,7 @@ function MapLegendContent({ layer }: CardProps) {
   if (layer.id === 'actionsWaterbodies') return actionsWaterbodiesLegend;
   if (layer.id === 'tribalLayer') return tribalLegend;
   if (layer.id === 'wsioHealthIndexLayer') return healthIndexLegend;
+  if (layer.id === 'congressionalLayer') return congressionalDistrictsLegend;
 
   return null;
 }

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -770,14 +770,7 @@ function WaterbodyInfo({
         <p>
           <strong>District:</strong>
           <br />
-          {attributes.URL ? (
-            <a rel="noopener noreferrer" target="_blank" href={attributes.URL}>
-              {attributes.CONG_DIST}
-            </a>
-          ) : (
-            attributes.CONG_DIST
-          )}{' '}
-          - {attributes.CONG_REP}
+          {attributes.CDFIPS} - {attributes.NAME}
         </p>
 
         {renderChangeWatershed()}

--- a/app/client/src/config/mapServiceConfig.js
+++ b/app/client/src/config/mapServiceConfig.js
@@ -20,7 +20,8 @@ export const wsio = `${watersGeoBase}r4/wsio/MapServer/0`;
 
 export const tribal = `${geopubBase}EMEF/tribal/MapServer`;
 
-export const congressional = `${geopubBase}NEPAssist/Boundaries/MapServer/1`;
+export const congressional =
+  'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_116th_Congressional_Districts_all/FeatureServer';
 
 export const waterbodyService = {
   points: `${watersGeoBase}OW/ATTAINS_Assessment/MapServer/0`,

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -827,10 +827,14 @@ function useSharedLayers() {
     // END - Tribal layers
 
     const congressionalLayerOutFields = [
-      'CONG_DIST',
-      'URL',
-      'CONG_REP',
-      'STATE',
+      'DISTRICTID',
+      'STFIPS',
+      'CDFIPS',
+      'STATE_ABBR',
+      'NAME',
+      'LAST_NAME',
+      'PARTY',
+      'SQMI',
     ];
     const congressionalLayer = new FeatureLayer({
       id: 'congressionalLayer',
@@ -838,6 +842,18 @@ function useSharedLayers() {
       title: 'Congressional Districts',
       listMode: 'hide-children',
       visible: false,
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'simple-fill',
+          style: 'none',
+          outline: {
+            style: 'solid',
+            color: '#FF00C5',
+            width: 2,
+          },
+        },
+      },
       outFields: congressionalLayerOutFields,
       popupTemplate: {
         title: getTitle,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3506271
* https://app.breeze.pm/projects/100762/cards/3470439

## Main Changes:
* Uses Arcgis Congressional District (CD) layer so that we can customize the color and styles
* Adds CD layer to map legend
* Removes Url from the CD popup because it does not exist in this service

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Enable the Congressional Districts layer in the layers widget
3. Verify CD layer appears in Map Legend
4. Verify clicking a location shows a modified CD popup with no URL