### PR TITLE
Feature/attains org names in waterbody details

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -236,6 +236,10 @@ const NewTabDisclaimerDiv = styled.div`
   display: inline-block;
 `;
 
+const TextBottomMargin = styled.p`
+  margin-bottom: 0.5em !important;
+`;
+
 // --- components ---
 type Props = {
   ...RouteProps,
@@ -353,6 +357,12 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
 
         return (
           <>
+            {organizationName && orgId && (
+              <TextBottomMargin>
+                <strong>Organization Name (ID):&nbsp;</strong>
+                {organizationName} ({orgId})
+              </TextBottomMargin>
+            )}
             {hasTmdlData && (
               <>
                 <strong>Associated Impairments: </strong>

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -324,6 +324,13 @@ function WaterbodyInfo({
           />,
         )}
 
+        {attributes?.organizationid && attributes?.organizationname && (
+          <TextBottomPadding>
+            <strong>Organization Name (ID): </strong>
+            {`${attributes.organizationname} (${attributes.organizationid})`}
+          </TextBottomPadding>
+        )}
+
         {useLabel === 'Waterbody' && (
           <>
             {applicableFields.length === 0 && (


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3604848

## Main Changes:
* Adds Organization Name (Organization ID) to all waterbody map popups and accordions on the Community, State, Waterbody Report, and Plan Summary pages


## Steps To Test:
1. Verify map popups and listview accordions contain the Org Names and Org IDs on the following pages:
* State Advanced http://localhost:3000/state/NH/advanced-search
* Waterbody Report http://localhost:3000/waterbody-report/MDE_EASP/MD-PATMH-Bear_Creek
* Community http://localhost:3000/community/dc/swimming
* Plan Summary http://localhost:3000/plan-summary/DOEE/40594
