### PR TITLE
Bugfix/adw display issues

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/index.js
+++ b/app/client/src/components/shared/AddDataWidget/index.js
@@ -56,6 +56,8 @@ const WidgetHeader = styled.div`
 
   h1 {
     margin: 0 10px;
+    font-family: 'Source Sans Pro', 'Helvetica Neue', 'Helvetica', 'Roboto',
+      'Arial', sans-serif;
     font-size: 16px;
     line-height: 35px;
     padding: 0;

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -397,8 +397,21 @@ function MapWidgets({
       width = window.innerWidth;
       if (difference < 0 || !rnd?.current) return;
 
+      let mapRect = document
+        .getElementById('base-container')
+        .getBoundingClientRect();
+      let awdRect = document
+        .getElementById('add-data-widget')
+        .getBoundingClientRect();
+
+      const maxLeft = mapRect.width - awdRect.width;
+      const curLeft = awdRect.left - mapRect.left;
+
       // update the position of the add data widget
-      const newPosition = rnd.current.draggable.state.x - difference / 2;
+      const newPosition =
+        curLeft > maxLeft
+          ? maxLeft
+          : awdRect.left - mapRect.left - difference / 2;
       rnd.current.updatePosition({
         x: newPosition < 0 ? 0 : newPosition,
         y: rnd.current.draggable.state.y,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3672304

## Main Changes:
* Fixed an issue with the ADW opening somewhere off the map. 
* Updated the ADW title font to use the HMW font instead of the Esri font.
* Investigated an issue I noticed yesterday where all 3 ADW tabs were visible at the same time. Unfortunately, I haven't been able to reproduce this issue. 

## Steps To Test:
1. Open Chrome on a desktop
2. Maximize the browser
3. Navigate to http://localhost:3000/community/dc/overview
4. Open the add data widget
5. Click the restore down button (button left of the close browser button) to make the browser a smaller window
6. Verify the add data widget stays over top of the map
7. Refresh the browser
8. Open the add data widget
9. Open dev tools
10. Verify the add data widget stays over top of the map
11. Resize the dev tools 
12. Verify the add data widget stays over top of the map
13. Inspect the Add Data Widget title
14. Verify the font-family is `'Source Sans Pro','Helvetica Neue','Helvetica','Roboto', 'Arial',sans-serif`
