### PR TITLE
Bugfix/state impairments calculation error

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -174,7 +174,7 @@ function SiteSpecific({
       if (param.Cause) {
         let groupName = param.parameterGroup;
         let currentValue = parameterCalc[groupName] || 0;
-        let value = param.Cause || 0;
+        let value = Number(param.Cause) || 0;
 
         parameterCalc[groupName] = currentValue + value;
       }

--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -171,10 +171,10 @@ function SiteSpecific({
   let parameterCalc = {};
   completeUseList.forEach((use) => {
     use.parameters.forEach((param) => {
-      if (param.Cause) {
+      if (param.Cause || param['Cause-count']) {
         let groupName = param.parameterGroup;
         let currentValue = parameterCalc[groupName] || 0;
-        let value = Number(param.Cause) || 0;
+        let value = Number(param.Cause) || Number(param['Cause-count']) || 0;
 
         parameterCalc[groupName] = currentValue + value;
       }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3506917

## Main Changes:
* Cast impairment mile counts to numbers to prevent string concatenation issues where numbers should be added together.

## Steps To Test:
1. Navigate to http://localhost:3000/state/AK/advanced-search
2. Open the "Top Reasons for Impairment..." accordion
3. Verify values displayed for each reason are formatted properly and correctly sorted by descending % value. (screenshots of the issue on dev are in the Breeze thread)


