### PR TITLE
Trying a different google analytics log method.

### DIFF
--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -31,12 +31,13 @@ class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true };
   }
 
-  componentDidCatch(error: Error) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.warn(error);
 
-    if (document.location.hostname === 'localhost') return;
-
-    throw error;
+    window.ga('send', 'exception', {
+      exDescription: `${error.toString()}${JSON.stringify(errorInfo)}`,
+      exFatal: true,
+    });
   }
 
   render() {


### PR DESCRIPTION


## Main Changes:
* This method of logging the error broke the error boundary. Changed how the errors get logged.

## Steps To Test:
1. Navigate to the state water quality overview page.
2. Find the "Log React Boundary Exception" button in the element explorer of Chrome dev tools and change `display: none;` to `display: block;`.
3. Click the "Log React Boundary Exception". 
4. Verify the error boundary is displayed and works.

## TODO:
- [ ] Remove the hidden button after confirming the google analytics exception logs still work.


