### PR TITLE
Feature/ios 9.3.5 arcgis

### DIFF
--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -187,18 +187,11 @@ function splitSuggestedSearch(Point, text) {
 // returns true if browser supports this feature
 
 function browserIsCompatibleWithArcGIS() {
-  const performance =
-    window.performance ||
-    window.webkitPerformance ||
-    window.msPerformance ||
-    window.mozPerformance;
+  const performance = window.performance;
 
-  if (performance === undefined) {
-    console.log(
-      'Unfortunately, your browser does not support the Navigation Timing API',
-    );
-    return false;
-  }
+  if (performance === undefined) return false;
+  if (typeof performance.mark !== 'function') return false;
+  if (!performance.mark) return false;
 
   // performance.mark() is supported
   return true;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3642570

## Main Changes:
* Potential solution to checking if browser supports ArcGIS 4.16. If this branch still causes errors on iOS 9.3.5 we should pursue other methods for detection.
