### PR TITLE
Feature/state bar chart height fix

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -248,7 +248,8 @@ function SiteSpecific({
     });
   }
 
-  const responsiveBarChartHeight = barChartData.length * 60;
+  const responsiveBarChartHeight =
+    barChartData.length === 1 ? 75 : barChartData.length * 60;
 
   const responsiveBarChartFontSize =
     window.innerWidth < 350


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3591959

## Main Changes:
* Adds extra height to the Highcharts bar chart on the State Water Quality Overview for scenarios where there is only 1 bar
* Currently when only 1 bar is displayed the default Highcharts padding around the bars causes it to be shorter than when there are 3 bars


## Steps To Test:
1. Navigate to http://localhost:3000/state/OK/water-quality-overview
2. Switch to the Other tab of the State Water Quality Overview page
3. Verify singular Good bar has increased height like the other tabs where 3 bars appear
