### PR TITLE
Trying to get error boundary working locally.

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -138,14 +138,12 @@ function IdentifiedIssues() {
   const setViolatingFacilities = React.useCallback(
     (data: Object) => {
       if (!data || !data['Results'] || !data['Results']['Facilities']) return;
-      const violatingFacilities = data['Results']['Facilities'].filter(
-        (fac) => {
-          return (
-            fac['CWPSNCStatus'] &&
-            fac['CWPSNCStatus'].toLowerCase().indexOf('effluent') !== -1
-          );
-        },
-      );
+      const violatingFacilities = data['Results']['Facilities'].filter(fac => {
+        return (
+          fac['CWPSNCStatus'] &&
+          fac['CWPSNCStatus'].toLowerCase().indexOf('effluent') !== -1
+        );
+      });
 
       // if the permitter discharger data has changed from a new search
       if (permittedDischargersData !== permittedDischargers.data) {
@@ -186,7 +184,7 @@ function IdentifiedIssues() {
     parameter: String,
   ) => {
     const filteredFields = parameterFields.filter(
-      (field) => parameter === field.parameterGroup,
+      field => parameter === field.parameterGroup,
     )[0];
     if (!filteredFields) {
       return null;
@@ -206,15 +204,15 @@ function IdentifiedIssues() {
     issuesLayer.graphics.removeAll();
 
     if (features && features.length !== 0) {
-      features.forEach((feature) => {
+      features.forEach(feature => {
         if (
           feature &&
           feature.attributes &&
           impairmentFields.findIndex(
-            (field) => feature.attributes[field.value] === 'Cause',
+            field => feature.attributes[field.value] === 'Cause',
           ) !== -1
         ) {
-          impairmentFields.forEach((field) => {
+          impairmentFields.forEach(field => {
             // if impairment is not a cause, ignore it. overview waterbody listview only displays impairments that are causes
             if (feature.attributes[field.value] !== 'Cause') return null;
             else if (parameterToggleObject[field.label] || showAllParameters) {
@@ -249,7 +247,7 @@ function IdentifiedIssues() {
 
     // generate an object with all possible parameters to store which ones are displayed
     const parameterToggles = {};
-    impairmentFields.forEach((param) => {
+    impairmentFields.forEach(param => {
       parameterToggles[param.label] = true;
     });
 
@@ -362,7 +360,7 @@ function IdentifiedIssues() {
     const parameters = [];
 
     // get a list of all parameters displayed in table and push them to array
-    cipSummaryData.items[0].summaryByParameterImpairments.forEach((param) => {
+    cipSummaryData.items[0].summaryByParameterImpairments.forEach(param => {
       const mappedParameterName = getMappedParameterName(
         impairmentFields,
         param['parameterGroupName'],
@@ -374,11 +372,11 @@ function IdentifiedIssues() {
     });
 
     // return true if toggle for a parameter is not checked
-    const checkNotCheckedParameters = (param) => {
+    const checkNotCheckedParameters = param => {
       return !tempParameterToggleObject[param];
     };
 
-    const checkAnyCheckedParameters = (param) => {
+    const checkAnyCheckedParameters = param => {
       return tempParameterToggleObject[param];
     };
 
@@ -549,6 +547,7 @@ function IdentifiedIssues() {
     toggleDischargersChecked = false;
   }
 
+  const [testError, setTestError] = React.useState(false);
   return (
     <Container>
       <>
@@ -716,7 +715,7 @@ function IdentifiedIssues() {
                                 </THead>
                                 <tbody>
                                   {cipSummary.data.items[0].summaryByParameterImpairments.map(
-                                    (param) => {
+                                    param => {
                                       const percent = formatNumber(
                                         Math.min(
                                           100,
@@ -852,6 +851,21 @@ function IdentifiedIssues() {
                 like sewers and pipes
               </li>
             </ul>
+          </>
+        )}
+        <button
+          style={{ display: 'none' }}
+          onClick={() => {
+            setTestError(true);
+          }}
+        >
+          Log React Boundary Exception
+        </button>
+        {testError && (
+          <>
+            {cipSummary.test.mmmmaaaaapppp((item, idx) => {
+              return <p key={idx}>item</p>;
+            })}
           </>
         )}
       </>

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -33,10 +33,6 @@ class ErrorBoundary extends React.Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.warn(error);
-
-    // throw the error so the global error handler
-    // can log it to google analytics
-    throw error;
   }
 
   render() {


### PR DESCRIPTION
## Main Changes:
* Did some testing locally and found that `throw error;` is why the error boundary is not working locally. I removed that line.
* Added in a hidden button for testing the error boundary google analytics logs on the HMW dev site. 

## Steps To Test:
1. Navigate to the identified issues of the community tab.
2. Find the "Log React Boundary Exception" button in the element explorer of Chrome dev tools and change `display: none;` to `display: block;`.
3. Click the "Log React Boundary Exception". 
4. Verify the error boundary is displayed and works.

## TODO:
- [ ] Remove the hidden button after confirming the google analytics exception logs still work.
