### PR TITLE
Feature/monitoring microbiological change

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -44,7 +44,7 @@ const switches = [
     groupName: 'Sediment',
   },
   {
-    label: 'Microbiological',
+    label: 'Bacterial',
     groupName: 'Microbiological',
   },
   {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3576782

## Main Changes:
* Changes the Monitoring tab label "Microbiological" to "Bacterial"

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/monitoring
2, Verify Bacterial is displayed instead of Microbiological in the Monitoring tab table for toggling stations
3. Toggle all stations off then toggle just the Bacterial stations on to verify they still show up correctly
