### PR TITLE
Bugfix/google analytics blocked by anti tracking extension

### DIFF
--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -126,6 +126,7 @@ export function logCallToGoogleAnalytics(
   startTime: number,
 ) {
   if (!window.gaTarget) return;
+  if (!window.ga) return;
 
   const duration = performance.now() - startTime;
 


### PR DESCRIPTION

## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3665155

## Main Changes:
* Anti-tracking extensions like Ghostery cause the app to crash when sending events to Google Analytics due to window.ga being undefined.
* Check for existence of window.ga before attempting to log events to Google Analytics.

## Steps To Test:
1. I don't see a way to verify this without a deployment.

