### PR TITLE
Feature/adw remove autozoom

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/FilePanel.js
+++ b/app/client/src/components/shared/AddDataWidget/FilePanel.js
@@ -450,7 +450,6 @@ function FilePanel() {
     setFeaturesAdded(true);
 
     const featureLayers: __esri.FeatureLayer[] = [];
-    const graphicsAdded: __esri.Graphic[] = [];
     generateResponse.featureCollection.layers.forEach((layer: any) => {
       if (
         !layer?.featureSet?.features ||
@@ -478,7 +477,6 @@ function FilePanel() {
         }
         const graphic = Graphic.fromJSON(feature);
         features.push(graphic);
-        graphicsAdded.push(graphic);
       });
 
       // use jsonUtils to convert the REST API renderer to an ArcGIS JS renderer

--- a/app/client/src/components/shared/AddDataWidget/FilePanel.js
+++ b/app/client/src/components/shared/AddDataWidget/FilePanel.js
@@ -523,7 +523,6 @@ function FilePanel() {
     });
 
     mapView.map.addMany(featureLayers);
-    if (graphicsAdded.length > 0) mapView.goTo(graphicsAdded);
 
     setUploadStatus('success');
   }, [

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -788,11 +788,6 @@ function ResultCard({ result }: ResultCardProps) {
 
             if (mapView) {
               layer.visible = true;
-
-              // zoom to the layer if it has an extent
-              if (layer.fullExtent) {
-                mapView.goTo(layer.fullExtent);
-              }
             }
           } else if (loadStatus === 'failed') {
             setStatus('error');

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -321,7 +321,7 @@ function SearchPanel() {
   React.useEffect(() => {
     if (!mapView || watchViewInitialized) return;
 
-    const watchEvent = watchUtils.whenTrue(mapView, 'stationary', () => {
+    watchUtils.whenTrue(mapView, 'stationary', () => {
       setCurrentExtent(mapView.extent);
     });
 

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -326,11 +326,6 @@ function SearchPanel() {
     });
 
     setWatchViewInitialized(true);
-
-    // remove watch event to prevent it from running after component unmounts
-    return function cleanup() {
-      watchEvent.remove();
-    };
   }, [mapView, watchUtils, watchViewInitialized]);
 
   const [showLocationOptions, setShowLocationOptions] = React.useState(false);

--- a/app/client/src/components/shared/AddDataWidget/index.js
+++ b/app/client/src/components/shared/AddDataWidget/index.js
@@ -140,7 +140,7 @@ const RecordContainer = styled.div`
   align-items: center;
 `;
 
-const DeleteButton = styled.button`
+const LayerIconButton = styled.button`
   margin: 0;
   color: black;
   background-color: transparent;
@@ -242,40 +242,53 @@ function AddDataWidget() {
               layersToDisplay.map((item) => {
                 return (
                   <RecordContainer key={item.layer.id}>
-                    <label htmlFor={item.layer.id}>{item.title}</label>
-                    <DeleteButton
-                      id={item.layer.id}
-                      className="esri-icon-trash"
-                      onClick={() => {
-                        if (
-                          !item.layer.parent?.type ||
-                          item.layer.parent.type !== 'group'
-                        ) {
-                          setWidgetLayers((widgetLayers) =>
-                            widgetLayers.filter(
-                              (widgetLayer) => widgetLayer.id !== item.layer.id,
-                            ),
-                          );
-                          mapView.map.remove(item.layer);
-                          return;
-                        }
+                    <span>{item.title}</span>
+                    <div>
+                      <LayerIconButton
+                        className="esri-icon-zoom-in-magnifying-glass"
+                        onClick={() => {
+                          if (!item?.layer?.fullExtent) return;
+                          mapView.goTo(item.layer.fullExtent);
+                        }}
+                      >
+                        <ButtonHiddenText>Zoom to Layer</ButtonHiddenText>
+                      </LayerIconButton>
+                      <LayerIconButton
+                        className="esri-icon-trash"
+                        onClick={() => {
+                          if (
+                            !item.layer.parent?.type ||
+                            item.layer.parent.type !== 'group'
+                          ) {
+                            setWidgetLayers((widgetLayers) =>
+                              widgetLayers.filter(
+                                (widgetLayer) =>
+                                  widgetLayer.id !== item.layer.id,
+                              ),
+                            );
+                            mapView.map.remove(item.layer);
+                            return;
+                          }
 
-                        // If the parent layer only has 1 layer left, remove the
-                        // parent layer, otherwise just remove the layer from
-                        // the parent layer.
-                        if (item.layer.parent.layers.length > 1) {
-                          item.layer.parent.remove(item.layer);
-                        } else {
-                          setWidgetLayers((widgetLayers) =>
-                            widgetLayers.filter(
-                              (widgetLayer) =>
-                                widgetLayer.id !== item.layer.parent.id,
-                            ),
-                          );
-                          mapView.map.remove(item.layer.parent);
-                        }
-                      }}
-                    ></DeleteButton>
+                          // If the parent layer only has 1 layer left, remove the
+                          // parent layer, otherwise just remove the layer from
+                          // the parent layer.
+                          if (item.layer.parent.layers.length > 1) {
+                            item.layer.parent.remove(item.layer);
+                          } else {
+                            setWidgetLayers((widgetLayers) =>
+                              widgetLayers.filter(
+                                (widgetLayer) =>
+                                  widgetLayer.id !== item.layer.parent.id,
+                              ),
+                            );
+                            mapView.map.remove(item.layer.parent);
+                          }
+                        }}
+                      >
+                        <ButtonHiddenText>Delete Layer</ButtonHiddenText>
+                      </LayerIconButton>
+                    </div>
                   </RecordContainer>
                 );
               })}


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3672316
* https://app.breeze.pm/projects/100762/cards/3672319

## Main Changes:
* Removed the code that automatically zooms to layers that are added from the Add Data Widget.
* Added a zoom button to the layer panel of the Add Data Widget.
* Fixed the "Within map..." filter

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the add data widget
3. Add some layers
4. Verify the map does not zoom to any of the layers added via the ADW
5. Click the layers button in the bottom right of the ADW
6. Click the zoom buttons next to the layers
7. Verify the map correctly zooms to those layers
8. Go to the Search panel of the ADW and verify the "Within map..." switch is on
9. Pan around on the map and verify the search results refresh when you stop panning

