### PR TITLE
Bugfix/state sublayers being shown

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -54,8 +54,9 @@ function handleMapZoomChange(newVal: number, target: any) {
   target.map.layers.items.forEach((layer) => {
     if (zoomDependentLayers.includes(layer.id)) {
       if (isInScale(layer, target.scale)) {
-        if (layer.id === 'stateBoundariesLayer')
-          layer.listMode = layer.sublayers ? 'hide-children' : 'show';
+        layer.listMode = layer.hasOwnProperty('sublayers')
+          ? 'hide-children'
+          : 'show';
       } else {
         layer.listMode = 'hide';
       }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3561185

## Main Changes:
* Fixed issue with state sub layers being shown in layer list widget. I basically fixed this by making the logic for checking if "sublayers" exists more reliable. The old code did not account sublayers existing on the layer object with a null value.

## Steps To Test:
1. Navigate to http://localhost:3000/community/1952%20Parkersburg%20Tpke,%20Swoope,%20Virginia,%2024479/overview
2. Verify the state layer does not have any sublayers.
3. Navigate to http://localhost:3000/waterbody-report/21VASWCB/VAV-B10R_XDN01A00/2018
4. Verify the state layer does not have any sublayers.
5. Navigate to http://localhost:3000/plan-summary/21VASWCB/9461
6. Verify the state layer does not have any sublayers.
