### PR TITLE
Feature/fix reporting cycle for tribe data

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -229,7 +229,7 @@ function AdvancedSearch({ ...props }: Props) {
     currentReportingCycle,
     setCurrentReportingCycle,
     activeState,
-    organizationId,
+    stateAndOrganization,
   } = React.useContext(StateTabsContext);
 
   const { fullscreenActive } = React.useContext(FullscreenContext);
@@ -379,18 +379,11 @@ function AdvancedSearch({ ...props }: Props) {
 
   // these lists just have the name and id for faster load time
   const [waterbodiesList, setWaterbodiesList] = React.useState(null);
-  const [lastOrgId, setLastOrgId] = React.useState('');
   // Get the features on the waterbodies point layer
   React.useEffect(() => {
-    if (
-      activeState.code === '' ||
-      organizationId === lastOrgId ||
-      !summaryLayerMaxRecordCount
-    ) {
+    if (!stateAndOrganization || !summaryLayerMaxRecordCount) {
       return;
     }
-
-    setLastOrgId(organizationId);
 
     const { Query, QueryTask } = esriHelper.modules;
 
@@ -398,7 +391,7 @@ function AdvancedSearch({ ...props }: Props) {
     if (!currentFilter) {
       const queryParams = {
         returnGeometry: false,
-        where: `state = '${activeState.code}' AND organizationid = '${organizationId}'`,
+        where: `state = '${stateAndOrganization.state}' AND organizationid = '${stateAndOrganization.organizationId}'`,
         outFields: [
           'assessmentunitidentifier',
           'assessmentunitname',
@@ -474,12 +467,10 @@ function AdvancedSearch({ ...props }: Props) {
     esriHelper,
     setWaterbodyData,
     currentFilter,
-    activeState,
     summaryLayerMaxRecordCount,
     setCurrentReportingCycle,
     services,
-    organizationId,
-    lastOrgId,
+    stateAndOrganization,
   ]);
 
   const [waterbodyFilter, setWaterbodyFilter] = React.useState([]);
@@ -605,7 +596,7 @@ function AdvancedSearch({ ...props }: Props) {
     setNewDisplayOptions([defaultDisplayOption]);
     setDisplayOptions([defaultDisplayOption]);
     setSelectedDisplayOption(defaultDisplayOption);
-  }, [activeState, setWaterbodyData, setCurrentReportingCycle]);
+  }, [stateAndOrganization, setWaterbodyData, setCurrentReportingCycle]);
 
   const executeFilter = () => {
     setSearchLoading(true);

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -257,8 +257,8 @@ function WaterQualityOverview({ ...props }: Props) {
     setCurrentReportStatus,
     setCurrentSummary,
     setUsesStateSummaryServiceError,
-    organizationId,
-    setOrganizationId,
+    stateAndOrganization,
+    setStateAndOrganization,
   } = React.useContext(StateTabsContext);
 
   const [loading, setLoading] = React.useState(true);
@@ -360,7 +360,7 @@ function WaterQualityOverview({ ...props }: Props) {
   );
   React.useEffect(() => {
     if (
-      !organizationId ||
+      !stateAndOrganization ||
       currentReportingCycle.status === 'fetching' ||
       usesStateSummaryCalled
     ) {
@@ -384,7 +384,7 @@ function WaterQualityOverview({ ...props }: Props) {
 
     const url =
       `${services.data.attains.serviceUrl}usesStateSummary` +
-      `?organizationId=${organizationId}` +
+      `?organizationId=${stateAndOrganization.organizationId}` +
       reportingCycleParam;
 
     fetchCheck(url)
@@ -426,7 +426,10 @@ function WaterQualityOverview({ ...props }: Props) {
         }
         setLoading(false);
 
-        fetchAssessments(organizationId, latestReportingCycle);
+        fetchAssessments(
+          stateAndOrganization.organizationId,
+          latestReportingCycle,
+        );
       })
       .catch((err) => {
         console.error('Error with attains summary web service: ', err);
@@ -450,7 +453,7 @@ function WaterQualityOverview({ ...props }: Props) {
     fetchAssessments,
     setCurrentSummary,
     setUsesStateSummaryServiceError,
-    organizationId,
+    stateAndOrganization,
     currentReportingCycle,
     setCurrentReportingCycle,
     usesStateSummaryCalled,
@@ -511,7 +514,10 @@ function WaterQualityOverview({ ...props }: Props) {
 
           // go to the next step if an org id was found, otherwise flag an error
           if (orgID) {
-            setOrganizationId(orgID);
+            setStateAndOrganization({
+              state: activeState.code,
+              organizationId: orgID,
+            });
             fetchIntroText(orgID);
             fetchSurveyData(orgID);
           } else {
@@ -531,7 +537,13 @@ function WaterQualityOverview({ ...props }: Props) {
           setLoading(false);
         });
     },
-    [fetchIntroText, fetchSurveyData, services, setOrganizationId],
+    [
+      fetchIntroText,
+      fetchSurveyData,
+      services,
+      setStateAndOrganization,
+      activeState,
+    ],
   );
 
   // If the user changes the search
@@ -995,7 +1007,7 @@ function WaterQualityOverview({ ...props }: Props) {
                   ) : (
                     <SurveyResults
                       loading={surveyLoading}
-                      organizationId={organizationId}
+                      organizationId={stateAndOrganization.organizationId}
                       activeState={activeState}
                       subPopulationCodes={subPopulationCodes}
                       surveyData={surveyData}

--- a/app/client/src/contexts/StateTabs.js
+++ b/app/client/src/contexts/StateTabs.js
@@ -10,7 +10,7 @@ export const StateTabsContext: Object = React.createContext({
   currentReportingCycle: { status: 'fetching', currentReportingCycle: '' },
   activeState: { code: '', name: '' },
   introText: { status: 'fetching', data: {} },
-  organizationId: '',
+  stateAndOrganizationId: null,
 });
 
 type Props = {
@@ -23,7 +23,7 @@ type State = {
   currentReportingCycle: object,
   activeState: { code: string, name: string },
   introText: object,
-  organizationId: string,
+  stateAndOrganization: object,
 };
 
 export class StateTabsProvider extends React.Component<Props, State> {
@@ -43,7 +43,7 @@ export class StateTabsProvider extends React.Component<Props, State> {
       status: 'fetching',
       data: {},
     },
-    organizationId: '',
+    stateAndOrganization: null,
     // in case ATTAINS usesStateSummary service returns invalid data or an internal error
     usesStateSummaryServiceError: false,
     setActiveTabIndex: (activeTabIndex: number) => {
@@ -69,8 +69,8 @@ export class StateTabsProvider extends React.Component<Props, State> {
     ) => {
       this.setState({ usesStateSummaryServiceError });
     },
-    setOrganizationId: (organizationId: string) => {
-      this.setState({ organizationId });
+    setStateAndOrganization: (stateAndOrganization: object) => {
+      this.setState({ stateAndOrganization });
     },
   };
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3585871

## Main Changes:
* Added organizationid to the query for getting list of waterbodies for the state.

## Steps To Test:
1. In "app\server\app\public\data\config\services-attains.json" change each item under "waterbodyService" to use "inlandwaters.geoplatform.gov" instead of "gispub.epa.gov"
2. Navigate to http://localhost:3000/state/OK/water-quality-overview
3. Verify the state water quality overview tab loads with data
4. Click on the Advanced Search tab
5. Search for "Mud Creek (MUD)" in the "Waterbody Names" drop down box
6. Verify that "Mud Creek (MUD)" is not an option, since it is tribe data
7. Search and select "111303030602" the huc in the "Watershed Names" drop down box
8. Click "Search" 
9. Verify the map loads
