### PR TITLE
Feature/change county layer styles

### DIFF
--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -842,6 +842,18 @@ function useSharedLayers() {
       title: 'County',
       listMode: 'show',
       visible: false,
+      renderer: {
+        type: 'simple',
+        symbol: {
+          type: 'simple-fill',
+          style: 'none',
+          outline: {
+            color: [251, 164, 93, 255],
+            width: 0.75,
+            style: 'solid',
+          },
+        },
+      },
     });
 
     const watershedsLayer = new FeatureLayer({


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3526954

## Main Changes:
* Updated the styles of the county layer to remove the solid fill.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Turn on the "County" layer
3. Verify the layer just has an orange outline and does not have a fill. 
