### PR TITLE
Feature/upstream watershed highlight outline

### DIFF
--- a/app/client/src/components/shared/MapMouseEvents/index.js
+++ b/app/client/src/components/shared/MapMouseEvents/index.js
@@ -196,6 +196,13 @@ function MapMouseEvents({ map, view }: Props) {
       ) {
         loadMonitoringLocation(graphic, services);
       }
+
+      // set the view highlight options to 0 fill opacity if upstream watershed is selected
+      if (graphic?.layer?.id === 'upstreamWatershed') {
+        view.highlightOptions.fillOpacity = 0;
+      } else {
+        view.highlightOptions.fillOpacity = 1;
+      }
     });
 
     // auto expands the popup when it is first opened

--- a/app/client/src/components/shared/MapMouseEvents/index.js
+++ b/app/client/src/components/shared/MapMouseEvents/index.js
@@ -59,7 +59,6 @@ function MapMouseEvents({ map, view }: Props) {
             // set the view highlight options to 0 fill opacity
             if (graphic.layer.id === 'upstreamWatershed') {
               view.highlightOptions.fillOpacity = 0;
-              console.log('setting upstream selected to true');
             } else {
               view.highlightOptions.fillOpacity = 1;
             }

--- a/app/client/src/components/shared/MapMouseEvents/index.js
+++ b/app/client/src/components/shared/MapMouseEvents/index.js
@@ -54,9 +54,9 @@ function MapMouseEvents({ map, view }: Props) {
           // get and update the selected graphic
           const graphic = getGraphicFromResponse(res);
 
-          // if upstream watershed is clicked:
-          // set the view highlight options to 0 fill opacity
           if (graphic && graphic.attributes) {
+            // if upstream watershed is clicked:
+            // set the view highlight options to 0 fill opacity
             if (graphic.layer.id === 'upstreamWatershed') {
               view.highlightOptions.fillOpacity = 0;
               console.log('setting upstream selected to true');

--- a/app/client/src/components/shared/MapMouseEvents/index.js
+++ b/app/client/src/components/shared/MapMouseEvents/index.js
@@ -53,7 +53,17 @@ function MapMouseEvents({ map, view }: Props) {
         .then((res) => {
           // get and update the selected graphic
           const graphic = getGraphicFromResponse(res);
+
+          // if upstream watershed is clicked:
+          // set the view highlight options to 0 fill opacity
           if (graphic && graphic.attributes) {
+            if (graphic.layer.id === 'upstreamWatershed') {
+              view.highlightOptions.fillOpacity = 0;
+              console.log('setting upstream selected to true');
+            } else {
+              view.highlightOptions.fillOpacity = 1;
+            }
+
             setSelectedGraphic(graphic);
           } else {
             setSelectedGraphic('');
@@ -146,6 +156,16 @@ function MapMouseEvents({ map, view }: Props) {
 
           // get the graphic from the hittest
           let feature = getGraphicFromResponse(res);
+
+          // if any feature besides the upstream watershed is moused over:
+          // set the view's highlight fill opacity back to 1
+          if (
+            feature?.layer?.id !== 'upstreamWatershed' &&
+            view.highlightOptions.fillOpacity !== 1 &&
+            !view.popup.visible // if popup is not visible then the upstream layer isn't currently selected
+          ) {
+            view.highlightOptions.fillOpacity = 1;
+          }
 
           // ensure the graphic actually changed prior to setting the context variable
           const equal = graphicComparison(feature, lastFeature);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3586501

## Main Changes:
* The map click and hover events now check if the graphic is part of the Upstream Watershed layer and modify the fillOpacity in the highlightOptions of the view to 0 or 1. 
* If the Upstream layer is clicked the fillOpacity becomes 0 so that only the outline is highlighted for the Upstream layer:
![image](https://user-images.githubusercontent.com/17204883/98418424-e23c3080-2050-11eb-8589-0d7dc385ea03.png)
* When a different graphic is clicked or moused over the fillOpacity changes back to 1.
* The issue with this feature is the highlightOptions are global and not layer-specific. If a user mouses over a waterbody while the Upstream Layer is selected - the highlight on the waterbody will also have a fillOpacity of 0. The same issue occurs when a user clicks a waterbody under the Upstream Watershed with the Upstream Watershed displayed and then tabs through the popups to select the waterbody underneath. When the Upstream Watershed is not selected the highlights behave normally with full opacity.

@cschwinderg if you have any ideas about implementing this let me know. The only way around the global highlight options issue that I can think of is instead of using Esri's highlight features - we draw our own custom highlight graphics on top of graphics when they are clicked or moused over. This would likely cause other problems with the app.

## Steps To Test:
1. Navigate to http://localhost:3000/community/080701000104/overview
2. Turn on the Upstream Widget
3. Click inside the Upstream Watershed boundaries
4. Verify the highlight is only on the outline and has no fill.
5. Click a waterbody outside of the Upstream Watershed.
6. Verify the highlight has a fill.

