### PR TITLE
Fixed color/label issue with the site specific chart.

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -222,7 +222,9 @@ function SiteSpecific({
       });
 
   const barChartData = [];
+  const categories = [];
   if (calculatedSupport.supporting > 0) {
+    categories.push('Good');
     barChartData.push({
       name: 'Good',
       y: calculatedSupport.supporting || 0,
@@ -230,6 +232,7 @@ function SiteSpecific({
     });
   }
   if (calculatedSupport.notSupporting > 0) {
+    categories.push('Impaired');
     barChartData.push({
       name: 'Impaired',
       y: calculatedSupport.notSupporting || 0,
@@ -237,6 +240,7 @@ function SiteSpecific({
     });
   }
   if (calculatedSupport.insufficent > 0) {
+    categories.push('Insufficient Info');
     barChartData.push({
       name: 'Insufficient Info',
       y: calculatedSupport.insufficent || 0,
@@ -311,7 +315,7 @@ function SiteSpecific({
                     },
                     xAxis: {
                       lineWidth: 0,
-                      categories: ['Good', 'Impaired', 'Insufficient Info'],
+                      categories,
                       labels: { style: { fontSize: '15px' } },
                     },
                     yAxis: {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3515701

## Main Changes:
* Fixed issue with label not matching the color of the bar on the site specific chart of the state page.

## Steps To Test:
1. Navigate to http://localhost:3000/state/DC/water-quality-overview
2. Verify the bar chart in the site specific section has a red bar with "Impaired" as the label instead of a red bar with "Good" as the label.
