### PR TITLE
Feature/state disclaimer spacing

### DIFF
--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -145,6 +145,7 @@ const Disclaimer = styled(DisclaimerModal)`
 
 const ByTheNumbersExplanation = styled.p`
   font-style: italic;
+  padding: 0.5rem 0 0 0;
 `;
 
 // --- components ---


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3527539

## Main Changes:
* Adjust spacing under state metrics so items are evenly spaced vertically

## Steps To Test:
1. Navigate to http://localhost:3000/state/CO/water-quality-overview
2. Verify _Waters not assessed do not show up in summaries below._ text doesn't have large white space below it like the Breeze ticket screenshot does.


Old:
![image](https://user-images.githubusercontent.com/17204883/95250692-74e67700-07e8-11eb-8d79-e004a608f366.png)


New:
![image](https://user-images.githubusercontent.com/17204883/95250736-82036600-07e8-11eb-9402-4f72353e9ba7.png)
