### PR TITLE
Feature/bold waterbody report other parameter headings

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -162,11 +162,11 @@ const ParameterCategory = styled.p`
   font-style: italic;
   font-size: 1em !important;
   color: #526571;
+  font-weight: bold;
 `;
 
 const Parameter = styled.li`
   border-bottom: 1px dotted #eee;
-
   &:last-of-type {
     border-bottom: none;
   }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3576844

## Main Changes:
*Bolds the category headings under the Other Parameters Evaluated section of the Waterbody Report page

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/MDE_EASP/MD-PATMH-Bear_Creek
2. Open the Aquatic and Wild Life accordion under What is this water used for?
3. Verify the "Assessed Good" subheading under "Other Parameters Evaluated" is now bold.

