### PR TITLE
Bugfix/loading spinner tribal layer

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -444,9 +444,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     linesLayer === 'error' || areasLayer === 'error' || pointsLayer === 'error';
 
   // Builds the waterbody layer once data has been fetched for all sub layers
-  const [waterbodyLayerCreated, setWaterbodyLayerCreated] = React.useState(
-    waterbodyLayer ? true : false,
-  );
   React.useEffect(() => {
     if (mapServiceFailure) {
       setMapLoading(false);
@@ -486,7 +483,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       }
     });
     setLayers(newLayers);
-    setWaterbodyLayerCreated(true);
   }, [
     layers,
     waterbodyLayer,
@@ -631,7 +627,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   React.useEffect(() => {
     if (mapServiceFailure) {
       setMapLoading(false);
-      setWaterbodyLayerCreated(false);
     }
   }, [mapServiceFailure]);
 
@@ -868,7 +863,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             setAddress(searchText); // preserve the user's search so it is displayed
             setNoDataAvailable();
             setMapLoading(false);
-            setWaterbodyLayerCreated(false);
             setErrorMessage(noDataAvailableError);
             return;
           }
@@ -1081,7 +1075,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
     resetData();
     setMapLoading(true);
-    setWaterbodyLayerCreated(false);
     setHucResponse(null);
     setErrorMessage('');
     setLastSearchText(searchText);
@@ -1100,7 +1093,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     if (!searchText) {
       setHuc12('');
       setMapLoading(false);
-      setWaterbodyLayerCreated(false);
     }
   }, [searchText, setHuc12]);
 

--- a/app/client/src/components/shared/MapPopup/index.js
+++ b/app/client/src/components/shared/MapPopup/index.js
@@ -61,6 +61,7 @@ function MapPopup({
           isPopup={true}
           extraContent={extraContent}
           getClickedHuc={getClickedHuc}
+          resetData={resetData}
         />
       </Content>
     </Container>

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -204,6 +204,7 @@ function StateMap({
   // cDU
   // detect when user changes their search
   const [homeWidgetSet, setHomeWidgetSet] = React.useState(false);
+  const [mapLoading, setMapLoading] = React.useState(true);
   React.useEffect(() => {
     // query geocode server for every new search
     if (
@@ -266,6 +267,8 @@ function StateMap({
                   // cut down on unnecessary service calls
                   waterbodyLayer.listMode = 'hide-children';
                   waterbodyLayer.visible = true;
+
+                  setMapLoading(false);
                 });
               } else {
                 waterbodyLayer.listMode = 'hide-children';
@@ -341,7 +344,6 @@ function StateMap({
   const mapInputsHeight = mapInputs && mapInputs.getBoundingClientRect().height;
 
   // jsx
-  const [mapLoading, setMapLoading] = React.useState(true);
   const mapContent = (
     <div
       style={
@@ -385,11 +387,6 @@ function StateMap({
           onLoad={(map, view) => {
             setView(view);
             setMapView(view);
-
-            // display a loading spinner until the initial map completes
-            view.watch('rendering', (rendering) => {
-              if (!view.interacting) setMapLoading(rendering); // turn off loading spinner
-            });
           }}
           onFail={(err) => {
             console.error(err);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3507667

## Main Changes:
* Fixed an issue with the "resetData" function not being passed down to the change location button click event. This did not fix the loading spinner issue.
* Modified the community map loading spinner so that it keys off of the waterbody count loading spinner
* Modified the state map loading spinner so that it keys off of the zoom complete event. I initially set this up to key off of the waterbody data query completion, but since the query does not return geometry data the loading spinner never showed up.

## Steps To Test:
1. Go to the community page
2. Turn on the tribal layer
3. Click on one of the tribal layer graphics and change to that location
4. Verify the loading spinner turns off
5. Change to various other locations and verify the loading spinner turns off
6. Navigate to the state advanced search page
7. Do multiple searches and verify the loading spinner turns off and does not flicker
