### PR TITLE
feature/check-browser-compatibility-with-esri

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -233,20 +233,6 @@
         return true;
       });
     }
-
-    // {remove this} code for debugging iPad issues
-    const displayError = function (message, url, linenumber) {
-      var errorbox = document.createElement("div");
-      errorbox.className = 'display-error';
-      errorbox.innerHTML = `<strong>Error:</strong> ${message}<br><strong>Line number:</strong> ${linenumber}<br><strong>Error source:</strong> ${url}`
-      document.getElementById('error-message-container').appendChild(errorbox);
-      return false;
-    }
-
-    window.onerror = function (message, url, linenumber) {
-      console.log(message)
-      return displayError(message, url, linenumber);
-    }
   </script>
   <!-- End Google Analytics-->
 </head>
@@ -256,58 +242,6 @@
   <noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0" width="0"
       style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager -->
-
-  <!-- {remove this} code for testing ipad issues -->
-  <style>
-    .error-message-container {
-      padding: 5px;
-      position: fixed;
-      top: 0;
-      right: 0;
-      min-height: 50px;
-      max-height: 600px;
-      background-color: #535353;
-      overflow: auto;
-      z-index: 99999;
-      width: 450px;
-    }
-
-    .display-error {
-      font-size: 11px;
-      margin: 0;
-      margin-bottom: 10px;
-      background-color: #f8d7da;
-      color: #721c24;
-      padding: 5px;
-    }
-
-    .error-log-title {
-      color: white;
-      padding-bottom: 5px;
-    }
-
-    .sample-button {
-      position: fixed;
-      top: 0;
-      right: 0;
-      z-index: 999999999999;
-    }
-
-    .clear-button {
-      position: fixed;
-      top: 0;
-      right: 125px;
-      z-index: 999999999999;
-    }
-  </style>
-  <div id="error-message-container" class="error-message-container">
-    <div class="error-log-title">Global Error Log</div>
-  </div>
-  <button class="sample-button" onclick="throw('test error event')">Sample Error</button>
-  <button class="clear-button"
-    onclick="document.getElementById('error-message-container').innerHTML='<div class=\'error-log-title\'>Global Error Log</div>'">Clear
-    Logs</button>
-
   <div class="skip-links">
     <a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
   </div>

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -20,6 +20,7 @@ import { useServicesContext } from 'contexts/LookupFiles';
 import { esriApiUrl } from 'config/esriConfig';
 // helpers
 import { useSharedLayers, useWaterbodyHighlight } from 'utils/hooks';
+import { browserIsCompatibleWithArcGIS } from 'utils/utils';
 import {
   getPopupTitle,
   getPopupContent,
@@ -344,6 +345,17 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
     setMapLoading(false);
   }, [fetchStatus, mapView, actionsLayer, esriModules, homeWidget]);
 
+  // check for browser compatibility with map
+  if (!browserIsCompatibleWithArcGIS() && !actionsMapLoadError) {
+    setActionsMapLoadError(true);
+    window.logToGa('send', 'exception', {
+      exDescription: `${
+        window.location.pathname.split('/')[1]
+      } map failed to load - browser does not support performance.mark()`,
+      exFatal: false,
+    });
+  }
+
   if (actionsMapLoadError) {
     return <StyledErrorBox>{esriMapLoadingFailure}</StyledErrorBox>;
   }
@@ -376,15 +388,13 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
         }}
         onFail={(err: Any) => {
           console.error(err);
+          setActionsMapLoadError(true);
           window.logToGa('send', 'exception', {
             exDescription: `${
-              window.location.pathname.includes('waterbody-report')
-                ? 'Waterbody Report'
-                : 'Plan Summary'
+              window.location.pathname.split('/')[1]
             } map failed to load - ${err}`,
             exFatal: false,
           });
-          setActionsMapLoadError(true);
         }}
       >
         {/* manually passing map and view props to Map component's     */}

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -409,6 +409,7 @@ function StateMap({
             setStateMapLoadError(true);
             setView(null);
             setMapView(null);
+            // log event to GA
             window.logToGa('send', 'exception', {
               exDescription: `State map failed to load - ${err}`,
               exFatal: false,

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -27,6 +27,7 @@ import { useServicesContext } from 'contexts/LookupFiles';
 import { esriApiUrl } from 'config/esriConfig';
 // helpers
 import { useSharedLayers, useWaterbodyHighlight } from 'utils/hooks';
+import { browserIsCompatibleWithArcGIS } from 'utils/utils';
 // styles
 import 'components/pages/LocationMap/mapStyles.css';
 // errors
@@ -349,6 +350,15 @@ function StateMap({
   const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
   const mapInputsHeight = mapInputs && mapInputs.getBoundingClientRect().height;
 
+  // check for browser compatibility with map
+  if (!browserIsCompatibleWithArcGIS() && !stateMapLoadError) {
+    setStateMapLoadError(true);
+    window.logToGa('send', 'exception', {
+      exDescription: `State map failed to load - browser does not support performance.mark()`,
+      exFatal: false,
+    });
+  }
+
   // jsx
   const mapContent = (
     <div
@@ -396,13 +406,13 @@ function StateMap({
           }}
           onFail={(err) => {
             console.error(err);
+            setStateMapLoadError(true);
+            setView(null);
+            setMapView(null);
             window.logToGa('send', 'exception', {
               exDescription: `State map failed to load - ${err}`,
               exFatal: false,
             });
-            setStateMapLoadError(true);
-            setView(null);
-            setMapView(null);
           }}
         >
           {/* manually passing map and view props to Map component's         */}

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -162,7 +162,7 @@ function getPointFromCoordinates(Point, text) {
 }
 
 // Determines if the input text is a string that contains coordinates.
-// The return value is an object containing the esri point for the coordinates (coordinatesPart) 
+// The return value is an object containing the esri point for the coordinates (coordinatesPart)
 // and any remaining text (searchPart).
 function splitSuggestedSearch(Point, text) {
   // split search
@@ -173,7 +173,7 @@ function splitSuggestedSearch(Point, text) {
   const coordinatesPart = getPointFromCoordinates(Point, tempCoords);
 
   // remove the coordinates part from initial array
-  let coordinatesString = "";
+  let coordinatesString = '';
   if (coordinatesPart) coordinatesString = parts.pop();
 
   // get the point from the coordinates part
@@ -181,6 +181,14 @@ function splitSuggestedSearch(Point, text) {
     searchPart: parts.length > 0 ? parts.join('|') : coordinatesString,
     coordinatesPart,
   };
+}
+
+// older browsers lack support for performance.mark() which is used by arcgis 4.x
+// returns true if browser supports this feature
+function browserIsCompatibleWithArcGIS() {
+  if (performance && typeof performance.mark === 'function') return true;
+
+  return false; // browser is incompatible with current arcgis version
 }
 
 export {
@@ -197,5 +205,6 @@ export {
   removeJsonLD,
   createMarkup,
   getPointFromCoordinates,
-  splitSuggestedSearch
+  splitSuggestedSearch,
+  browserIsCompatibleWithArcGIS,
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3442549

## Main Changes:
* Removes code used to debug issues with older iPad devices
* Adds function to check if the browser supports `performance.mark()` which ArcGIS 4.16 relies on. If the browser does not support this feature: the map is hidden, a message is displayed, and the event is logged to Google Analytics. 

## Steps To Test:
1. Merge and test Community, Waterbody Report, and State maps with iPad 2 running iOS 9.3.5 (Safari 9)