### PR TITLE
Bugfix/hidden waterbodies displayed as triangles

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -154,7 +154,6 @@ export function createWaterbodySymbol({
 
   // for polygons, add transparency to the color so that lines can be seen
   if (geometryType === 'polygon') color.a = 0.75;
-  if (condition === 'hidden') color.a = 0; //handle the identified issues panel
 
   let symbol = {
     type: 'simple-marker', // autocasts as new SimpleMarkerSymbol()
@@ -164,6 +163,12 @@ export function createWaterbodySymbol({
     outline,
     condition,
   };
+
+  if (condition === 'hidden') {
+    symbol.outline = { color: [0, 0, 0, 0], width: 0 };
+    symbol.color = [0, 0, 0, 0];
+    return symbol;
+  }
 
   if (geometryType === 'point') {
     if (condition === 'good') {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3576770

## Main Changes:
* Recently we noticed some issues with hidden waterbodies while testing the inlandwaters services. This led us to find similar issues on the production site.
* On the production site users are able to click waterbodies on the map that should be hidden. Navigate here and click the lake on the right side of the boundaries to reproduce: https://mywaterway.epa.gov/community/101500031602/eating-fish
* On the Tribes site where inlandwaters services are used - we see triangles rendered as waterbodies that should be hidden. Note that they do not appear in the waterbody list in the tabs because they should be hidden altogether. Their use value is null.  https://mywaterway-tribes.app.cloud.gov/community/111303030602/eating-fish


Service response for 111303030602: ![image](https://user-images.githubusercontent.com/17204883/98716238-3a2cad00-2359-11eb-9048-2c19b463c537.png)


I've updated the logic for rendering waterbodies with a condition of 'hidden' that resolves these problems by returning a completely blank symbol that can't be clicked instead of a triangle with no color. 

## Steps To Test:
Replace the gispub urls with the inlandwaters services like so:
In **services.json**
`  "waterbodyService": {
    "points": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/0",
    "lines": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1",
    "areas": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/2",
    "summary": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
  },`
1. Navigate to http://localhost:3000/community/101500031602/eating-fish
2. Click on the dark lake on the right side of the map. You can view its exact location by switching to the Overview tab.
3. Verify no popup appears and it is not highlighted.
4. Navigate to http://localhost:3000/community/111303030602/eating-fish
5. Verify no triangles are rendered on the map. Verify only the waterbodies shown in the tab list views are displayed on the map.
6. Test out other pages and tabs to make sure nothing is broken. 

If you think this logic change could cause issues on the state page because the same code is user elsewhere let me know and we can discuss.


Useful testing locations:
https://mywaterway-tribes.app.cloud.gov/community/101500031602/eating-fish
https://mywaterway-tribes.app.cloud.gov/community/111303030602/eating-fish