### PR TITLE
Feature/point outlines

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -183,7 +183,9 @@ export function createWaterbodySymbol({
   selected: boolean,
   geometryType: string,
 }) {
-  const outline = selected ? { color: [0, 255, 255, 0.5], width: 1 } : null;
+  const outline = selected
+    ? { color: [0, 255, 255, 0.5], width: 1 }
+    : { color: [0, 0, 0, 1], width: 1 };
 
   // from colors.highlightedPurple() and colors.purple()
   let color = selected ? { r: 84, g: 188, b: 236 } : { r: 107, g: 65, b: 149 };
@@ -212,6 +214,9 @@ export function createWaterbodySymbol({
   if (geometryType === 'point') {
     if (condition === 'good') {
       symbol.style = 'circle';
+      // symbol.outline = selected
+      //   ? { color: [0, 255, 255, 0.5], width: 1 }
+      //   : { color: 'black', width: 1 };
     }
 
     if (condition === 'polluted') {

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -214,9 +214,6 @@ export function createWaterbodySymbol({
   if (geometryType === 'point') {
     if (condition === 'good') {
       symbol.style = 'circle';
-      // symbol.outline = selected
-      //   ? { color: [0, 255, 255, 0.5], width: 1 }
-      //   : { color: 'black', width: 1 };
     }
 
     if (condition === 'polluted') {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3543984

## Main Changes:
* Added outlines to point geometries to make them easier to see when they are on top of area geometries.

## Steps To Test:
1. Navigate to http://localhost:3000/community/lake%20tahoe/overview
2. Verify the point geometries have an outline that makes them easier to see on the area geometries.
3. Navigate to http://localhost:3000/state/NV/advanced-search
4. Search all waterbodies in Nevada. Pan and zoom into Carson City on the western side of the state. 
5. Verify the State page points have an outline as well.
