### PR TITLE
feature/bold water type names

### DIFF
--- a/app/client/src/components/pages/State/index.js
+++ b/app/client/src/components/pages/State/index.js
@@ -108,18 +108,18 @@ const Content = styled.div`
     font-size: 1.375em;
   }
 
+  h2,
+  h3 {
+    font-family: ${fonts.primary};
+    font-weight: normal;
+  }
+
   h4 {
     margin-bottom: 0.75rem;
     padding-bottom: 0;
     font-size: 1.125em;
     color: #526571;
-  }
-
-  h2,
-  h3,
-  h4 {
     font-family: ${fonts.primary};
-    font-weight: normal;
   }
 `;
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -622,7 +622,7 @@ function MapWidgets({
       ? 'Upstream Widget Not Available'
       : upstreamLayer.visible
       ? 'Hide Upstream Watershed'
-      : 'Display Upstream Watershed';
+      : 'View Upstream Watershed';
 
     return (
       <div


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3568823
* https://app.breeze.pm/projects/100762/cards/3576454

## Main Changes:
* Bolds the water type names on the state page drinking water section
* Changes label on Upstream map widget to 'View Upstream Watershed'

## Steps To Test:
1. Navigate to Community page
2. Search a location. Hover mouse over the upstream widget and confirm text is changed to View Upstream Watershed
3. Navigate to http://localhost:3000/state/AL/water-quality-overview
4. Open the Drinking Water tab on the State Water Quality Overview page
5. Verify bolding has been added to water type names as described in the screenshots of the Breeze ticket:
![image](https://user-images.githubusercontent.com/17204883/97898648-23a5a680-1d06-11eb-8098-ec78632b780c.png)



