### PR TITLE
Fixed issue of sublayers being visible.

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -60,17 +60,6 @@ function handleMapZoomChange(newVal: number, target: any) {
       } else {
         layer.listMode = 'hide';
       }
-
-      // Workaround for issue of stateBoundariesLayer showing excluded layers.
-      // This issue is caused by esri hiding/unhiding sub layers when the
-      // zoom threshould is reached. This esri logic overrides the sublayer
-      // visibility setting that is set when the layer is defined.
-      if (layer.id === 'stateBoundariesLayer' && layer?.sublayers) {
-        layer.sublayers.forEach((sublayer) => {
-          if (sublayer.id === 0) return;
-          sublayer.visible = false;
-        });
-      }
     }
   });
 }

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -855,7 +855,7 @@ function useSharedLayers() {
       id: 'stateBoundariesLayer',
       url: services.data.stateBoundaries,
       title: 'State',
-      subLayers: [{ id: 0 }],
+      sublayers: [{ id: 0 }],
       listMode: 'hide',
       visible: false,
     });


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3561185

## Main Changes:
* Fixed issue with state sub layers being shown in layer list widget. I basically fixed this by making the logic for checking if "sublayers" exists more reliable. The old code did not account sublayers existing on the layer object with a null value.

## Steps To Test:
1. Navigate to http://localhost:3000/community/1952%20Parkersburg%20Tpke,%20Swoope,%20Virginia,%2024479/overview
2. Verify the state layer does not have any sublayers.
3. Navigate to http://localhost:3000/waterbody-report/21VASWCB/VAV-B10R_XDN01A00/2018
4. Verify the state layer does not have any sublayers.
5. Navigate to http://localhost:3000/plan-summary/21VASWCB/9461
6. Verify the state layer does not have any sublayers.
