### PR TITLE
Feature/update waterbody id labels

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -691,13 +691,9 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                                     {assessmentUnitName || 'Name not provided'}
                                   </strong>
                                 }
-                                subTitle={`${
-                                  waterbodyData?.attributes
-                                    ? getOrganizationLabel(
-                                        waterbodyData.attributes,
-                                      )
-                                    : ''
-                                } ID: ${assessmentUnitIdentifier}`}
+                                subTitle={`${getOrganizationLabel(
+                                  waterbodyData?.attributes,
+                                )} ${assessmentUnitIdentifier}`}
                               >
                                 <AccordionContent>
                                   {unitIds[assessmentUnitIdentifier] &&

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -381,13 +381,13 @@ const organizationMapping = {
 };
 
 export function getOrganizationLabel(attributes: Object) {
-  if (!attributes) return '';
+  if (!attributes) return 'Waterbody ID:';
 
   const mappedLabel = organizationMapping[attributes.organizationid];
-  if (mappedLabel) return mappedLabel;
-  if (attributes.orgtype === 'Tribe') return 'Tribe';
-  if (attributes.orgtype === 'State') return 'State';
-  return ''; // catch all
+  if (mappedLabel) return `${mappedLabel} Waterbody ID:`;
+  if (attributes.orgtype === 'Tribe') return 'Tribe Waterbody ID:';
+  if (attributes.orgtype === 'State') return 'State Waterbody ID:';
+  return 'Waterbody ID:'; // catch all
 }
 
 export function getPopupTitle(attributes: Object) {
@@ -399,7 +399,7 @@ export function getPopupTitle(attributes: Object) {
   if (attributes.assessmentunitname) {
     title = `${attributes.assessmentunitname} (${getOrganizationLabel(
       attributes,
-    )} ID: ${attributes.assessmentunitidentifier})`;
+    )} ${attributes.assessmentunitidentifier})`;
   }
 
   // discharger

--- a/app/client/src/components/pages/State/components/WaterbodyList.js
+++ b/app/client/src/components/pages/State/components/WaterbodyList.js
@@ -225,7 +225,7 @@ function WaterbodyItems({ sortedWaterbodies, allExpanded, fieldName }) {
               graphic.attributes.assessmentunitidentifier
             }
             title={<strong>{graphic.attributes.assessmentunitname}</strong>}
-            subTitle={`${getOrganizationLabel(graphic.attributes)} ID: ${
+            subTitle={`${getOrganizationLabel(graphic.attributes)} ${
               graphic.attributes.assessmentunitidentifier
             }`}
             icon={<WaterbodyIcon condition={condition} selected={false} />}

--- a/app/client/src/components/shared/WaterbodyList/index.js
+++ b/app/client/src/components/shared/WaterbodyList/index.js
@@ -133,7 +133,7 @@ function WaterbodyList({
             <AccordionItem
               key={index}
               title={<strong>{graphic.attributes.assessmentunitname}</strong>}
-              subTitle={`${getOrganizationLabel(graphic.attributes)} ID: ${
+              subTitle={`${getOrganizationLabel(graphic.attributes)} ${
                 graphic.attributes.assessmentunitidentifier
               }`}
               icon={<WaterbodyIcon condition={condition} selected={false} />}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3602843

## Main Changes:
* Updates the getOrganizationLabel() function to return 'Waterbody ID:' as well as the correct label

## Steps To Test:
1. Test out the following locations and their map popups, if applicable
* http://localhost:3000/community/dc/overview
* http://localhost:3000/community/guam/overview
* http://localhost:3000/state/DC/advanced-search
* http://localhost:3000/state/AL/water-quality-overview
* http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205-Mainstem/2018
* http://localhost:3000/waterbody-report/21GUAM/GUASRI-3/2018
* http://localhost:3000/plan-summary/DOEE/40594

2. Change gispub service urls in services.json to use inlandwaters services:
"waterbodyService": { "points": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/0", "lines": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1", "areas": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/2", "summary": "https://inlandwaters.geoplatform.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4" },
3. Navigate to http://localhost:3000/community/36%C2%B045'26.17%22N%2094%C2%B042'14.25%22W/overview and verify labels are correct
