### PR TITLE
Feature/display community errors on mobile

### DIFF
--- a/app/client/src/components/pages/Community/index.js
+++ b/app/client/src/components/pages/Community/index.js
@@ -11,6 +11,7 @@ import TabLinks from 'components/shared/TabLinks';
 import LocationSearch from 'components/shared/LocationSearch';
 import LocationMap from 'components/pages/LocationMap';
 import MapVisibilityButton from 'components/shared/MapVisibilityButton';
+import { StyledErrorBox } from 'components/shared/MessageBoxes';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
 import {
@@ -60,6 +61,10 @@ const RightColumn = styled.div`
   }
 `;
 
+const ErrorBox = styled(StyledErrorBox)`
+  margin-bottom: 1em;
+`;
+
 // --- components ---
 type Props = {
   children: Node,
@@ -101,7 +106,8 @@ function Community({ children, ...props }: Props) {
   const {
     resetData,
     setSearchText,
-    setLastSearchText, //
+    setLastSearchText,
+    errorMessage,
   } = React.useContext(LocationSearchContext);
   React.useEffect(() => {
     return function cleanup() {
@@ -166,6 +172,7 @@ function Community({ children, ...props }: Props) {
             return (
               <Columns data-content="community">
                 <LeftColumn data-column="left">
+                  {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
                   {searchMarkup}
                   <RightColumn data-column="right">
                     {/* children is either CommunityIntro or CommunityTabs (upper tabs) */}
@@ -195,6 +202,7 @@ function Community({ children, ...props }: Props) {
             return (
               <Columns data-content="community">
                 <LeftColumn data-column="left">
+                  {errorMessage && <ErrorBox>{errorMessage}</ErrorBox>}
                   <LocationMap windowHeight={height} layout="wide">
                     {searchMarkup}
                   </LocationMap>

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -16,7 +16,6 @@ import {
   getPopupContent,
   getPopupTitle,
 } from 'components/pages/LocationMap/MapFunctions';
-import { StyledErrorBox } from 'components/shared/MessageBoxes';
 import MapErrorBoundary from 'components/shared/ErrorBoundary/MapErrorBoundary';
 // contexts
 import { EsriModulesContext } from 'contexts/EsriModules';
@@ -54,10 +53,6 @@ const Container = styled.div`
   position: relative;
   border: 1px solid #aebac3;
   background-color: #fff;
-`;
-
-const ErrorBox = styled(StyledErrorBox)`
-  margin-bottom: 1em;
 `;
 
 // --- components ---
@@ -141,7 +136,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setPointsLayer,
     setLinesLayer,
     setAreasLayer,
-    errorMessage,
     setErrorMessage,
   } = React.useContext(LocationSearchContext);
 
@@ -1300,12 +1294,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   // jsx
   const mapContent = (
     <>
-      {errorMessage && layout !== 'fullscreen' && (
-        <ErrorBox>
-          <p>{errorMessage}</p>
-        </ErrorBox>
-      )}
-
       {/* for wide screens, LocationMap's children is searchText */}
       <div ref={measuredRef}>{children}</div>
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3567286

## Main Changes:
* Moves the Community error message box out of the LocationMap component and into the Community component itself
* The LocationMap component is hidden by default on small screens so displaying the error message there caused it to be hidden on small screens

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Change screen size to the narrow format
3. Search an invalid location like "218i47219847982471892472914912"
4. Error message should be displayed above the search bar
5. Change screen size to wide format and verify error message is still displayed
