### PR TITLE
Revert "Feature/monitoring microbiological change"

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -44,7 +44,7 @@ const switches = [
     groupName: 'Sediment',
   },
   {
-    label: 'Bacterial',
+    label: 'Microbiological',
     groupName: 'Microbiological',
   },
   {


### PR DESCRIPTION
Reverts Eastern-Research-Group/mywaterway#309

@cschwinderg Sorry for the confusion, I meant to cancel this PR. This ticket is on hold for now. Next week Brad will ask the team how this change should be made because it would set a precedent for the other categories we are re-labelling and if we should re-label them in the actual Monitoring station tables:

Metals -> Major, Inorganic, Metals,
Bacterial -> Microbiological
and so on.