### PR TITLE
Feature/fix geocoding issue with non usa

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -960,10 +960,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         } catch (err) {
           console.error(err);
           setNoDataAvailable();
+          setMapLoading(false);
           setErrorMessage(noDataAvailableError);
         }
       } else {
         setNoDataAvailable();
+        setMapLoading(false);
         setErrorMessage(noDataAvailableError);
       }
     },
@@ -1247,6 +1249,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           .then((response) => {
             if (response.features.length === 0) {
               // flag no data available for no response
+              setMapLoading(false);
               setErrorMessage(noDataAvailableError);
               setNoDataAvailable();
             }
@@ -1266,6 +1269,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           })
           .catch((err) => {
             console.error(err);
+            setMapLoading(false);
             setErrorMessage(noDataAvailableError);
             setNoDataAvailable();
           });


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3672367

## Main Changes:
* Fixed an issue where searching for a location outside the US would result in the app zooming to somewhere in the US (i.e., searching for Longon, England would zoom to London, KY). 
  * The way I coded it is if you type something and don't select a suggestion, the app will use the US based geocoder. If you select a suggestion, the app will use the coordinates of the suggestion.
 
## Steps To Test:
1. Type london in the search box and do not select any of the suggestions
2. Click Go
3. Verify the app zooms to London, OH. 
4. Type london in the search box and select London England from the suggestions
5. Click Go
6. Verify the app displays the "Data is not available for this location..." error

