### PR TITLE
Feature/color waterbody report features

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -174,41 +174,41 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
               let color = { r: 0, g: 123, b: 255 };
               if (type === 'polygon') color.a = 0.75;
 
-              let symbol;
+              let planSummarySymbol;
               if (type === 'point') {
-                symbol = new SimpleMarkerSymbol({
+                planSummarySymbol = new SimpleMarkerSymbol({
                   color,
                   style: 'circle',
                 });
               }
               if (type === 'polyline') {
-                symbol = new SimpleLineSymbol({
+                planSummarySymbol = new SimpleLineSymbol({
                   color,
                   style: 'solid',
                   width: '2',
                 });
               }
               if (type === 'polygon') {
-                symbol = new SimpleFillSymbol({
+                planSummarySymbol = new SimpleFillSymbol({
                   color,
                   style: 'solid',
                 });
               }
 
-              return symbol;
+              return planSummarySymbol;
             }
 
             // handle Waterbody Report page
             const condition = getWaterbodyCondition(feature.attributes)
               .condition;
 
-            const symbol = createWaterbodySymbol({
+            const waterbodyReportSymbol = createWaterbodySymbol({
               condition: condition,
               selected: false,
               geometryType: type,
             });
 
-            return symbol;
+            return waterbodyReportSymbol;
           }
 
           function createGraphic(feature: Object, type: string) {

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -164,24 +164,64 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             return;
           }
 
+          function getWaterbodyColor(feature: Object, type: string) {
+            // handle Actions page
+            if (window.location.pathname.includes('/plan-summary')) {
+              if (type === 'area') return [0, 123, 255, 0.75];
+              return [0, 123, 255];
+            }
+
+            // handle Waterbody Report page
+            const overallStatus = feature?.attributes?.overallstatus;
+            const condition =
+              overallStatus === 'Not Supporting' || overallStatus === 'Cause'
+                ? 'Impaired'
+                : overallStatus === 'Fully Supporting' ||
+                  overallStatus === 'Meeting Criteria'
+                ? 'Good'
+                : 'Condition Unknown'; // catch all
+
+            const formattedCondition =
+              condition === 'Good'
+                ? 'good'
+                : condition === 'Impaired'
+                ? 'polluted'
+                : 'unassessed';
+
+            let color = { r: 107, g: 65, b: 149 }; // purple
+            if (formattedCondition === 'good') {
+              color = { r: 32, g: 128, b: 12 }; // green
+            }
+            if (formattedCondition === 'polluted') {
+              color = { r: 203, g: 34, b: 62 }; // red
+            }
+
+            // add transparency for area features
+            if (type === 'area') color.a = 0.75;
+
+            return color;
+          }
+
           function createGraphic(feature: Object, type: string) {
+            const color = getWaterbodyColor(feature, type);
+
             let symbol;
             if (type === 'point') {
               symbol = new SimpleMarkerSymbol({
-                color: [0, 123, 255],
+                color,
                 style: 'circle',
               });
             }
             if (type === 'line') {
               symbol = new SimpleLineSymbol({
-                color: [0, 123, 255],
+                color,
                 style: 'solid',
                 width: '2',
               });
             }
             if (type === 'area') {
               symbol = new SimpleFillSymbol({
-                color: [0, 123, 255, 0.5],
+                color,
                 style: 'solid',
               });
             }

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -6,7 +6,10 @@ import MapLoadingSpinner from 'components/shared/MapLoadingSpinner';
 import MapWidgets from 'components/shared/MapWidgets';
 import MapMouseEvents from 'components/shared/MapMouseEvents';
 import MapErrorBoundary from 'components/shared/ErrorBoundary/MapErrorBoundary';
-import { createWaterbodySymbol } from 'components/pages/LocationMap/MapFunctions';
+import {
+  createWaterbodySymbol,
+  getWaterbodyCondition,
+} from 'components/pages/LocationMap/MapFunctions';
 // styled components
 import { StyledErrorBox, StyledInfoBox } from 'components/shared/MessageBoxes';
 // contexts
@@ -196,15 +199,8 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             }
 
             // handle Waterbody Report page
-            const overallStatus = feature?.attributes?.overallstatus;
-
-            const condition =
-              overallStatus === 'Not Supporting' || overallStatus === 'Cause'
-                ? 'polluted'
-                : overallStatus === 'Fully Supporting' ||
-                  overallStatus === 'Meeting Criteria'
-                ? 'good'
-                : 'unassessed'; // catch all
+            const condition = getWaterbodyCondition(feature.attributes)
+              .condition;
 
             const symbol = createWaterbodySymbol({
               condition: condition,

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -173,26 +173,18 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
 
             // handle Waterbody Report page
             const overallStatus = feature?.attributes?.overallstatus;
-            const condition =
-              overallStatus === 'Not Supporting' || overallStatus === 'Cause'
-                ? 'Impaired'
-                : overallStatus === 'Fully Supporting' ||
-                  overallStatus === 'Meeting Criteria'
-                ? 'Good'
-                : 'Condition Unknown'; // catch all
-
-            const formattedCondition =
-              condition === 'Good'
-                ? 'good'
-                : condition === 'Impaired'
-                ? 'polluted'
-                : 'unassessed';
 
             let color = { r: 107, g: 65, b: 149 }; // purple
-            if (formattedCondition === 'good') {
+            if (
+              overallStatus === 'Fully Supporting' ||
+              overallStatus === 'Meeting Criteria'
+            ) {
               color = { r: 32, g: 128, b: 12 }; // green
             }
-            if (formattedCondition === 'polluted') {
+            if (
+              overallStatus === 'Not Supporting' ||
+              overallStatus === 'Cause'
+            ) {
               color = { r: 203, g: 34, b: 62 }; // red
             }
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3586354

## Main Changes:
* Adds logic to the ActionsMap component to use color for waterbodies on the Waterbody Report page based on their Overall Status

## Steps To Test:
1. Navigate to the following locations and verify the icon next to the waterbody name at the top of the page matches the color on the map:
* Good: http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205-Northeast_Northwest_Branches/2018
* Polluted: http://localhost:3000/waterbody-report/DOEE/DCANA00E_02/2020
* Condition Unknown: http://localhost:3000/waterbody-report/MA_DEP/MA72010/2014

2. Verify the Plan Summary page is unaffected by these changes: http://localhost:3000/plan-summary/MA_DEP/R1_MA_2019_01