### PR TITLE
Trying another way to log the error by throwing and catching it.

### DIFF
--- a/app/client/src/components/shared/ErrorBoundary/index.js
+++ b/app/client/src/components/shared/ErrorBoundary/index.js
@@ -34,10 +34,14 @@ class ErrorBoundary extends React.Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.warn(error);
 
-    window.ga('send', 'exception', {
-      exDescription: `${error.toString()}${JSON.stringify(errorInfo)}`,
-      exFatal: true,
-    });
+    try {
+      throw error;
+    } catch (err) {
+      window.ga('send', 'exception', {
+        exDescription: `${error.message}${error.stack}`,
+        exFatal: true,
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION

## Main Changes:
* The last method did not have the stack trace in the Google Analytics logs. So now I'm trying another way to log the error by throwing, catching it and then logging the to GA from the catch block. Seems to work locally.

## Steps To Test:
1. Navigate to the state water quality overview page.
2. Find the "Log React Boundary Exception" button in the element explorer of Chrome dev tools and change `display: none;` to `display: block;`.
3. Click the "Log React Boundary Exception". 
4. Verify the error boundary is displayed and works.

## TODO:
- [ ] Remove the hidden button after confirming the google analytics exception logs still work.