### PR TITLE
Bugfix/issues found by ga

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -1000,22 +1000,22 @@ function WaterQualityOverview({ ...props }: Props) {
                 </FiltersSection>
 
                 <Section>
-                  {surveyServiceError ? (
+                  {surveyServiceError || !stateAndOrganization || !surveyData ? (
                     <StyledErrorBox>
                       <p>{stateSurveySectionError}</p>
                     </StyledErrorBox>
                   ) : (
-                    <SurveyResults
-                      loading={surveyLoading}
-                      organizationId={stateAndOrganization.organizationId}
-                      activeState={activeState}
-                      subPopulationCodes={subPopulationCodes}
-                      surveyData={surveyData}
-                      topicUses={topicUses}
-                      useSelected={useSelected}
-                      waterType={waterType}
-                    />
-                  )}
+                      <SurveyResults
+                        loading={surveyLoading}
+                        organizationId={stateAndOrganization.organizationId}
+                        activeState={activeState}
+                        subPopulationCodes={subPopulationCodes}
+                        surveyData={surveyData}
+                        topicUses={topicUses}
+                        useSelected={useSelected}
+                        waterType={waterType}
+                      />
+                    )}
                 </Section>
 
                 <SiteSpecific
@@ -1124,30 +1124,30 @@ function WaterQualityOverview({ ...props }: Props) {
                     No additional information available for this state.
                   </NoDataMessage>
                 ) : (
-                  <LinkList>
-                    {introText.data.organizationURLs.map((item, index) => {
-                      return (
-                        <li key={index}>
-                          <a
-                            href={item.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            {item.label ? item.label : item.url}
+                    <LinkList>
+                      {introText.data.organizationURLs.map((item, index) => {
+                        return (
+                          <li key={index}>
+                            <a
+                              href={item.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {item.label ? item.label : item.url}
+                            </a>
+                            <a
+                              className="exit-disclaimer"
+                              href="https://www.epa.gov/home/exit-epa"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              EXIT
                           </a>
-                          <a
-                            className="exit-disclaimer"
-                            href="https://www.epa.gov/home/exit-epa"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            EXIT
-                          </a>
-                        </li>
-                      );
-                    })}
-                  </LinkList>
-                )}
+                          </li>
+                        );
+                      })}
+                    </LinkList>
+                  )}
               </>
             )}
           </AccordionContent>

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -460,7 +460,10 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       // reset the zoom and home widget to the initial extent
       if (useDefaultZoom && mapView) {
         mapView.extent = initialExtent;
-        homeWidget.viewpoint = mapView.viewpoint;
+
+        if (homeWidget) {
+          homeWidget.viewpoint = mapView.viewpoint;
+        }
       }
 
       // reset lines, points, and areas layers


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3644841

## Main Changes:
* Added some additional checking around the usage of the `SurveyResults` component. This was to fix the `Cannot read property ‘organizationId’ of nullTypeError: Cannot read property ‘organizationId’ of null` errors being flagged by Google Analytics. 
  * Note: The key change for this is line 1003 in `WaterQualityOverview.js`. All of the other changes were from prettier and can be ignored.
* Added some additional checking around the setting of the `homeWidget.viewpoint` variable in the `locationSearch.js` component. This was to fix the `Cannot set property ‘viewpoint’ of nullTypeError: Cannot set property ‘viewpoint’ of null` errors being flagged by Google Analytics. 

## Steps To Test:
I was unable to reproduce the issue for either of the above errors, so I don't have a good way to test these. I just used the stack traces to find the line in the code causing the issue and then looked at what could be causing the issue.  

