### PR TITLE
Feature/add suggestions to search box

### DIFF
--- a/app/client/src/contexts/EsriModules.js
+++ b/app/client/src/contexts/EsriModules.js
@@ -63,6 +63,7 @@ export class EsriModulesProvider extends React.Component<Props, State> {
         'esri/widgets/LayerList',
         'esri/widgets/LayerList/ListItem',
         'esri/widgets/ScaleBar',
+        'esri/widgets/Search',
       ],
       { url: esriApiUrl },
     )
@@ -96,6 +97,7 @@ export class EsriModulesProvider extends React.Component<Props, State> {
           LayerList,
           ListItem,
           ScaleBar,
+          Search,
         ]) => {
           // $FlowFixMe
           this.setState({
@@ -127,6 +129,7 @@ export class EsriModulesProvider extends React.Component<Props, State> {
             LayerList,
             ListItem,
             ScaleBar,
+            Search,
           });
 
           var callId = 0;

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -143,6 +143,46 @@ function createMarkup(message) {
   return { __html: message };
 }
 
+// Determines if the input text is a string representing coordinates.
+// If so the coordinates are converted to an Esri Point object.
+function getPointFromCoordinates(Point, text) {
+  const regex = /^(-?\d+(\.\d*)?)[\s,]+(-?\d+(\.\d*)?)$/;
+  let point = null;
+  if (regex.test(text)) {
+    const found = text.match(regex);
+    if (found.length >= 4 && found[1] && found[3]) {
+      point = new Point({
+        x: found[1],
+        y: found[3],
+      });
+    }
+  }
+
+  return point;
+}
+
+// Determines if the input text is a string that contains coordinates.
+// The return value is an object containing the esri point for the coordinates (coordinatesPart) 
+// and any remaining text (searchPart).
+function splitSuggestedSearch(Point, text) {
+  // split search
+  const parts = text.split('|');
+
+  // get the coordinates part (is last item)
+  const tempCoords = parts[parts.length - 1];
+  const coordinatesPart = getPointFromCoordinates(Point, tempCoords);
+
+  // remove the coordinates part from initial array
+  let coordinatesString = "";
+  if (coordinatesPart) coordinatesString = parts.pop();
+
+  // get the point from the coordinates part
+  return {
+    searchPart: parts.length > 0 ? parts.join('|') : coordinatesString,
+    coordinatesPart,
+  };
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -156,4 +196,6 @@ export {
   resetCanonicalLink,
   removeJsonLD,
   createMarkup,
+  getPointFromCoordinates,
+  splitSuggestedSearch
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3602586

## Main Changes:
* Updated the location search component to use the built in Esri Search widget. This was done to provide search suggestions to the user as they type.
  *  By default esri includes a drop down in there search widget for changing the source. I left that in there for now, but I'm open to hiding that feature if it seems unnecessary. 

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Start typing something into the search input
3. Verify that suggestions are displayed
4. Click one of the suggestions and click "Go"
5. Verify the search works correctly
6. Type "Beaver" into the search and click "Go"
7. Verify the map zooms to Beaver, Pennsylvania
8. Type "Beaver" into the search, click the "Beaver" option under "EPA Tribal Areas: Alaska Native Villages", and click "Go"
9. Verify the map zooms to Beaver, Alaska
10. Click on the map and use the popup to change locations
11. Verify this changes to the other locations correctly
12. Type a HUC value (e.g., 020700100204) into the search and click "Go"
13. Verify the huc search works correctly
14. Type coordinates (e.g., -131.4764686227817, 55.13739215101023) into the search and click "Go"
15. Verify the search by coordinates works correctly
16. Test other possible search methods that may have been missed in the previous steps. 
