### PR TITLE
Feature/display notifications in error boundary

### DIFF
--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -61,22 +61,14 @@ class ErrorBoundary extends React.Component<Props, State> {
     const page = window.location.pathname.split('/')[1];
     const data = notifications.status === 'success' ? notifications.data : {};
 
-    const allPagesBanner = data && data['all'] && (
-      <Banner
-        color={data['all'].color}
-        backgroundColor={data['all'].backgroundColor}
-        dangerouslySetInnerHTML={createMarkup(data['all'].message)}
-      ></Banner>
-    );
-
     if (this.state.hasError) {
       return (
         <>
-          {data && Object.keys(data).includes(page) && (
+          {data && data['all'] && (
             <Banner
-              color={data[page].color}
-              backgroundColor={data[page].backgroundColor}
-              dangerouslySetInnerHTML={createMarkup(data[page].message)}
+              color={data['all'].color}
+              backgroundColor={data['all'].backgroundColor}
+              dangerouslySetInnerHTML={createMarkup(data['all'].message)}
             ></Banner>
           )}
           {data && Object.keys(data).includes(page) && (

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -19,12 +19,10 @@ const ErrorBox = styled(StyledErrorBox)`
 const ErrorBanner = styled.div`
   margin: 1rem;
   text-align: center;
-
   background-color: ${(props) => props.backgroundColor};
   color: ${(props) => props.color};
   padding: 10px 5px;
   text-align: center;
-
   p {
     padding: 0;
     margin: 0;

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -5,11 +5,30 @@ import type { Node } from 'react';
 import styled from 'styled-components';
 // components
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
+// contexts
+import { LookupFilesContext } from 'contexts/LookupFiles';
+// utilities
+import { createMarkup } from 'utils/utils';
 
 // --- styled components ---
 const ErrorBox = styled(StyledErrorBox)`
   margin: 1rem;
   text-align: center;
+`;
+
+const Banner = styled.div`
+  margin: 1rem;
+  text-align: center;
+
+  background-color: ${(props) => props.backgroundColor};
+  color: ${(props) => props.color};
+  padding: 10px 5px;
+  text-align: center;
+
+  p {
+    padding: 0;
+    margin: 0;
+  }
 `;
 
 // --- components ---
@@ -27,6 +46,8 @@ class ErrorBoundary extends React.Component<Props, State> {
     hasError: false,
   };
 
+  static contextType = LookupFilesContext;
+
   static getDerivedStateFromError(error: Error) {
     return { hasError: true };
   }
@@ -36,8 +57,38 @@ class ErrorBoundary extends React.Component<Props, State> {
   }
 
   render() {
+    const notifications = this.context.notifications;
+    const page = window.location.pathname.split('/')[1];
+    const data = notifications.status === 'success' ? notifications.data : {};
+
+    const allPagesBanner = data && data['all'] && (
+      <Banner
+        color={data['all'].color}
+        backgroundColor={data['all'].backgroundColor}
+        dangerouslySetInnerHTML={createMarkup(data['all'].message)}
+      ></Banner>
+    );
+
     if (this.state.hasError) {
-      return <ErrorBox>{this.props.message}</ErrorBox>;
+      return (
+        <>
+          {data && Object.keys(data).includes(page) && (
+            <Banner
+              color={data[page].color}
+              backgroundColor={data[page].backgroundColor}
+              dangerouslySetInnerHTML={createMarkup(data[page].message)}
+            ></Banner>
+          )}
+          {data && Object.keys(data).includes(page) && (
+            <Banner
+              color={data[page].color}
+              backgroundColor={data[page].backgroundColor}
+              dangerouslySetInnerHTML={createMarkup(data[page].message)}
+            ></Banner>
+          )}
+          <ErrorBox>{this.props.message}</ErrorBox>
+        </>
+      );
     }
 
     return this.props.children;

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -16,7 +16,7 @@ const ErrorBox = styled(StyledErrorBox)`
   text-align: center;
 `;
 
-const Banner = styled.div`
+const ErrorBanner = styled.div`
   margin: 1rem;
   text-align: center;
 
@@ -65,18 +65,18 @@ class ErrorBoundary extends React.Component<Props, State> {
       return (
         <>
           {data && data['all'] && (
-            <Banner
+            <ErrorBanner
               color={data['all'].color}
               backgroundColor={data['all'].backgroundColor}
               dangerouslySetInnerHTML={createMarkup(data['all'].message)}
-            ></Banner>
+            />
           )}
           {data && Object.keys(data).includes(page) && (
-            <Banner
+            <ErrorBanner
               color={data[page].color}
               backgroundColor={data[page].backgroundColor}
               dangerouslySetInnerHTML={createMarkup(data[page].message)}
-            ></Banner>
+            />
           )}
           <ErrorBox>{this.props.message}</ErrorBox>
         </>

--- a/app/client/src/contexts/LookupFiles.js
+++ b/app/client/src/contexts/LookupFiles.js
@@ -235,4 +235,5 @@ export {
   useWaterTypeOptionsContext,
   useNarsContext,
   useNotificationsContext,
+  LookupFilesContext,
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3511220

## Main Changes:
* Displays notifications from the messages.json file after the default error boundary is reached.

## Steps To Test:
1. Replace the contents of **server\app\public\data\notifications\messages.json** with the following: 
`{
  "all": {
    "color": "#721c24",
    "backgroundColor": "#f8d7da",
    "message": "<p>There will be <a href=\"https://www.epa.gov\" target=\"_blank\">scheduled maintenance</a> on the <strong>ATTAINS</strong> services on Thursday, July 16th starting at 8am and ending at 11am.</p>"
  },
  "community": {
    "color": "#0c5460",
    "backgroundColor": "#d1ecf1",
    "message": "<p>This is a message for the <strong>Community</strong> page. Check out <a href=\"epa.gov\">this link</a> for more information</p>"
  },
  "state": {
    "color": "#721c24",
    "backgroundColor": "#f8d7da",
    "message": "<p>State page message.</p>"
  },
  "plan-summary": {
    "color": "#721c24",
    "backgroundColor": "#f8d7da",
    "message": "Plan summary message."
  },
  "national": {
    "color": "#721c24",
    "backgroundColor": "#f8d7da",
    "message": "National message."
  },
  "waterbody-report": {
    "color": "#721c24",
    "backgroundColor": "#f8d7da",
    "message": "Waterbody Report message."
  }
}
`

2. Trigger the error boundary by adding something like  `throw "error"` or console.logging a property of an undefined object. Do this in the Community, State, or any main page.
3. Verify that the **'all' error message**, the **page-specific error message**, and the **default error message** are displayed.
4. Open the Network dev tools tab and search "messages". Block the messages.json request.
5. Refresh the page and trigger a crash and verify only the default error boundary message is correctly displayed.
6. Unblock the request, set the messages.json file contents back to `{}` and refresh the page. Verify only the default message is displayed during a crash.


