### PR TITLE
Feature/switch to overallstatus

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -277,6 +277,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
       !fetchStatus ||
       !mapView ||
       !actionsLayer ||
+      !homeWidget ||
       fetchStatus === 'fetching'
     ) {
       return;

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -34,108 +34,30 @@ export function getWaterbodyCondition(
   showNulls: boolean = false,
 ) {
   // when no fieldName is provided, use the isassessed/isimpaired logic
-  if (!fieldName) {
-    return attributes.isassessed === 'N'
-      ? waterbodyStatuses.unassessed
-      : attributes.isimpaired === 'Y'
-      ? waterbodyStatuses.polluted
-      : waterbodyStatuses.good;
-  }
+  const statusValue = fieldName
+    ? attributes[fieldName]
+    : attributes.overallstatus;
 
-  if (!attributes[fieldName]) {
+  if (!statusValue) {
     if (showNulls) return waterbodyStatuses.unassessed;
     else return waterbodyStatuses.notApplicable;
-  } else if (attributes[fieldName] === 'Not Supporting') {
+  } else if (statusValue === 'Not Supporting') {
     return waterbodyStatuses.polluted;
-  } else if (attributes[fieldName] === 'Fully Supporting') {
+  } else if (statusValue === 'Fully Supporting') {
     return waterbodyStatuses.good;
-  } else if (attributes[fieldName] === 'Cause') {
+  } else if (statusValue === 'Cause') {
     return waterbodyStatuses.polluted;
-  } else if (attributes[fieldName] === 'Meeting Criteria') {
+  } else if (statusValue === 'Meeting Criteria') {
     return waterbodyStatuses.good;
   } else {
     return waterbodyStatuses.unassessed;
   }
 }
 
-export function createUniqueValueInfos(
-  geometryType: string,
-  attributeName: string = '',
-) {
-  if (attributeName) {
-    return [
-      {
-        value: `Fully Supporting`,
-        symbol: createWaterbodySymbol({
-          condition: 'good',
-          selected: false,
-          geometryType,
-        }),
-      },
-      {
-        value: `Not Supporting`,
-        symbol: createWaterbodySymbol({
-          condition: 'polluted',
-          selected: false,
-          geometryType,
-        }),
-      },
-      {
-        value: `Insufficient Information`,
-        symbol: createWaterbodySymbol({
-          condition: 'unassessed',
-          selected: false,
-          geometryType,
-        }),
-      },
-      {
-        value: `Not Assessed`,
-        symbol: createWaterbodySymbol({
-          condition: 'unassessed',
-          selected: false,
-          geometryType,
-        }),
-      },
-      {
-        value: `Meeting Criteria`,
-        symbol: createWaterbodySymbol({
-          condition: 'good',
-          selected: false,
-          geometryType,
-        }),
-      },
-      {
-        value: `Cause`,
-        symbol: createWaterbodySymbol({
-          condition: 'polluted',
-          selected: false,
-          geometryType,
-        }),
-      },
-
-      // else use the default symbol (community = hiddend and state = unassessed)
-    ];
-  }
-
+export function createUniqueValueInfos(geometryType: string) {
   return [
     {
-      value: `N, N`,
-      symbol: createWaterbodySymbol({
-        condition: 'unassessed',
-        selected: false,
-        geometryType,
-      }),
-    },
-    {
-      value: `N, Y`,
-      symbol: createWaterbodySymbol({
-        condition: 'unassessed',
-        selected: false,
-        geometryType,
-      }),
-    },
-    {
-      value: `Y, N`,
+      value: `Fully Supporting`,
       symbol: createWaterbodySymbol({
         condition: 'good',
         selected: false,
@@ -143,7 +65,39 @@ export function createUniqueValueInfos(
       }),
     },
     {
-      value: `Y, Y`,
+      value: `Not Supporting`,
+      symbol: createWaterbodySymbol({
+        condition: 'polluted',
+        selected: false,
+        geometryType,
+      }),
+    },
+    {
+      value: `Insufficient Information`,
+      symbol: createWaterbodySymbol({
+        condition: 'unassessed',
+        selected: false,
+        geometryType,
+      }),
+    },
+    {
+      value: `Not Assessed`,
+      symbol: createWaterbodySymbol({
+        condition: 'unassessed',
+        selected: false,
+        geometryType,
+      }),
+    },
+    {
+      value: `Meeting Criteria`,
+      symbol: createWaterbodySymbol({
+        condition: 'good',
+        selected: false,
+        geometryType,
+      }),
+    },
+    {
+      value: `Cause`,
       symbol: createWaterbodySymbol({
         condition: 'polluted',
         selected: false,

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -286,8 +286,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
           const linesRenderer = {
             type: 'unique-value',
-            field: 'isassessed',
-            field2: 'isimpaired',
+            field: 'overallstatus',
             fieldDelimiter: ', ',
             defaultSymbol: createWaterbodySymbol({
               condition: 'unassessed',
@@ -343,8 +342,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
           const areasRenderer = {
             type: 'unique-value',
-            field: 'isassessed',
-            field2: 'isimpaired',
+            field: 'overallstatus',
             fieldDelimiter: ', ',
             defaultSymbol: createWaterbodySymbol({
               condition: 'unassessed',
@@ -400,8 +398,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
           const pointsRenderer = {
             type: 'unique-value',
-            field: 'isassessed',
-            field2: 'isimpaired',
+            field: 'overallstatus',
             fieldDelimiter: ', ',
             defaultSymbol: createWaterbodySymbol({
               condition: 'unassessed',

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -413,6 +413,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
 
         const {
           epaIRCategory,
+          overallStatus,
           rationaleText,
           useAttainments,
           parameters,
@@ -422,19 +423,17 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
         setDecisionRationale(rationaleText);
 
         const status = {
-          polluted:
-            ['4A', '4B', '4C', '5', '5A', '5M'].indexOf(epaIRCategory) !== -1,
           planForRestoration: ['4A', '4B', '5A'].indexOf(epaIRCategory) !== -1,
           listed303d: ['5', '5A', '5M'].indexOf(epaIRCategory) !== -1,
-          good: ['1', '2'].indexOf(epaIRCategory) !== -1,
-          unknown: ['3'].indexOf(epaIRCategory) !== -1,
         };
 
-        const condition = status.polluted
-          ? 'Impaired'
-          : status.good
-          ? 'Good'
-          : 'Condition Unknown'; // catch all
+        const condition =
+          overallStatus === 'Not Supporting' || overallStatus === 'Cause'
+            ? 'Impaired'
+            : overallStatus === 'Fully Supporting' ||
+              overallStatus === 'Meeting Criteria'
+            ? 'Good'
+            : 'Condition Unknown'; // catch all
 
         // Use the status above initially. When looping through the use attainments
         // this will be set this to yes if any of the uses have a plan in place

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -105,8 +105,7 @@ function StateMap({
     // Build the feature layers that will make up the waterbody layer
     const pointsRenderer = {
       type: 'unique-value',
-      field: 'isassessed',
-      field2: 'isimpaired',
+      field: 'overallstatus',
       fieldDelimiter: ', ',
       defaultSymbol: createWaterbodySymbol({
         condition: 'unassessed',
@@ -126,8 +125,7 @@ function StateMap({
 
     const linesRenderer = {
       type: 'unique-value',
-      field: 'isassessed',
-      field2: 'isimpaired',
+      field: 'overallstatus',
       fieldDelimiter: ', ',
       defaultSymbol: createWaterbodySymbol({
         condition: 'unassessed',
@@ -147,8 +145,7 @@ function StateMap({
 
     const areasRenderer = {
       type: 'unique-value',
-      field: 'isassessed',
-      field2: 'isimpaired',
+      field: 'overallstatus',
       fieldDelimiter: ', ',
       defaultSymbol: createWaterbodySymbol({
         condition: 'unassessed',

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -147,22 +147,15 @@ function useWaterbodyOnMap(
     (layer, geometryType, attributeName) => {
       const renderer = {
         type: 'unique-value',
+        field: attributeName ? attributeName : 'overallstatus',
         fieldDelimiter: ', ',
         defaultSymbol: createWaterbodySymbol({
           condition: defaultCondition,
           selected: false,
           geometryType,
         }),
-        uniqueValueInfos: createUniqueValueInfos(geometryType, attributeName),
+        uniqueValueInfos: createUniqueValueInfos(geometryType),
       };
-
-      if (attributeName) {
-        renderer.field = attributeName;
-      } else {
-        renderer.field = 'isassessed';
-        renderer.field2 = 'isimpaired';
-      }
-
       layer.renderer = renderer;
 
       // close popup and clear highlights when the renderer changes


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3576825

## Main Changes:
* Fixed a bug that crashes the app when going to http://localhost:3000/waterbody-report/CNENVSER/RC40/2019.
* Updated the waterbody report page to use the "overallStatus", from attains assessments, value for determining the waterbody status. 
* Updated the community and state pages to use the "overallstatus" attribute, instead of the "isassessed" and "isimpaired" attributes.

## Steps To Test:
1. Navigate http://localhost:3000/waterbody-report/CNENVSER/RC40/2019
2. Verify the app does not crash on the "homeWidget" context variable
3. Verify the waterbody status is polluted, instead of unknown
4. Navigate to the community page and do a search
5. Open the same page on https://mywaterway-dev.app.cloud.gov/
6. Verify the waterbody statuses are the same
7. Cycle through the tabs to make sure the waterbody statuses change based on tab
8. Navigate to http://localhost:3000/state/HI/advanced-search
9. Select "Ammonia" under "Parameter Groups"
10. Select "Recreation" under "Use Groups"
11. Click "Search"
12. Verify the statuses match up with https://mywaterway-dev.app.cloud.gov/state/HI/advanced-search
13. Change the "Display Waterbodies by" selection
14. Verify the waterbody statuses change
15. Click the "List" button on the top right of the map
16. Repeat steps 13 and 14
