### PR TITLE
Feature/highcharts adjustments

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -328,6 +328,8 @@ function SiteSpecific({
                       series: {
                         pointPadding: 0.05,
                         groupPadding: 0,
+                        pointWidth: 45,
+                        minPointLength: 3,
                         inside: true,
                         shadow: false,
                         borderWidth: 1,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3608921

## Main Changes:
On the State Water Quality Overview bar chart:
* Adds minimum bar width (minPointLength) so that a sliver of bar will always be displayed for small values. This resolves an issue where comparatively small values were not rendered and appeared empty. I selected 3 as the minimum length because 1 was not rendered and 2 was a single pixel wide and difficult to see.
* Sets the pointWidth to 45 pixels so that the bar sizes remain the same across chart sizes. The chart size is currently dynamic to account for 1-3 bars being displayed but due to Highcharts' scaling the actual width of the bars vary around 45 pixels.

## Steps To Test:
1. Navigate to http://localhost:3000/state/CT/water-quality-overview
2. Set options to Swimming and Coastal Waters. (should be that by default)
3. Verify a sliver of bar is displayed for the <1 value.
4. Navigate to http://localhost:3000/state/OK/water-quality-overview
5. Open Dev tools and check the height of the bars. For the default tab it should be 45px:
![image](https://user-images.githubusercontent.com/17204883/100001014-77992d80-2d90-11eb-8c93-7162c6600476.png)
6. Select Other and a single bar should appear.
7. Verify the height is 45px for the single bar.

