### PR TITLE
bugfix/state-layer-issue

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -64,7 +64,7 @@ function handleMapZoomChange(newVal: number, target: any) {
       // This issue is caused by esri hiding/unhiding sub layers when the
       // zoom threshould is reached. This esri logic overrides the sublayer
       // visibility setting that is set when the layer is defined.
-      if (layer.id === 'stateBoundariesLayer') {
+      if (layer.id === 'stateBoundariesLayer' && layer?.sublayers) {
         layer.sublayers.forEach((sublayer) => {
           if (sublayer.id === 0) return;
           sublayer.visible = false;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3561185

## Main Changes:
* Fixed issue of app crashing when using a url with a community search.

## Steps To Test:
1. Navigate to http://localhost:3000/community/1952%20Parkersburg%20Tpke,%20Swoope,%20Virginia,%2024479/overview
2. Verify the app does not crash.
3. Toggle the state layer.
4. Zoom out and verify the state layer is visible.
5. Open a waterbody report. Be sure to choose one of the polluted waterbodies at this location, since most of them have associated plans. 
6. Verify the state layer works on the waterbody report page.
7. From the waterbody report page, open one of the associated plans to restore the waterbody.
8. Verify the state layer works on the plan summary page.
9. Navigate to http://localhost:3000/state/AL/advanced-search
10. Perform a search.
11. Verify the state layer works. 
