### PR TITLE
Feature/glossary exact match term click

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -9045,7 +9045,7 @@
       }
     },
     "glossary-panel": {
-      "version": "github:Eastern-Research-Group/glossary#3b17ad8785e762ce7dc692f7af4611238ad9cf75",
+      "version": "github:Eastern-Research-Group/glossary#b36979a69bf5b3d89f9cb05227cc80bfecf13bd1",
       "from": "github:Eastern-Research-Group/glossary",
       "requires": {
         "aria-accordion": "^1.0.0",


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3640779
* https://github.com/Eastern-Research-Group/glossary/pull/16

## Main Changes:
* Updated the glossary component to attempt to find an exact match on term click. If an exact match is not found, then the glossary will show all terms containing the search term and expand the first (as it does now). 
* Searches via the input box work the same as before.

## Steps To Test:
1. Run `npm install`
2. Navigate to http://localhost:3000/community/dc/overview
3. Click the "watershed" glossary term
4. Verify the glossary opens and "Watershed" is expanded and the only term visible
5. Clear the glossary search input
6. Type "Watershed" 
7. Verify there are three glossary terms visible that contain the word "Watershed" and no terms are expanded.
8. On line 44 of the `src\components\pages\Community\config.js` file, change `<GlossaryTerm term="Watershed">` to `<GlossaryTerm term="Watersh">`
9. When the app refreshes click the "watershed" glossary term
10. Verify there are three glossary terms visible that contain the word "Watershed" and the first term is expanded.

