### PR TITLE
Feature/update pollutant mapping

### DIFF
--- a/app/client/src/components/pages/Attains/index.js
+++ b/app/client/src/components/pages/Attains/index.js
@@ -91,7 +91,7 @@ function Attains({ ...props }: Props) {
 
   React.useEffect(() => {
     // array of arrays - each containing 3 values: the HMW mapping, the ATTAINS context, and the ATTAINS name
-    // i.e. ["Excess Algae", "ALGAL GROWTH", "EXCESS ALGAL GROWTH"]
+    // i.e. ["Algae", "ALGAL GROWTH", "EXCESS ALGAL GROWTH"]
     let data = [];
     if (attainsData) {
       data = attainsData.map((obj) => {

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -844,7 +844,7 @@ function IdentifiedIssues() {
               <li>
                 Impairments take many forms, often a result of human behavior.
                 Water impairments are identified across 34 categories such as
-                excess algae, mercury, pathogens, pesticides, trash and more.
+                algae, mercury, pathogens, pesticides, trash and more.
               </li>
               <li>
                 Impairments can enter your water through runoff, water discharge

--- a/app/client/src/config/attainsToHmwMapping.js
+++ b/app/client/src/config/attainsToHmwMapping.js
@@ -13,8 +13,8 @@ export const impairmentFields = [
   {
     value: 'algal_growth',
     parameterGroup: 'ALGAL GROWTH',
-    label: 'Excess Algae',
-    term: 'Excess Algae',
+    label: 'Algae',
+    term: 'Algae',
     sentence: null,
   },
   {
@@ -138,8 +138,8 @@ export const impairmentFields = [
   {
     value: 'noxious_aquatic_plants',
     parameterGroup: 'NOXIOUS AQUATIC PLANTS',
-    label: 'Excess Aquatic Weeds',
-    term: 'Excess Aquatic Weeds',
+    label: 'Aquatic Weeds',
+    term: 'Aquatic Weeds',
     sentence: null,
   },
   {
@@ -159,8 +159,8 @@ export const impairmentFields = [
   {
     value: 'nutrients',
     parameterGroup: 'NUTRIENTS',
-    label: 'Nitrogen and Phosphorus',
-    term: 'Nitrogen and Phosphorus',
+    label: 'Nitrogen and/or Phosphorus',
+    term: 'Nitrogen and/or Phosphorus',
     sentence: null,
   },
   {
@@ -233,8 +233,8 @@ export const impairmentFields = [
   {
     value: 'sediment',
     parameterGroup: 'SEDIMENT',
-    label: 'Excess Sediment',
-    term: 'Excess Sediment',
+    label: 'Sediment',
+    term: 'Sediment',
     sentence: null,
   },
   {

--- a/app/server/app/public/data/national/NARS.json
+++ b/app/server/app/public/data/national/NARS.json
@@ -8,7 +8,7 @@
     {
       "metric": "46%",
       "title": "of our rivers and streams have excess nutrients when compared to the worst 5% of the least-disturbed river and stream reference sites",
-      "content": "<p>Nutrients like nitrogen and phosphorus are important, but too much of a good thing can become a bad thing. Excess nutrients can come from fertilizer, wastewater treatment, atmospheric deposition, animal manure, and urban runoff.</p><p>Excess nutrients can lead to algal blooms and fish kills, causing a loss of fishing and recreational opportunities. High levels of nutrients can also threaten drinking water.</p>"
+      "content": "<p>Nutrients like nitrogen and/or phosphorus are important, but too much of a good thing can become a bad thing. Excess nutrients can come from fertilizer, wastewater treatment, atmospheric deposition, animal manure, and urban runoff.</p><p>Excess nutrients can lead to algal blooms and fish kills, causing a loss of fishing and recreational opportunities. High levels of nutrients can also threaten drinking water.</p>"
     },
 
     {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3557158

## Main Changes:
* Update pollutant mappings for Excess Algae, Excess Sediment, Excess Aquatic Weeds, Nitrogen and Phosphorus and hardcoded labels.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/identified-issues
2. Scroll down to **Sediment** in the table.
3. Verify label is updated.

## TODO:
- [ ] Update term names in the HMW Glossary so references aren't broken
![image](https://user-images.githubusercontent.com/17204883/96172044-cc28cd80-0ef3-11eb-9e2b-26e7542d657e.png)

