### PR TITLE
Bugfix/actions useEffect orgname missing dependency

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -463,7 +463,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
     });
 
     setUnitIds(unitIds);
-  }, [waters, actionTypeCode, orgId]);
+  }, [waters, actionTypeCode, orgId, organizationName]);
 
   // calculate height of div holding actions info
   const [infoHeight, setInfoHeight] = React.useState(0);


### PR DESCRIPTION
## Main Changes:
* Resolves a React error where a useEffect was missing a dependency

## Steps To Test:
1. Navigate to http://localhost:3000/plan-summary/DOEE/405942
2. Verify no warnings are displayed in console
