### PR TITLE
Feature/inline map popups

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -67,8 +67,9 @@ const Icon = styled.i`
 `;
 
 const IconValue = styled.span`
-  display: flex;
-  align-items: center;
+  /* display: flex;
+  align-items: center; */
+  display: inline-block;
 `;
 
 const Table = styled.table`
@@ -156,7 +157,6 @@ function WaterbodyInfo({
       return (
         <p>
           <strong>{label}: </strong>
-          <br />
           {icon ? (
             <IconValue>
               {icon} {value}

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -67,8 +67,6 @@ const Icon = styled.i`
 `;
 
 const IconValue = styled.span`
-  /* display: flex;
-  align-items: center; */
   display: inline-block;
 `;
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3515660

## Main Changes:
* Map popup key/value pairs are now inline

## Steps To Test:
1. Navigate to Community, State, and Waterbody Report maps and verify popup key/values are inline
http://localhost:3000/state/AL/advanced-search
http://localhost:3000/community/boston/overview
http://localhost:3000/waterbody-report/DOEE/DCANA00E_01/2020
