### PR TITLE
Feature/fix reporting cycle for tribe data

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -230,6 +230,7 @@ function AdvancedSearch({ ...props }: Props) {
     setCurrentReportingCycle,
     activeState,
     stateAndOrganization,
+    setStateAndOrganization,
   } = React.useContext(StateTabsContext);
 
   const { fullscreenActive } = React.useContext(FullscreenContext);
@@ -576,6 +577,7 @@ function AdvancedSearch({ ...props }: Props) {
     setWaterbodyData(null);
     setWaterbodiesList(null);
     setNumberOfRecords(null);
+    setStateAndOrganization(null);
     setCurrentReportingCycle({
       status: 'fetching',
       reportingCycle: '',
@@ -596,7 +598,12 @@ function AdvancedSearch({ ...props }: Props) {
     setNewDisplayOptions([defaultDisplayOption]);
     setDisplayOptions([defaultDisplayOption]);
     setSelectedDisplayOption(defaultDisplayOption);
-  }, [stateAndOrganization, setWaterbodyData, setCurrentReportingCycle]);
+  }, [
+    activeState,
+    setWaterbodyData,
+    setCurrentReportingCycle,
+    setStateAndOrganization,
+  ]);
 
   const executeFilter = () => {
     setSearchLoading(true);

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -583,6 +583,7 @@ function AdvancedSearch({ ...props }: Props) {
       reportingCycle: '',
     });
 
+    console.log('clear stuff...');
     // Reset the filters
     setCurrentFilter(null);
     setWaterbodyFilter([]);
@@ -654,9 +655,9 @@ function AdvancedSearch({ ...props }: Props) {
 
   // build esri where clause
   const executeFilterWrapped = (watershedResults: Object) => {
-    if (activeState.code === '') return;
+    if (activeState.code === '' || !stateAndOrganization) return;
 
-    let newFilter = `state = '${activeState.code}'`;
+    let newFilter = `state = '${activeState.code}' AND organizationid = '${stateAndOrganization.organizationId}'`;
 
     // radio button filters
     if (waterTypeFilter === '303d') {

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -611,17 +611,19 @@ function AdvancedSearch({ ...props }: Props) {
 
     // waterbody and watershed filter
     const requests = [];
-    watershedFilter.forEach((watershed) => {
-      // Fire off requests for any watersheds that we don't already have data for
-      if (!watershedResults.hasOwnProperty(watershed.value)) {
-        // run a fetch to get the assessments in the huc
-        requests.push(
-          fetchCheck(
-            `${services.data.attains.serviceUrl}huc12summary?huc=${watershed.value}`,
-          ),
-        );
-      }
-    });
+    if (watershedFilter) {
+      watershedFilter.forEach((watershed) => {
+        // Fire off requests for any watersheds that we don't already have data for
+        if (!watershedResults.hasOwnProperty(watershed.value)) {
+          // run a fetch to get the assessments in the huc
+          requests.push(
+            fetchCheck(
+              `${services.data.attains.serviceUrl}huc12summary?huc=${watershed.value}`,
+            ),
+          );
+        }
+      });
+    }
 
     // If we have data for everything then execute the filter, otherwise parse the requests
     if (requests.length === 0) {

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -583,7 +583,6 @@ function AdvancedSearch({ ...props }: Props) {
       reportingCycle: '',
     });
 
-    console.log('clear stuff...');
     // Reset the filters
     setCurrentFilter(null);
     setWaterbodyFilter([]);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3585871

## Main Changes:
* Fixed an unintended side affect of previous changes. Basically, the stateAndOrganization value was not being reset before, which broke the state water quality overview tab.
* Fixed an issue where tribe data would still be displayed on the map, if the user selects a huc with tribe data.
* Fixed an issue where clearing the watershed filter and clicking search would crash the app.

## Steps To Test:
1. In "app\server\app\public\data\config\services-attains.json" change each item under "waterbodyService" to use "inlandwaters.geoplatform.gov" instead of "gispub.epa.gov"
2. Navigate to http://localhost:3000/state/OK/water-quality-overview
3. Verify the state water quality overview tab loads with data
4. Click on the Advanced Search tab
5. Search for "Mud Creek (MUD)" in the "Waterbody Names" drop down box
6. Verify that "Mud Creek (MUD)" is not an option, since it is tribe data
7. Search and select "111303030602" the huc in the "Watershed Names" drop down box
8. Click "Search" 
9. Verify only 6 waterbodies are found
10. Verify the map loads with 6 waterbodies
11. Clear the "Watershed Names" filter
12. Click Search
13. Verify the app does not crash and the map loads
14. Click on the "State Water Quality Overview" tab
15. Verify the pie chart loads
16. Switch to a different state, like Alabama that has swimming data
17. Verify the pie chart loads
18. Repeat steps 12 and 13 several times, using different states. Keep in mind that some states, like Florida, don't have data to display on the swimming tab
