### PR TITLE
Feature/remove GA events from State, Plan Summary, and Waterbody Report maps

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -348,12 +348,6 @@ function ActionsMap({ esriModules, layout, unitIds, onLoad }: Props) {
   // check for browser compatibility with map
   if (!browserIsCompatibleWithArcGIS() && !actionsMapLoadError) {
     setActionsMapLoadError(true);
-    window.logToGa('send', 'exception', {
-      exDescription: `${
-        window.location.pathname.split('/')[1]
-      } map failed to load - browser does not support performance.mark()`,
-      exFatal: false,
-    });
   }
 
   if (actionsMapLoadError) {

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -353,10 +353,6 @@ function StateMap({
   // check for browser compatibility with map
   if (!browserIsCompatibleWithArcGIS() && !stateMapLoadError) {
     setStateMapLoadError(true);
-    window.logToGa('send', 'exception', {
-      exDescription: `State map failed to load - browser does not support performance.mark()`,
-      exFatal: false,
-    });
   }
 
   // jsx


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3642570

## Main Changes:
* Removes the GA events that cause errors on older iOS versions from the StateMap and ActionsMap.
