### PR TITLE
Bugfix/waterbody report ircategory issue

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -411,14 +411,22 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
           name: firstItem.organizationName,
         });
 
-        const {
-          epaIRCategory,
-          overallStatus,
-          rationaleText,
-          useAttainments,
-          parameters,
-          probableSources,
-        } = res.items[0].assessments[0];
+        let epaIRCategory = null;
+        let overallStatus = null;
+        let rationaleText = null;
+        let useAttainments = [];
+        let parameters = [];
+        let probableSources = [];
+        if (firstItem.assessments.length > 0) {
+          const assessment = firstItem.assessments[0];
+
+          epaIRCategory = assessment.epaIRCategory;
+          overallStatus = assessment.overallStatus;
+          rationaleText = assessment.rationaleText;
+          useAttainments = assessment.useAttainments;
+          parameters = assessment.parameters;
+          probableSources = assessment.probableSources;
+        }
 
         setDecisionRationale(rationaleText);
 

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -262,7 +262,7 @@ describe('Identified Issues Tab', () => {
   it('Clicking a Discharger accordion item expands it', () => {
     // navigate to Identified Issues tab of Community page
     cy.findByPlaceholderText('Search by address', { exact: false }).type(
-      '071401010403',
+      '050301011109',
     );
     cy.findByText('Go').click();
 
@@ -274,7 +274,7 @@ describe('Identified Issues Tab', () => {
     // switch to Dischargers tab of Identified Issues tab and check that the discharger accordion item exists and expands when clicked
     cy.findByText('Identified Issues').click();
     cy.findByTestId('hmw-dischargers').click();
-    cy.findByText('ILLINOIS AMERICAN WATER').click();
+    cy.findByText('KOPPERS INC.').click();
     cy.findByText('Compliance Status:');
   });
 });

--- a/app/cypress/integration/data.spec.js
+++ b/app/cypress/integration/data.spec.js
@@ -7,7 +7,7 @@ describe('Data page', () => {
     cy.findByText('Go').click();
 
     // wait for the all web services to finish
-    cy.findAllByTestId('hmw-loading-spinner', { timeout: 20000 }).should(
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
       'not.exist',
     );
 

--- a/app/cypress/integration/waterbody_report.spec.js
+++ b/app/cypress/integration/waterbody_report.spec.js
@@ -34,13 +34,13 @@ describe('Waterbody Report page', () => {
     );
   });
 
-  it('For waterbodies without GIS data, display the "has no data available" message', () => {
+  it('For waterbodies without GIS data, display the "No map data is available" message', () => {
     const orgId = '21GAEPD';
     const auId = 'GAR_A-33_5_00';
 
     cy.visit(`/waterbody-report/${orgId}/${auId}`);
 
-    cy.findByText('has no data available.', { exact: false });
+    cy.findByText('No map data is available.', { exact: false });
   });
 
   it('Viewing waterbody report for an older year', () => {
@@ -79,5 +79,17 @@ describe('Waterbody Report page', () => {
     );
     cy.findByText(linkText).should('have.attr', 'target', '_blank');
     cy.findByText(linkText).should('have.attr', 'rel', 'noopener noreferrer');
+  });
+
+  it('Test waterbody report with empty attains assessments array', () => {
+    cy.visit('/waterbody-report/DOEE/DC_02_DCANA00E_02');
+
+    // wait for the web services to finish (attains/plans is sometimes slow)
+    // the timeout chosen is the same timeout used for the attains/plans fetch
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 20000 }).should(
+      'not.exist',
+    );
+
+    cy.findAllByText('DC_02_DCANA00E_02').should('be.visible');
   });
 });


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3596485
* https://app.breeze.pm/projects/100762/cards/3600566

## Main Changes:
* Fixed issue with waterbody report page not working for waterbodies that are missing assessments data.
* Added a test case for this bugfix.
* Updated the 'For waterbodies without GIS data, display the "has no data available" message' test case to check for the "No map data message" instead. The latest update to attains made the original test case no longer necessary. I couldn't find any waterbody-reports to reproduce the original test case. 
* Fixed the 'Clicking a Discharger accordion item expands it' test case. The location we were using no longer has dischargers with effluent violations.
* Increased the timeout on the data page test, to make it more reliable.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/DOEE/DC_02_DCANA00E_02
2. Verify the page loads and does not crash
3. Open a different waterbody report that has assessments data, like http://localhost:3000/waterbody-report/DOEE/DCANA00E_02/2020, and verify it still works
4. Run the `waterbody_report.spec.js` test
5. Verify the test cases work
6. Run the `community.spec.js` test
7. Verify the test cases work
8. Run the `data.spec.js` test
9. Verify the test cases work