### PR TITLE
Feature/state fishing advisory

### DIFF
--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -9,6 +9,8 @@ import highchartsAccessibility from 'highcharts/modules/accessibility';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
+// styled components
+import { StyledErrorBox } from 'components/shared/MessageBoxes';
 // contexts
 import { StateTabsContext } from 'contexts/StateTabs';
 // utilities
@@ -17,6 +19,8 @@ import { formatNumber } from 'utils/utils';
 import { impairmentFields } from 'config/attainsToHmwMapping';
 // styles
 import { fonts, colors } from 'styles/index.js';
+// errors
+import { fishingAdvisoryError } from 'config/errorMessages';
 
 // add accessibility features to highcharts
 highchartsAccessibility(Highcharts);
@@ -65,6 +69,14 @@ const HighchartsContainer = styled.div`
   }
 `;
 
+const FishingAdvisoryText = styled.h3`
+  display: inline-block;
+`;
+
+const ErrorBox = styled(StyledErrorBox)`
+  margin-bottom: 1.5em;
+`;
+
 // --- components ---
 type Props = {
   activeState: { code: string, name: string },
@@ -81,6 +93,7 @@ function SiteSpecific({
   waterTypeData,
   completeUseList,
   useSelected,
+  fishingAdvisoryData,
 }: Props) {
   const { currentReportingCycle } = React.useContext(StateTabsContext);
 
@@ -396,6 +409,45 @@ function SiteSpecific({
           </AccordionItem>
         </AccordionList>
       )}
+
+      {topic === 'fishing' && fishingAdvisoryData.status === 'fetching' && (
+        <LoadingSpinner />
+      )}
+
+      {topic === 'fishing' && fishingAdvisoryData.status === 'failure' && (
+        <ErrorBox>{fishingAdvisoryError}</ErrorBox>
+      )}
+
+      {topic === 'fishing' &&
+        fishingAdvisoryData.status === 'success' &&
+        fishingAdvisoryData.data.length === 0 && (
+          <ErrorBox>{fishingAdvisoryError}</ErrorBox>
+        )}
+
+      {topic === 'fishing' &&
+        fishingAdvisoryData.status === 'success' &&
+        fishingAdvisoryData.data.length !== 0 && (
+          <>
+            <FishingAdvisoryText>
+              Fish Consumption Advisories for{' '}
+              <a
+                href={fishingAdvisoryData.data[0].url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {activeState.name}
+              </a>{' '}
+            </FishingAdvisoryText>
+            <a
+              className="exit-disclaimer"
+              href="https://www.epa.gov/home/exit-epa"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              EXIT
+            </a>
+          </>
+        )}
     </>
   );
 }

--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -10,7 +10,7 @@ import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 // styled components
-import { StyledErrorBox } from 'components/shared/MessageBoxes';
+import { StyledErrorBox, StyledInfoBox } from 'components/shared/MessageBoxes';
 // contexts
 import { StateTabsContext } from 'contexts/StateTabs';
 // utilities
@@ -74,6 +74,10 @@ const FishingAdvisoryText = styled.h3`
 `;
 
 const ErrorBox = styled(StyledErrorBox)`
+  margin-bottom: 1.5em;
+`;
+
+const InfoBox = styled(StyledInfoBox)`
   margin-bottom: 1.5em;
 `;
 
@@ -421,7 +425,9 @@ function SiteSpecific({
       {topic === 'fishing' &&
         fishingAdvisoryData.status === 'success' &&
         fishingAdvisoryData.data.length === 0 && (
-          <ErrorBox>{fishingAdvisoryError}</ErrorBox>
+          <InfoBox>
+            Fishing Advisory information is not available for this state.
+          </InfoBox>
         )}
 
       {topic === 'fishing' &&

--- a/app/client/src/components/pages/State/components/SiteSpecific.js
+++ b/app/client/src/components/pages/State/components/SiteSpecific.js
@@ -426,7 +426,7 @@ function SiteSpecific({
         fishingAdvisoryData.status === 'success' &&
         fishingAdvisoryData.data.length === 0 && (
           <InfoBox>
-            Fishing Advisory information is not available for this state.
+            Fishing Advisory information is not available for this location.
           </InfoBox>
         )}
 

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -280,6 +280,11 @@ function WaterQualityOverview({ ...props }: Props) {
   const [surveyData, setSurveyData] = React.useState(null);
   const [assessmentDocuments, setAssessmentDocuments] = React.useState(null);
 
+  const [fishingAdvisoryData, setFishingAdvisoryData] = React.useState({
+    status: 'fetching',
+    data: [],
+  });
+
   const [topicUses, setTopicUses] = React.useState({});
   const [useList, setUseList] = React.useState([]);
   const [completeUseList, setCompleteUseList] = React.useState([]);
@@ -460,6 +465,40 @@ function WaterQualityOverview({ ...props }: Props) {
     services,
   ]);
 
+  // Get fishing advisory information
+  const fetchFishingAdvisoryData = React.useCallback(
+    (stateCode) => {
+      setFishingAdvisoryData({ status: 'fetching', data: [] });
+
+      const url =
+        services.data.fishingInformationService.serviceUrl +
+        services.data.fishingInformationService.queryStringFirstPart +
+        `'${stateCode}'` +
+        services.data.fishingInformationService.queryStringSecondPart;
+
+      fetchCheck(url)
+        .then((res) => {
+          if (!res || !res.features || res.features.length === 0) {
+            setFishingAdvisoryData({ status: 'success', data: [] });
+            return;
+          }
+
+          const fishingInfo = [
+            {
+              url: res.features[0].attributes.STATEURL,
+            },
+          ];
+
+          setFishingAdvisoryData({ status: 'success', data: fishingInfo });
+        })
+        .catch((err) => {
+          console.error(err);
+          setFishingAdvisoryData({ status: 'failure', data: [] });
+        });
+    },
+    [setFishingAdvisoryData, services],
+  );
+
   // Get the survey data and survey documents
   const fetchSurveyData = React.useCallback(
     (orgID) => {
@@ -571,6 +610,7 @@ function WaterQualityOverview({ ...props }: Props) {
 
       setCurrentState(activeState.code);
       fetchStateOrgId(activeState.code);
+      fetchFishingAdvisoryData(activeState.code);
 
       setCurrentSummary({
         status: 'fetching',
@@ -593,6 +633,7 @@ function WaterQualityOverview({ ...props }: Props) {
     setCurrentSummary,
     setIntroText,
     fetchStateOrgId,
+    fetchFishingAdvisoryData,
     services,
   ]);
 
@@ -1028,6 +1069,7 @@ function WaterQualityOverview({ ...props }: Props) {
                   useSelected={useSelected}
                   waterType={waterType}
                   waterTypeData={waterTypeData}
+                  fishingAdvisoryData={fishingAdvisoryData}
                 />
 
                 <DrinkingWaterSection displayed={currentTopic === 'drinking'}>

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -155,6 +155,10 @@ export const waterbodyReportError = (type) =>
 export const attainsParameterServiceError =
   'Parameter information is temporarily unavailable, please try again later.';
 
+// WatersGEO Fishing Advisory Service Error
+export const fishingAdvisoryError =
+  'Fishing Advisory information is not available at this time. Please try again later.';
+
 // Add Data Widget //
 export const webServiceErrorMessage = 'An error occurred in the web service';
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3665605

## Main Changes:
* Adds a link to the fishing advisory page for the current state on the State - Eating Fish tab.

## Steps To Test:
1. Navigate to http://localhost:3000/state/AK/water-quality-overview
2. Open the Eating Fish tab. Verify Fishing Consumption Advisory link now exists at the bottom of the tab.
3. Try out a few other states.
4. Block the watersgeo fishing advisory service call (https://watersgeo.epa.gov/arcgis/rest/services/NLFA/FISH_GEN/MapServer/13/) and verify the service error is handled.

