### PR TITLE
Feature/fix reporting cycle for tribe data

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -379,15 +379,18 @@ function AdvancedSearch({ ...props }: Props) {
 
   // these lists just have the name and id for faster load time
   const [waterbodiesList, setWaterbodiesList] = React.useState(null);
+  const [lastOrgId, setLastOrgId] = React.useState('');
   // Get the features on the waterbodies point layer
   React.useEffect(() => {
     if (
       activeState.code === '' ||
-      organizationId === '' ||
+      organizationId === lastOrgId ||
       !summaryLayerMaxRecordCount
     ) {
       return;
     }
+
+    setLastOrgId(organizationId);
 
     const { Query, QueryTask } = esriHelper.modules;
 
@@ -476,6 +479,7 @@ function AdvancedSearch({ ...props }: Props) {
     setCurrentReportingCycle,
     services,
     organizationId,
+    lastOrgId,
   ]);
 
   const [waterbodyFilter, setWaterbodyFilter] = React.useState([]);

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -229,6 +229,7 @@ function AdvancedSearch({ ...props }: Props) {
     currentReportingCycle,
     setCurrentReportingCycle,
     activeState,
+    organizationId,
   } = React.useContext(StateTabsContext);
 
   const { fullscreenActive } = React.useContext(FullscreenContext);
@@ -380,7 +381,13 @@ function AdvancedSearch({ ...props }: Props) {
   const [waterbodiesList, setWaterbodiesList] = React.useState(null);
   // Get the features on the waterbodies point layer
   React.useEffect(() => {
-    if (activeState.code === '' || !summaryLayerMaxRecordCount) return;
+    if (
+      activeState.code === '' ||
+      organizationId === '' ||
+      !summaryLayerMaxRecordCount
+    ) {
+      return;
+    }
 
     const { Query, QueryTask } = esriHelper.modules;
 
@@ -388,10 +395,11 @@ function AdvancedSearch({ ...props }: Props) {
     if (!currentFilter) {
       const queryParams = {
         returnGeometry: false,
-        where: `state = '${activeState.code}'`,
+        where: `state = '${activeState.code}' AND organizationid = '${organizationId}'`,
         outFields: [
           'assessmentunitidentifier',
           'assessmentunitname',
+          'orgtype',
           'reportingcycle',
         ],
       };
@@ -467,6 +475,7 @@ function AdvancedSearch({ ...props }: Props) {
     summaryLayerMaxRecordCount,
     setCurrentReportingCycle,
     services,
+    organizationId,
   ]);
 
   const [waterbodyFilter, setWaterbodyFilter] = React.useState([]);

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -257,6 +257,8 @@ function WaterQualityOverview({ ...props }: Props) {
     setCurrentReportStatus,
     setCurrentSummary,
     setUsesStateSummaryServiceError,
+    organizationId,
+    setOrganizationId,
   } = React.useContext(StateTabsContext);
 
   const [loading, setLoading] = React.useState(true);
@@ -274,7 +276,6 @@ function WaterQualityOverview({ ...props }: Props) {
   const [currentTopic, setCurrentTopic] = React.useState('swimming');
   const [waterTypes, setWaterTypes] = React.useState(null);
   const [waterTypeData, setWaterTypeData] = React.useState(null);
-  const [organizationId, setOrganizationId] = React.useState('');
 
   const [surveyData, setSurveyData] = React.useState(null);
   const [assessmentDocuments, setAssessmentDocuments] = React.useState(null);
@@ -530,7 +531,7 @@ function WaterQualityOverview({ ...props }: Props) {
           setLoading(false);
         });
     },
-    [fetchIntroText, fetchSurveyData, services],
+    [fetchIntroText, fetchSurveyData, services, setOrganizationId],
   );
 
   // If the user changes the search

--- a/app/client/src/contexts/StateTabs.js
+++ b/app/client/src/contexts/StateTabs.js
@@ -10,6 +10,7 @@ export const StateTabsContext: Object = React.createContext({
   currentReportingCycle: { status: 'fetching', currentReportingCycle: '' },
   activeState: { code: '', name: '' },
   introText: { status: 'fetching', data: {} },
+  organizationId: '',
 });
 
 type Props = {
@@ -22,6 +23,7 @@ type State = {
   currentReportingCycle: object,
   activeState: { code: string, name: string },
   introText: object,
+  organizationId: string,
 };
 
 export class StateTabsProvider extends React.Component<Props, State> {
@@ -41,6 +43,7 @@ export class StateTabsProvider extends React.Component<Props, State> {
       status: 'fetching',
       data: {},
     },
+    organizationId: '',
     // in case ATTAINS usesStateSummary service returns invalid data or an internal error
     usesStateSummaryServiceError: false,
     setActiveTabIndex: (activeTabIndex: number) => {
@@ -65,6 +68,9 @@ export class StateTabsProvider extends React.Component<Props, State> {
       usesStateSummaryServiceError: boolean,
     ) => {
       this.setState({ usesStateSummaryServiceError });
+    },
+    setOrganizationId: (organizationId: string) => {
+      this.setState({ organizationId });
     },
   };
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3585871

## Main Changes:
* Added organizationid to the query for getting list of waterbodies for the state.

## Steps To Test:
1. In "app\server\app\public\data\config\services-attains.json" change each item under "waterbodyService" to use "inlandwaters.geoplatform.gov" instead of "gispub.epa.gov"
2. Navigate to http://localhost:3000/state/OK/water-quality-overview
3. Verify the state water quality overview tab loads with data
4. Click on the Advanced Search tab
5. Search for "Mud Creek (MUD)" in the "Waterbody Names" drop down box
6. Verify that "Mud Creek (MUD)" is not an option, since it is tribe data

