### PR TITLE
feature/remove-alaska-allotments-layer

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -524,11 +524,6 @@ export function getPopupContent({
     type = 'Tribe';
   }
 
-  // want to display allotment for Alaska Native Allotments
-  else if (attributes.PARCEL_NO) {
-    type = 'Alaska Native Allotment';
-  }
-
   // stand alone change location popup
   else if (attributes.changelocationpopup) {
     type = 'Change Location';

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -435,16 +435,6 @@ function MapLegendContent({ layer }: CardProps) {
         </ImageContainer>
         <LegendLabel>Alaska Native Villages</LegendLabel>
       </LI>
-      <LI>
-        <ImageContainer>
-          {squareIcon({
-            color: 'rgb(245, 215, 191)',
-            strokeWidth: 1,
-            stroke: '#6e6e6e',
-          })}
-        </ImageContainer>
-        <LegendLabel>Alaska Native Allotments</LegendLabel>
-      </LI>
     </>
   );
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -99,7 +99,6 @@ function updateVisibleLayers(view: any, legendNode: Node) {
     'tribalLayer',
     'tribalLayer-1',
     'tribalLayer-2',
-    'tribalLayer-3',
     'tribalLayer-4',
     'congressionalLayer',
     'wsioHealthIndexLayer',

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -797,15 +797,6 @@ function WaterbodyInfo({
   );
 
   // jsx
-  const alaskaNativeAllotmentContent = (
-    <>
-      {labelValue('Allotment', attributes.PARCEL_NO)}
-
-      {renderChangeWatershed()}
-    </>
-  );
-
-  // jsx
   const changeLocationContent = renderChangeWatershed();
 
   // jsx
@@ -826,7 +817,6 @@ function WaterbodyInfo({
   if (type === 'Congressional District') return congressionalDistrictContent();
   if (type === 'Tribe') return tribeContent;
   if (type === 'Alaska Native Village') return alaskaNativeVillageContent;
-  if (type === 'Alaska Native Allotment') return alaskaNativeAllotmentContent;
   if (type === 'Change Location') return changeLocationContent;
 
   return null;

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -731,20 +731,6 @@ function useSharedLayers() {
       },
     };
 
-    const allotmentsRenderer = {
-      type: 'simple',
-      symbol: {
-        type: 'simple-fill',
-        style: 'solid',
-        color: [245, 215, 191, 0.75],
-        outline: {
-          style: 'solid',
-          color: [110, 110, 110, 0.75],
-          width: 0,
-        },
-      },
-    };
-
     const alaskaNativeVillageOutFields = ['NAME', 'TRIBE_NAME'];
     const alaskaNativeVillages = new FeatureLayer({
       id: 'tribalLayer-1',
@@ -778,23 +764,6 @@ function useSharedLayers() {
       },
     });
 
-    const alaskaNativeAllotmentsOutFields = ['PARCEL_NO'];
-    const alaskaNativeAllotments = new FeatureLayer({
-      id: 'tribalLayer-3',
-      url: `${tribal}/3`,
-      title: 'Alaska Native Allotments',
-      outFields: alaskaNativeAllotmentsOutFields,
-      listMode: 'hide',
-      visible: true,
-      labelsVisible: false,
-      renderer: allotmentsRenderer,
-      popupTemplate: {
-        title: getTitle,
-        content: getTemplate,
-        outFields: alaskaNativeAllotmentsOutFields,
-      },
-    });
-
     const lower48TribalOutFields = ['TRIBE_NAME'];
     const lower48Tribal = new FeatureLayer({
       id: 'tribalLayer-4',
@@ -817,12 +786,7 @@ function useSharedLayers() {
       title: 'Tribal Areas',
       listMode: 'show',
       visible: false,
-      layers: [
-        alaskaNativeVillages,
-        alaskaReservations,
-        alaskaNativeAllotments,
-        lower48Tribal,
-      ],
+      layers: [alaskaNativeVillages, alaskaReservations, lower48Tribal],
     });
 
     // END - Tribal layers


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3506425

## Main Changes:
* Removed the Alaska native allotments layer from the tribal layer.

## Steps To Test:
1. Navigate to the community page
2. Turn on the tribal layer
3. Open the legend
4. Verify the "Alaska Native Allotments" item is no longer in the legend
5. Pan over Alaska and verify the tan squares are no longer visible. Usually the native allotments would show up around clusters of Alaska Native Villages (the circles).
