### PR TITLE
Feature/upstream watershed enhancements

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -451,11 +451,6 @@ export function getPopupTitle(attributes: Object) {
     title = attributes.TRIBE_NAME;
   }
 
-  // upstream watershed
-  else if (attributes.xwalk_huc12) {
-    title = `Currently Selected Huc12: ${attributes.xwalk_huc12}`;
-  }
-
   // want to display allotment for Alaska Native Allotments
   else if (attributes.PARCEL_NO) {
     title = attributes.PARCEL_NO;

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -804,7 +804,6 @@ function MapWidgets({
 
           // zoom out to full extent
           view.goTo(upstreamExtent);
-          // view.map.layers.items.forEach((item) => console.log(item.id));
         })
         .catch((err) => {
           setUpstreamLoading(false);

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -189,6 +189,7 @@ function MapWidgets({
     getUpstreamExtent,
     setUpstreamExtent,
     setErrorMessage,
+    getWatershed,
   } = React.useContext(LocationSearchContext);
 
   const services = useServicesContext();
@@ -423,7 +424,6 @@ function MapWidgets({
     const layerList = [
       'dischargersLayer',
       'monitoringStationsLayer',
-      'upstreamLayer',
       'nonprofitsLayer',
       'providersLayer',
       'waterbodyLayer',
@@ -552,6 +552,7 @@ function MapWidgets({
     setUpstreamWidget(node); // store the widget in context so it can be shown or hidden later
     ReactDOM.render(
       <ShowUpstreamWatershed
+        getWatershed={getWatershed}
         getHuc12={getHuc12}
         getCurrentExtent={getCurrentExtent}
         getUpstreamLayer={getUpstreamLayer}
@@ -570,6 +571,7 @@ function MapWidgets({
     setUpstreamWidget,
     view,
     upstreamWidgetCreated,
+    getWatershed,
     getHuc12,
     getCurrentExtent,
     setUpstreamLayer,
@@ -583,6 +585,7 @@ function MapWidgets({
   ]);
 
   type upstreamProps = {
+    getWatershed: Function,
     getHuc12: Function,
     getCurrentExtent: Function,
     getUpstreamLayer: Function,
@@ -596,6 +599,7 @@ function MapWidgets({
   };
 
   function ShowUpstreamWatershed({
+    getWatershed,
     getHuc12,
     getCurrentExtent,
     getUpstreamLayer,
@@ -632,6 +636,7 @@ function MapWidgets({
         onMouseOut={() => setHover(false)}
         onClick={(ev) => {
           retrieveUpstreamWatershed(
+            getWatershed,
             currentHuc12,
             lastHuc12,
             setLastHuc12,
@@ -665,6 +670,7 @@ function MapWidgets({
 
   const retrieveUpstreamWatershed = React.useCallback(
     (
+      getWatershed,
       currentHuc12,
       lastHuc12,
       setLastHuc12,
@@ -704,6 +710,7 @@ function MapWidgets({
         upstreamLayer.graphics.length > 0
       ) {
         view.goTo(getCurrentExtent());
+        view.popup.close();
         upstreamLayer.visible = false;
         setUpstreamLayerVisible(false);
         setUpstreamLayer(upstreamLayer);
@@ -741,6 +748,8 @@ function MapWidgets({
         .then((res) => {
           setUpstreamLoading(false);
           const upstreamLayer = getUpstreamLayer();
+          const watershed = getWatershed() || 'Unknown Watershed';
+          const upstreamTitle = `Upstream Watershed for Currently Selected Location: ${watershed} (${currentHuc12})`;
 
           if (!res || !res.features || res.features.length === 0) {
             upstreamLayer.error = true;
@@ -773,7 +782,7 @@ function MapWidgets({
               },
               attributes: res.features[0].attributes,
               popupTemplate: {
-                title: getTitle,
+                title: upstreamTitle,
                 content: getTemplate,
                 outfields: ['*'],
               },
@@ -795,6 +804,7 @@ function MapWidgets({
 
           // zoom out to full extent
           view.goTo(upstreamExtent);
+          // view.map.layers.items.forEach((item) => console.log(item.id));
         })
         .catch((err) => {
           setUpstreamLoading(false);
@@ -816,7 +826,7 @@ function MapWidgets({
       Viewpoint,
       Graphic,
       services.data.upstreamWatershed,
-      getTitle,
+      // getTitle,
     ],
   );
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -826,7 +826,6 @@ function MapWidgets({
       Viewpoint,
       Graphic,
       services.data.upstreamWatershed,
-      // getTitle,
     ],
   );
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -552,7 +552,7 @@ function MapWidgets({
     setUpstreamWidget(node); // store the widget in context so it can be shown or hidden later
     ReactDOM.render(
       <ShowUpstreamWatershed
-        getWatershed={getWatershed}
+        getWatershedName={getWatershed}
         getHuc12={getHuc12}
         getCurrentExtent={getCurrentExtent}
         getUpstreamLayer={getUpstreamLayer}
@@ -585,7 +585,7 @@ function MapWidgets({
   ]);
 
   type upstreamProps = {
-    getWatershed: Function,
+    getWatershedName: Function,
     getHuc12: Function,
     getCurrentExtent: Function,
     getUpstreamLayer: Function,
@@ -599,7 +599,7 @@ function MapWidgets({
   };
 
   function ShowUpstreamWatershed({
-    getWatershed,
+    getWatershedName,
     getHuc12,
     getCurrentExtent,
     getUpstreamLayer,
@@ -636,7 +636,7 @@ function MapWidgets({
         onMouseOut={() => setHover(false)}
         onClick={(ev) => {
           retrieveUpstreamWatershed(
-            getWatershed,
+            getWatershedName,
             currentHuc12,
             lastHuc12,
             setLastHuc12,
@@ -670,7 +670,7 @@ function MapWidgets({
 
   const retrieveUpstreamWatershed = React.useCallback(
     (
-      getWatershed,
+      getWatershedName,
       currentHuc12,
       lastHuc12,
       setLastHuc12,
@@ -748,7 +748,7 @@ function MapWidgets({
         .then((res) => {
           setUpstreamLoading(false);
           const upstreamLayer = getUpstreamLayer();
-          const watershed = getWatershed() || 'Unknown Watershed';
+          const watershed = getWatershedName() || 'Unknown Watershed';
           const upstreamTitle = `Upstream Watershed for Currently Selected Location: ${watershed} (${currentHuc12})`;
 
           if (!res || !res.features || res.features.length === 0) {

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -195,7 +195,7 @@ function MapWidgets({
   const services = useServicesContext();
 
   const getDynamicPopup = useDynamicPopup();
-  const { getTitle, getTemplate } = getDynamicPopup();
+  const { getTemplate } = getDynamicPopup();
 
   const {
     getFullscreenActive,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -237,6 +237,9 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     getHuc12: () => {
       return this.state.huc12;
     },
+    getWatershed: () => {
+      return this.state.watershed;
+    },
     getUpstreamLayer: () => {
       return this.state.upstreamLayer;
     },

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -205,6 +205,7 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     monitoringStationsLayer,
     dischargersLayer,
     nonprofitsLayer,
+    upstreamLayer,
     actionsLayer,
     huc12,
   } = React.useContext(LocationSearchContext);
@@ -327,6 +328,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
       layer = monitoringStationsLayer;
     } else if (attributes.type === 'nonprofit') {
       layer = nonprofitsLayer;
+    } else if (attributes.xwalk_huc12) {
+      layer = upstreamLayer;
     }
 
     if (!layer) return;
@@ -409,12 +412,16 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
         });
 
         const requests = [];
-        areasLayer !== 'error' &&
+
+        if (areasLayer && areasLayer !== 'error')
           requests.push(areasLayer.queryFeatures(query));
-        linesLayer !== 'error' &&
+
+        if (linesLayer && linesLayer !== 'error')
           requests.push(linesLayer.queryFeatures(query));
-        pointsLayer !== 'error' &&
+
+        if (pointsLayer && pointsLayer !== 'error')
           requests.push(pointsLayer.queryFeatures(query));
+
         Promise.all(requests).then((responses) => {
           const featuresToCache = [];
           responses.forEach((response) => {
@@ -471,6 +478,7 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     dischargersLayer,
     monitoringStationsLayer,
     nonprofitsLayer,
+    upstreamLayer,
     issuesLayer,
     actionsLayer,
     findOthers,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3582737

## Main Changes:
* We have decided not to adjust the layer order because of how Esri's popups work. We are unable to decide which popup appears first when multiple features are stacked and this causes confusing results when clicking a waterbody on top of the upstream layer.
* Fixes an issue in hooks.js where areasLayer, pointsLayer, or linesLayer could occasionally be null while switching locations and the app would crash,
* Changes the logic for choosing the Upstream Watershed popup title so it can access the watershed and huc12 in the locationSearch context. Popup should look like this now:
![image](https://user-images.githubusercontent.com/17204883/98160848-ce57c980-1eac-11eb-8e24-5d0cbc0984f0.png)


## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Click the Upstream Widget
3. Verify the new popup title includes the current watershed name and HUC12
4. Mouse-over waterbodies on the map and confirm they do not highlight
5. Change locations by clicking in the Upstream layer outside current boundaries and switching location
6. Click Upstream Widget again and verify popup title watershed and HUC12 are updated to new location

Regarding issue where app occasionally crashes when switching locations:
I investigated the problem with Brad Cooper and was unable to reliably reproduce it. It does not seem related to the Upstream Widget code and happens at random. Issue seems to be resolved by checking for null values of the areas, lines, and points layers. I was able to trigger the scenario locally with a fix applied and the app did not crash. 
