### PR TITLE
Remove the hidden button for testing react error boundaries.

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -864,7 +864,6 @@ function WaterQualityOverview({ ...props }: Props) {
   // unfortunately  need to manage the activeTabIndex (an implementation detail)
   const [activeTabIndex, setActiveTabIndex] = React.useState(initialTabIndex);
 
-  const [testError, setTestError] = React.useState(false);
   if (
     serviceError ||
     waterTypeOptions.status === 'failure' ||
@@ -1136,21 +1135,6 @@ function WaterQualityOverview({ ...props }: Props) {
           </AccordionContent>
         </AccordionItem>
       </Accordions>
-      <button
-        style={{ display: 'none' }}
-        onClick={() => {
-          setTestError(true);
-        }}
-      >
-        Log React Boundary Exception
-      </button>
-      {testError && (
-        <>
-          {tabs.test.mmmmaaaaapppp((item, idx) => {
-            return <p key={idx}>item</p>;
-          })}
-        </>
-      )}
     </Container>
   );
 }


### PR DESCRIPTION
The testing that I did with the last PR worked. I was able to confirm the error boundary displayed and the exceptions were logged to Google Analytics with a full stack trace.

## Main Changes:
* Removed the hidden button for testing the error boundary from the State water quality overview page. 

## Steps To Test:
1. Just verify that all code related to the hidden button was removed.

## TODO:
- [x] Remove the hidden button after confirming the google analytics exception logs still work.

