### PR TITLE
bugfix/local-error-boundary

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -138,12 +138,14 @@ function IdentifiedIssues() {
   const setViolatingFacilities = React.useCallback(
     (data: Object) => {
       if (!data || !data['Results'] || !data['Results']['Facilities']) return;
-      const violatingFacilities = data['Results']['Facilities'].filter(fac => {
-        return (
-          fac['CWPSNCStatus'] &&
-          fac['CWPSNCStatus'].toLowerCase().indexOf('effluent') !== -1
-        );
-      });
+      const violatingFacilities = data['Results']['Facilities'].filter(
+        (fac) => {
+          return (
+            fac['CWPSNCStatus'] &&
+            fac['CWPSNCStatus'].toLowerCase().indexOf('effluent') !== -1
+          );
+        },
+      );
 
       // if the permitter discharger data has changed from a new search
       if (permittedDischargersData !== permittedDischargers.data) {
@@ -184,7 +186,7 @@ function IdentifiedIssues() {
     parameter: String,
   ) => {
     const filteredFields = parameterFields.filter(
-      field => parameter === field.parameterGroup,
+      (field) => parameter === field.parameterGroup,
     )[0];
     if (!filteredFields) {
       return null;
@@ -204,15 +206,15 @@ function IdentifiedIssues() {
     issuesLayer.graphics.removeAll();
 
     if (features && features.length !== 0) {
-      features.forEach(feature => {
+      features.forEach((feature) => {
         if (
           feature &&
           feature.attributes &&
           impairmentFields.findIndex(
-            field => feature.attributes[field.value] === 'Cause',
+            (field) => feature.attributes[field.value] === 'Cause',
           ) !== -1
         ) {
-          impairmentFields.forEach(field => {
+          impairmentFields.forEach((field) => {
             // if impairment is not a cause, ignore it. overview waterbody listview only displays impairments that are causes
             if (feature.attributes[field.value] !== 'Cause') return null;
             else if (parameterToggleObject[field.label] || showAllParameters) {
@@ -247,7 +249,7 @@ function IdentifiedIssues() {
 
     // generate an object with all possible parameters to store which ones are displayed
     const parameterToggles = {};
-    impairmentFields.forEach(param => {
+    impairmentFields.forEach((param) => {
       parameterToggles[param.label] = true;
     });
 
@@ -360,7 +362,7 @@ function IdentifiedIssues() {
     const parameters = [];
 
     // get a list of all parameters displayed in table and push them to array
-    cipSummaryData.items[0].summaryByParameterImpairments.forEach(param => {
+    cipSummaryData.items[0].summaryByParameterImpairments.forEach((param) => {
       const mappedParameterName = getMappedParameterName(
         impairmentFields,
         param['parameterGroupName'],
@@ -372,11 +374,11 @@ function IdentifiedIssues() {
     });
 
     // return true if toggle for a parameter is not checked
-    const checkNotCheckedParameters = param => {
+    const checkNotCheckedParameters = (param) => {
       return !tempParameterToggleObject[param];
     };
 
-    const checkAnyCheckedParameters = param => {
+    const checkAnyCheckedParameters = (param) => {
       return tempParameterToggleObject[param];
     };
 
@@ -547,7 +549,6 @@ function IdentifiedIssues() {
     toggleDischargersChecked = false;
   }
 
-  const [testError, setTestError] = React.useState(false);
   return (
     <Container>
       <>
@@ -715,7 +716,7 @@ function IdentifiedIssues() {
                                 </THead>
                                 <tbody>
                                   {cipSummary.data.items[0].summaryByParameterImpairments.map(
-                                    param => {
+                                    (param) => {
                                       const percent = formatNumber(
                                         Math.min(
                                           100,
@@ -851,21 +852,6 @@ function IdentifiedIssues() {
                 like sewers and pipes
               </li>
             </ul>
-          </>
-        )}
-        <button
-          style={{ display: 'none' }}
-          onClick={() => {
-            setTestError(true);
-          }}
-        >
-          Log React Boundary Exception
-        </button>
-        {testError && (
-          <>
-            {cipSummary.test.mmmmaaaaapppp((item, idx) => {
-              return <p key={idx}>item</p>;
-            })}
           </>
         )}
       </>

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -864,6 +864,7 @@ function WaterQualityOverview({ ...props }: Props) {
   // unfortunately  need to manage the activeTabIndex (an implementation detail)
   const [activeTabIndex, setActiveTabIndex] = React.useState(initialTabIndex);
 
+  const [testError, setTestError] = React.useState(false);
   if (
     serviceError ||
     waterTypeOptions.status === 'failure' ||
@@ -1135,6 +1136,21 @@ function WaterQualityOverview({ ...props }: Props) {
           </AccordionContent>
         </AccordionItem>
       </Accordions>
+      <button
+        style={{ display: 'none' }}
+        onClick={() => {
+          setTestError(true);
+        }}
+      >
+        Log React Boundary Exception
+      </button>
+      {testError && (
+        <>
+          {tabs.test.mmmmaaaaapppp((item, idx) => {
+            return <p key={idx}>item</p>;
+          })}
+        </>
+      )}
     </Container>
   );
 }

--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -31,8 +31,12 @@ class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error: Error) {
     console.warn(error);
+
+    if (document.location.hostname === 'localhost') return;
+
+    throw error;
   }
 
   render() {


### PR DESCRIPTION



## Main Changes:
* Unfortunately removing the throw error made it so Google Analytics was no longer getting the exception logs. This time I'm going to try only throwing the error if the hostname is not localhost. Our Google Analytics doesn't work from localhost anyway.
* Moved the hidden button for testing the error boundary to the State water quality overview page. 

## Steps To Test:
1. Navigate to the state water quality overview page.
2. Find the "Log React Boundary Exception" button in the element explorer of Chrome dev tools and change `display: none;` to `display: block;`.
3. Click the "Log React Boundary Exception". 
4. Verify the error boundary is displayed and works.

## TODO:
- [ ] Remove the hidden button after confirming the google analytics exception logs still work.

