### PR TITLE
Bugfix/advanced search dup watershed issue

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -318,7 +318,7 @@ function AdvancedSearch({ ...props }: Props) {
 
     const { Query, QueryTask } = esriHelper.modules;
     const queryParams = {
-      where: `STATES LIKE '%${activeState.code}%'`,
+      where: `UPPER(STATES) LIKE '%${activeState.code}%' AND STATES <> 'CAN' AND STATES <> 'MEX'`,
       outFields: ['huc12', 'name'],
     };
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3527552

## Main Changes:
* Fixed issue with each watershed in California showing up three times in the watersheds drop down. 
  * The issue was caused by trying to change the where clause using the same Query object. This caused all three queries to use the same list of ObjectIds which is why the watersheds showed up three times. To fix this I updated the code to create a new Query object for each fetch request. 
* Fixed issue with out of country watersheds showing up in the watersheds drop down. The HydrologicUnits map service includes some watersheds that are entirely in Canada (CAN) and Mexico (MEX). The Canadian watersheds got lumped in with California ("CAN" contains "CA") and the Mexican watersheds got lumped in with Maine ("MEX" contains "ME"). 
* Fixed issue with the "Upper Simpson Creek", in Colorado, being ignored. 
  * This watershed was not showing up because the states attribute value was "co" instead of "CO". I updated the query so that it is case insensitive. 

## Steps To Test:
1. Open the Network tab in the Chrome dev tools 
2. Navigate to http://localhost:3000/state/CA/advanced-search
3. Open the watersheds drop down and verify the watersheds are not being duplicated
4. Enter "watersgeo.epa.gov/arcgis/rest/services/Support/HydrologicUnits/MapServer/6/query?f=json&returnIdsOnly=true" in the filter
5. Verify that California does not include Canadian watersheds by verifying the query returns 4460 records instead of 4607
6. Change the state to Maine
7. Verify that Maine does not include Mexican watersheds by verifying the query returns 1044 records instead of 1047
8. Change the state to Colorado
9. Expand the watersheds filter and type "Upper Simpson Creek"
10. Verify that "Upper Simpson Creek" is an available filter option

