### PR TITLE
Feature/organization labels on waterbody IDs

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -34,6 +34,8 @@ import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { fetchCheck } from 'utils/fetchUtils';
 import { chunkArray } from 'utils/utils';
+// utilities
+import { getOrganizationLabel } from 'components/pages/LocationMap/MapFunctions';
 // styles
 import { colors } from 'styles/index.js';
 // errors
@@ -689,7 +691,13 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                                     {assessmentUnitName || 'Name not provided'}
                                   </strong>
                                 }
-                                subTitle={`ID: ${assessmentUnitIdentifier}`}
+                                subTitle={`${
+                                  waterbodyData?.attributes
+                                    ? getOrganizationLabel(
+                                        waterbodyData.attributes,
+                                      )
+                                    : ''
+                                } ID: ${assessmentUnitIdentifier}`}
                               >
                                 <AccordionContent>
                                   {unitIds[assessmentUnitIdentifier] &&

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -370,6 +370,24 @@ export const openPopup = (view: Object, feature: Object, services: Object) => {
   });
 };
 
+// map District and Territory organization IDs to their labels
+const organizationMapping = {
+  DOEE: 'District',
+  PR_LAKES: 'Territory',
+  USVIST: 'Territory',
+  '21AQ': 'Territory',
+  '21AS': 'Territory',
+  '21GUAM': 'Territory',
+};
+
+export function getOrganizationLabel(attributes: Object) {
+  const mappedLabel = organizationMapping[attributes.organizationid];
+  if (mappedLabel) return `${mappedLabel}`;
+  if (attributes.orgtype === 'Tribe') return 'Tribe';
+  if (attributes.orgtype === 'State') return 'State';
+  return ''; // catch all
+}
+
 export function getPopupTitle(attributes: Object) {
   let title = 'Unknown';
 
@@ -377,7 +395,9 @@ export function getPopupTitle(attributes: Object) {
 
   // line, area, point for waterbody
   if (attributes.assessmentunitname) {
-    title = `${attributes.assessmentunitname} (${attributes.assessmentunitidentifier})`;
+    title = `${attributes.assessmentunitname} (${getOrganizationLabel(
+      attributes,
+    )} ID: ${attributes.assessmentunitidentifier})`;
   }
 
   // discharger

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -381,6 +381,8 @@ const organizationMapping = {
 };
 
 export function getOrganizationLabel(attributes: Object) {
+  if (!attributes) return '';
+
   const mappedLabel = organizationMapping[attributes.organizationid];
   if (mappedLabel) return mappedLabel;
   if (attributes.orgtype === 'Tribe') return 'Tribe';

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -382,7 +382,7 @@ const organizationMapping = {
 
 export function getOrganizationLabel(attributes: Object) {
   const mappedLabel = organizationMapping[attributes.organizationid];
-  if (mappedLabel) return `${mappedLabel}`;
+  if (mappedLabel) return mappedLabel;
   if (attributes.orgtype === 'Tribe') return 'Tribe';
   if (attributes.orgtype === 'State') return 'State';
   return ''; // catch all

--- a/app/client/src/components/pages/State/components/WaterbodyList.js
+++ b/app/client/src/components/pages/State/components/WaterbodyList.js
@@ -20,6 +20,7 @@ import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import {
   getTypeFromAttributes,
   getWaterbodyCondition,
+  getOrganizationLabel,
 } from 'components/pages/LocationMap/MapFunctions';
 // contexts
 import { MapHighlightContext } from 'contexts/MapHighlight';
@@ -224,7 +225,9 @@ function WaterbodyItems({ sortedWaterbodies, allExpanded, fieldName }) {
               graphic.attributes.assessmentunitidentifier
             }
             title={<strong>{graphic.attributes.assessmentunitname}</strong>}
-            subTitle={`ID: ${graphic.attributes.assessmentunitidentifier}`}
+            subTitle={`${getOrganizationLabel(graphic.attributes)} ID: ${
+              graphic.attributes.assessmentunitidentifier
+            }`}
             icon={<WaterbodyIcon condition={condition} selected={false} />}
             feature={graphic}
             idKey={'assessmentunitidentifier'}

--- a/app/client/src/components/shared/WaterbodyList/index.js
+++ b/app/client/src/components/shared/WaterbodyList/index.js
@@ -17,6 +17,7 @@ import {
   createWaterbodySymbol,
   getWaterbodyCondition,
   getUniqueWaterbodies,
+  getOrganizationLabel,
 } from 'components/pages/LocationMap/MapFunctions';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
@@ -132,7 +133,9 @@ function WaterbodyList({
             <AccordionItem
               key={index}
               title={<strong>{graphic.attributes.assessmentunitname}</strong>}
-              subTitle={`ID: ${graphic.attributes.assessmentunitidentifier}`}
+              subTitle={`${getOrganizationLabel(graphic.attributes)} ID: ${
+                graphic.attributes.assessmentunitidentifier
+              }`}
               icon={<WaterbodyIcon condition={condition} selected={false} />}
               mapIcon={icon}
               feature={graphic}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3576846

## Main Changes:
* Adds a label next to the IDs of Waterbodies on the Community page in the popups and listviews
* Possible labels are Territory, State, District, or Tribe
* The logic for determining the label first checks to see if the Organization ID matches any items in the organization mapping object. Then it checks if the orgtype is State or Tribe.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Verify District and State IDs can be found in the waterbody listviews and popups
3. Navigate to http://localhost:3000/community/guam/overview
4. Verify Territory IDs can be found in the waterbody listviews and popups
5. Change gispub service urls in services.json to use inlandwaters services:
`  "waterbodyService": {
    "points": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/0",
    "lines": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1",
    "areas": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/2",
    "summary": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
  },`
6. Navigate to http://localhost:3000/community/36%C2%B045'26.17%22N%2094%C2%B042'14.25%22W/overview
7. Verify Tribe IDs can be found in the waterbody listviews and popups
