### PR TITLE
Feature/log esri map failures to GA

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -62,7 +62,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
   const [layers, setLayers] = React.useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [mapLoadError, setMapLoadError] = React.useState(false);
+  const [actionsMapLoadError, setActionsMapLoadError] = React.useState(false);
 
   const services = useServicesContext();
   const getSharedLayers = useSharedLayers();
@@ -344,7 +344,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
     setMapLoading(false);
   }, [fetchStatus, mapView, actionsLayer, esriModules, homeWidget]);
 
-  if (mapLoadError) {
+  if (actionsMapLoadError) {
     return <StyledErrorBox>{esriMapLoadingFailure}</StyledErrorBox>;
   }
 
@@ -384,7 +384,7 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
             } map failed to load - ${err}`,
             exFatal: false,
           });
-          setMapLoadError(true);
+          setActionsMapLoadError(true);
         }}
       >
         {/* manually passing map and view props to Map component's     */}

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -377,7 +377,11 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
         onFail={(err: Any) => {
           console.error(err);
           window.logToGa('send', 'exception', {
-            exDescription: `${window.location.pathname} map failed to load - ${err}`,
+            exDescription: `${
+              window.location.pathname.includes('waterbody-report')
+                ? 'Waterbody Report'
+                : 'Plan Summary'
+            } map failed to load - ${err}`,
             exFatal: false,
           });
           setMapLoadError(true);

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -151,7 +151,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   const [view, setView] = React.useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [mapLoadError, setMapLoadError] = React.useState(false);
+  const [communityMapLoadError, setCommunityMapLoadError] = React.useState(
+    false,
+  );
 
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
@@ -1343,7 +1345,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               exDescription: `Community map failed to load - ${err}`,
               exFatal: false,
             });
-            setMapLoadError(true);
+            setCommunityMapLoadError(true);
             setView(null);
             setMapView(null);
           }}
@@ -1369,7 +1371,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     </>
   );
 
-  if (mapLoadError) {
+  if (communityMapLoadError) {
     return <StyledErrorBox>{esriMapLoadingFailure}</StyledErrorBox>;
   }
 

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -93,7 +93,7 @@ function StateMap({
   const [layers, setLayers] = React.useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [mapLoadError, setMapLoadError] = React.useState(false);
+  const [stateMapLoadError, setStateMapLoadError] = React.useState(false);
 
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight(false);
@@ -400,7 +400,7 @@ function StateMap({
               exDescription: `State map failed to load - ${err}`,
               exFatal: false,
             });
-            setMapLoadError(true);
+            setStateMapLoadError(true);
             setView(null);
             setMapView(null);
           }}
@@ -429,7 +429,7 @@ function StateMap({
     </div>
   );
 
-  if (mapLoadError) {
+  if (stateMapLoadError) {
     return <StyledErrorBox>{esriMapLoadingFailure}</StyledErrorBox>;
   }
 

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -183,3 +183,7 @@ export const defaultErrorBoundaryMessage = (
     Something went wrong. Return to the <a href="/">homepage</a>.
   </p>
 );
+
+// message displayed when the Esri map fails to load due to incompatible browsers and devices
+export const esriMapLoadingFailure = `The How's My Waterway Map is currently unavailable. Your web browser is
+incompatible or outdated.`;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3642570

## Main Changes:
* Displays a standard HMW error message and logs the event to GA with the current page and error message when the Esri map onFail event fires.
