### PR TITLE
Feature/protect tab meeting changes

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -405,7 +405,7 @@ function Protect() {
                                 The Watershed Health Index, from the Preliminary
                                 Healthy Watersheds Assessment (PHWA), is a score
                                 of <strong>watershed health</strong> across the
-                                conterminous United States
+                                conterminous United States.
                               </p>
                               <ul>
                                 <li>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -601,8 +601,7 @@ function Protect() {
                       <Switch
                         checked={
                           wildScenicRiversDisplayed &&
-                          wildScenicRiversData.status === 'success' &&
-                          wildScenicRiversData.data.length > 0
+                          wildScenicRiversData.status === 'success'
                         }
                         onChange={(checked) => {
                           setWildScenicRiversDisplayed(checked);
@@ -610,10 +609,7 @@ function Protect() {
                             wildScenicRiversLayer: checked,
                           });
                         }}
-                        disabled={
-                          wildScenicRiversData.status === 'failure' ||
-                          wildScenicRiversData.data.length === 0
-                        }
+                        disabled={wildScenicRiversData.status === 'failure'}
                         ariaLabel="Wild and Scenic Rivers"
                       />
                       <span>Display on Map</span>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -11,6 +11,7 @@ import { StyledErrorBox } from 'components/shared/MessageBoxes';
 import TabErrorBoundary from 'components/shared/ErrorBoundary/TabErrorBoundary';
 import Switch from 'components/shared/Switch';
 import { gradientIcon } from 'components/pages/LocationMap/MapFunctions';
+import ShowLessMore from 'components/shared/ShowLessMore';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { CommunityTabsContext } from 'contexts/CommunityTabs';
@@ -123,6 +124,14 @@ const ErrorBox = styled(StyledErrorBox)`
   p {
     padding-bottom: 0 !important;
   }
+`;
+
+const InlineBlockWrapper = styled.div`
+  display: inline-block;
+`;
+
+const WsioQuestionContainer = styled.div`
+  padding-bottom: 0.875rem;
 `;
 
 // --- components ---
@@ -276,17 +285,14 @@ function Protect() {
                       />
                       <span>Display on Map</span>
                     </Label>
-
                     {wsioHealthIndexData.status === 'failure' && (
                       <ErrorBox>
                         <p>{wsioHealthIndexError}</p>
                       </ErrorBox>
                     )}
-
                     {wsioHealthIndexData.status === 'fetching' && (
                       <LoadingSpinner />
                     )}
-
                     {wsioHealthIndexData.status === 'success' &&
                       wsioHealthIndexData.data.length === 0 && (
                         <p>
@@ -294,7 +300,6 @@ function Protect() {
                           location.
                         </p>
                       )}
-
                     {wsioHealthIndexData.status === 'success' &&
                       wsioHealthIndexData.data.length > 0 && (
                         <WatershedContainer>
@@ -382,67 +387,93 @@ function Protect() {
                         </WatershedContainer>
                       )}
 
-                    {infoToggleChecked && (
-                      <>
+                    <WsioQuestionContainer>
+                      <InlineBlockWrapper>
                         <p>
                           <strong>
                             Where do the healthiest watersheds occur?
                           </strong>
                         </p>
-                        <p>
-                          The Watershed Health Index, from the Preliminary
-                          Healthy Watersheds Assessment (PHWA), is a score of{' '}
-                          <strong>watershed health</strong> across the
-                          conterminous United States
-                        </p>
-                        <ul>
-                          <li>
-                            The map to the left shows watershed health,
-                            characterized by the presence of natural land cover
-                            that supports hydrologic and geomorphic processes
-                            within their natural range of variation, good water
-                            quality, and habitats of sufficient size and
-                            connectivity to support healthy, native aquatic and
-                            riparian biological communities.
-                          </li>
-                          <li>
-                            Each Watershed Health Index score is relative to the
-                            scores (1-99% percentile) of watersheds across the
-                            state. A HUC12 watershed that straddles more than
-                            one state is scored only in the state in which its
-                            majority area resides.
-                          </li>
-                        </ul>
+                      </InlineBlockWrapper>
 
+                      <InlineBlockWrapper>
+                        <ShowLessMore
+                          charLimit={0}
+                          text={
+                            <>
+                              <p>
+                                The Watershed Health Index, from the Preliminary
+                                Healthy Watersheds Assessment (PHWA), is a score
+                                of <strong>watershed health</strong> across the
+                                conterminous United States
+                              </p>
+                              <ul>
+                                <li>
+                                  The map to the left shows watershed health,
+                                  characterized by the presence of natural land
+                                  cover that supports hydrologic and geomorphic
+                                  processes within their natural range of
+                                  variation, good water quality, and habitats of
+                                  sufficient size and connectivity to support
+                                  healthy, native aquatic and riparian
+                                  biological communities.
+                                </li>
+                                <li>
+                                  Each Watershed Health Index score is relative
+                                  to the scores (1-99% percentile) of watersheds
+                                  across the state. A HUC12 watershed that
+                                  straddles more than one state is scored only
+                                  in the state in which its majority area
+                                  resides.
+                                </li>
+                              </ul>
+                            </>
+                          }
+                        />
+                      </InlineBlockWrapper>
+                    </WsioQuestionContainer>
+
+                    <WsioQuestionContainer>
+                      <InlineBlockWrapper>
                         <p>
                           <strong>Why is the PHWA valuable?</strong>
                         </p>
-
-                        <ul>
-                          <li>
-                            Raises awareness of where the healthiest watersheds
-                            occur.
-                          </li>
-                          <li>
-                            Provides an initial dataset upon which others can
-                            build better watershed condition information.
-                          </li>
-                          <li>
-                            Improves communication and coordination among
-                            watershed management partners by providing
-                            nationally consistent measures of watershed health.
-                          </li>
-                          <li>
-                            Provides a basis to promote high quality waters
-                            protection.
-                          </li>
-                          <li>
-                            Supports efforts to prioritize, protect and maintain
-                            high quality waters.
-                          </li>
-                        </ul>
-                      </>
-                    )}
+                      </InlineBlockWrapper>
+                      <InlineBlockWrapper>
+                        <ShowLessMore
+                          charLimit={0}
+                          text={
+                            <>
+                              <ul>
+                                <li>
+                                  Raises awareness of where the healthiest
+                                  watersheds occur.
+                                </li>
+                                <li>
+                                  Provides an initial dataset upon which others
+                                  can build better watershed condition
+                                  information.
+                                </li>
+                                <li>
+                                  Improves communication and coordination among
+                                  watershed management partners by providing
+                                  nationally consistent measures of watershed
+                                  health.
+                                </li>
+                                <li>
+                                  Provides a basis to promote high quality
+                                  waters protection.
+                                </li>
+                                <li>
+                                  Supports efforts to prioritize, protect and
+                                  maintain high quality waters.
+                                </li>
+                              </ul>
+                            </>
+                          }
+                        />
+                      </InlineBlockWrapper>
+                    </WsioQuestionContainer>
 
                     <p>
                       <a

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -13,8 +13,10 @@ import Switch from 'components/shared/Switch';
 import { gradientIcon } from 'components/pages/LocationMap/MapFunctions';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
+import { CommunityTabsContext } from 'contexts/CommunityTabs';
 // utilities
 import { getUrlFromMarkup, getTitleFromMarkup } from 'components/shared/Regex';
+import { convertAgencyCode } from 'utils/utils';
 // styles
 import { fonts } from 'styles/index.js';
 // errors
@@ -140,6 +142,8 @@ function Protect() {
     protectedAreasData,
   } = React.useContext(LocationSearchContext);
 
+  const { infoToggleChecked } = React.useContext(CommunityTabsContext);
+
   const sortedGrtsData =
     grts.data.items && grts.data.items.length > 0
       ? grts.data.items
@@ -240,11 +244,13 @@ function Protect() {
           </TabList>
           <TabPanels>
             <TabPanel>
-              <p>
-                Learn about watershed health scores in relation to your state,
-                if there are any protected areas in your watershed, and the
-                location of any designated <em>Wild and Scenic Rivers</em>.
-              </p>
+              {infoToggleChecked && (
+                <p>
+                  Learn about watershed health scores in relation to your state,
+                  if there are any protected areas in your watershed, and the
+                  location of any designated <em>Wild and Scenic Rivers</em>.
+                </p>
+              )}
 
               <AccordionList>
                 <AccordionItem title={<strong>Watershed Health Scores</strong>}>
@@ -376,61 +382,67 @@ function Protect() {
                         </WatershedContainer>
                       )}
 
-                    <p>
-                      <strong>Where do the healthiest watersheds occur?</strong>
-                    </p>
-                    <p>
-                      The Watershed Health Index, from the Preliminary Healthy
-                      Watersheds Assessment (PHWA), is a score of{' '}
-                      <strong>watershed health</strong> across the conterminous
-                      United States
-                    </p>
-                    <ul>
-                      <li>
-                        The map to the left shows watershed health,
-                        characterized by the presence of natural land cover that
-                        supports hydrologic and geomorphic processes within
-                        their natural range of variation, good water quality,
-                        and habitats of sufficient size and connectivity to
-                        support healthy, native aquatic and riparian biological
-                        communities.
-                      </li>
-                      <li>
-                        Each Watershed Health Index score is relative to the
-                        scores (1-99% percentile) of watersheds across the
-                        state. A HUC12 watershed that straddles more than one
-                        state is scored only in the state in which its majority
-                        area resides.
-                      </li>
-                    </ul>
+                    {infoToggleChecked && (
+                      <>
+                        <p>
+                          <strong>
+                            Where do the healthiest watersheds occur?
+                          </strong>
+                        </p>
+                        <p>
+                          The Watershed Health Index, from the Preliminary
+                          Healthy Watersheds Assessment (PHWA), is a score of{' '}
+                          <strong>watershed health</strong> across the
+                          conterminous United States
+                        </p>
+                        <ul>
+                          <li>
+                            The map to the left shows watershed health,
+                            characterized by the presence of natural land cover
+                            that supports hydrologic and geomorphic processes
+                            within their natural range of variation, good water
+                            quality, and habitats of sufficient size and
+                            connectivity to support healthy, native aquatic and
+                            riparian biological communities.
+                          </li>
+                          <li>
+                            Each Watershed Health Index score is relative to the
+                            scores (1-99% percentile) of watersheds across the
+                            state. A HUC12 watershed that straddles more than
+                            one state is scored only in the state in which its
+                            majority area resides.
+                          </li>
+                        </ul>
 
-                    <p>
-                      <strong>Why is the PHWA valuable?</strong>
-                    </p>
+                        <p>
+                          <strong>Why is the PHWA valuable?</strong>
+                        </p>
 
-                    <ul>
-                      <li>
-                        Raises awareness of where the healthiest watersheds
-                        occur
-                      </li>
-                      <li>
-                        Provides an initial dataset upon which others can build
-                        better watershed condition information.
-                      </li>
-                      <li>
-                        Improves communication and coordination among watershed
-                        management partners by providing nationally consistent
-                        measures of watershed health.
-                      </li>
-                      <li>
-                        Provides a basis to promote high quality waters
-                        protection.
-                      </li>
-                      <li>
-                        Supports efforts to prioritize, protect and maintain
-                        high quality waters.
-                      </li>
-                    </ul>
+                        <ul>
+                          <li>
+                            Raises awareness of where the healthiest watersheds
+                            occur.
+                          </li>
+                          <li>
+                            Provides an initial dataset upon which others can
+                            build better watershed condition information.
+                          </li>
+                          <li>
+                            Improves communication and coordination among
+                            watershed management partners by providing
+                            nationally consistent measures of watershed health.
+                          </li>
+                          <li>
+                            Provides a basis to promote high quality waters
+                            protection.
+                          </li>
+                          <li>
+                            Supports efforts to prioritize, protect and maintain
+                            high quality waters.
+                          </li>
+                        </ul>
+                      </>
+                    )}
 
                     <p>
                       <a
@@ -448,26 +460,33 @@ function Protect() {
 
                 <AccordionItem title={<strong>Protected Areas</strong>}>
                   <AccordionContent>
-                    <p>
-                      The Protected Areas Database (PAD-US) is America’s
-                      official national inventory of U.S. terrestrial and marine
-                      protected areas that are dedicated to the preservation of
-                      biological diversity and to other natural, recreation and
-                      cultural uses, managed for these purposes through legal or
-                      other effective means.
-                    </p>
+                    {infoToggleChecked && (
+                      <>
+                        <p>
+                          The Protected Areas Database (PAD-US) is America’s
+                          official national inventory of U.S. terrestrial and
+                          marine protected areas that are dedicated to the
+                          preservation of biological diversity and to other
+                          natural, recreation and cultural uses, managed for
+                          these purposes through legal or other effective means.
+                        </p>
 
-                    <p>
-                      <a
-                        href="https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <i className="fas fa-info-circle" aria-hidden="true" />{' '}
-                        More Information
-                      </a>{' '}
-                      (opens new browser tab)
-                    </p>
+                        <p>
+                          <a
+                            href="https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <i
+                              className="fas fa-info-circle"
+                              aria-hidden="true"
+                            />{' '}
+                            More Information
+                          </a>{' '}
+                          (opens new browser tab)
+                        </p>
+                      </>
+                    )}
 
                     <Label>
                       <Switch
@@ -555,30 +574,28 @@ function Protect() {
 
                 <AccordionItem title={<strong>Wild and Scenic Rivers</strong>}>
                   <AccordionContent>
-                    <p>
-                      The National Wild and Scenic Rivers System was created by
-                      Congress in 1968 to preserve certain rivers with
-                      outstanding natural, cultural, and recreational values in
-                      a free-flowing condition for the enjoyment of present and
-                      future generations. The Act is notable for safeguarding
-                      the special character of these rivers, while also
-                      recognizing the potential for their appropriate use and
-                      development. It encourages river management that crosses
-                      political boundaries and promotes public participation in
-                      developing goals for river protection.
-                    </p>
-
-                    <p>
-                      <a
-                        href="https://www.rivers.gov/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <i className="fas fa-info-circle" aria-hidden="true" />{' '}
-                        More Information
-                      </a>{' '}
-                      (opens new browser tab)
-                    </p>
+                    {infoToggleChecked && (
+                      <p>
+                        The{' '}
+                        <a
+                          href="https://www.rivers.gov/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          National Wild and Scenic Rivers System{' '}
+                        </a>{' '}
+                        (opens new browser tab) was created by Congress in 1968
+                        to preserve certain rivers with outstanding natural,
+                        cultural, and recreational values in a free-flowing
+                        condition for the enjoyment of present and future
+                        generations. The Act is notable for safeguarding the
+                        special character of these rivers, while also
+                        recognizing the potential for their appropriate use and
+                        development. It encourages river management that crosses
+                        political boundaries and promotes public participation
+                        in developing goals for river protection.
+                      </p>
+                    )}
 
                     <Label>
                       <Switch
@@ -627,23 +644,20 @@ function Protect() {
                         return (
                           <Feature key={item}>
                             <FeatureTitle>
-                              <strong>{attributes.WSR_RIVER_NAME}</strong>
+                              <strong>
+                                River Name: {attributes.WSR_RIVER_SHORTNAME}
+                              </strong>
                             </FeatureTitle>
 
                             <table className="table">
                               <tbody>
                                 <tr>
                                   <td>
-                                    <em>Short Name</em>
-                                  </td>
-                                  <td>{attributes.WSR_RIVER_SHORTNAME}</td>
-                                </tr>
-
-                                <tr>
-                                  <td>
                                     <em>Agency</em>
                                   </td>
-                                  <td>{attributes.AGENCY}</td>
+                                  <td>
+                                    {convertAgencyCode(attributes.AGENCY)}
+                                  </td>
                                 </tr>
 
                                 <tr>
@@ -661,7 +675,11 @@ function Protect() {
                                   <td>
                                     <em>Managing Entities</em>
                                   </td>
-                                  <td>{attributes.MANAGING_ENTITIES}</td>
+                                  <td>
+                                    {convertAgencyCode(
+                                      attributes.MANAGING_ENTITIES,
+                                    )}
+                                  </td>
                                 </tr>
 
                                 <tr>
@@ -690,14 +708,20 @@ function Protect() {
                                     <em>Website</em>
                                   </td>
                                   <td>
-                                    <a
-                                      href={attributes.WEBLINK}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                    >
-                                      {attributes.WEBLINK}
-                                    </a>{' '}
-                                    (opens new browser tab)
+                                    {attributes.WEBLINK ? (
+                                      <>
+                                        <a
+                                          href={attributes.WEBLINK}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                        >
+                                          {attributes.WEBLINK}
+                                        </a>{' '}
+                                        (opens new browser tab)
+                                      </>
+                                    ) : (
+                                      'Not available.'
+                                    )}
                                   </td>
                                 </tr>
                               </tbody>

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -15,7 +15,6 @@ import {
   createUniqueValueInfos,
   getPopupContent,
   getPopupTitle,
-  plotWildScenicRivers,
   plotProtectedAreas,
 } from 'components/pages/LocationMap/MapFunctions';
 import MapErrorBoundary from 'components/shared/ErrorBoundary/MapErrorBoundary';
@@ -128,8 +127,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setWaterbodyLayer,
     setIssuesLayer,
     setMonitoringStationsLayer,
-    wildScenicRiversLayer,
-    setWildScenicRiversLayer,
     protectedAreasLayer,
     setProtectedAreasLayer,
     setUpstreamLayer,
@@ -216,14 +213,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
     setMonitoringStationsLayer(monitoringStationsLayer);
 
-    const wildScenicRiversLayer = new GraphicsLayer({
-      id: 'wildScenicRiversLayer',
-      title: 'Wild and Scenic Rivers',
-      listMode: 'hide',
-    });
-
-    setWildScenicRiversLayer(wildScenicRiversLayer);
-
     const protectedAreasLayer = new GraphicsLayer({
       id: 'protectedAreasLayer',
       title: 'Protected Areas',
@@ -262,7 +251,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       boundariesLayer,
       upstreamLayer,
       monitoringStationsLayer,
-      wildScenicRiversLayer,
       protectedAreasLayer,
       issuesLayer,
       dischargersLayer,
@@ -280,7 +268,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setIssuesLayer,
     setLayers,
     setMonitoringStationsLayer,
-    setWildScenicRiversLayer,
     setProtectedAreasLayer,
     setUpstreamLayer,
     setNonprofitsLayer,
@@ -764,7 +751,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
       const query = new Query({
         geometry: boundaries.features[0].geometry,
-        returnGeometry: true,
+        returnGeometry: false,
         spatialReference: 102100,
         outFields: ['*'],
       });
@@ -783,7 +770,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             data: res.features,
             status: 'success',
           });
-          plotWildScenicRivers(Graphic, res.features, wildScenicRiversLayer);
         })
         .catch((err) => {
           console.error(err);
@@ -793,14 +779,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           });
         });
     },
-    [
-      services,
-      Graphic,
-      Query,
-      QueryTask,
-      setWildScenicRiversData,
-      wildScenicRiversLayer,
-    ],
+    [services, Query, QueryTask, setWildScenicRiversData],
   );
 
   const getProtectedAreas = React.useCallback(

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -76,6 +76,7 @@ const orderedLayers = [
   'tribalLayer-2',
   'tribalLayer-4',
   'wsioHealthIndexLayer',
+  'wildScenicRiversLayer',
   'searchIconLayer',
 ];
 

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -109,7 +109,8 @@ const ScenicRiverImageContainer = styled.div`
 `;
 
 const ScenicRiverImage = styled.img`
-  max-width: 100%;
+  width: 100%;
+  height: auto;
 `;
 
 // --- components ---

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -11,7 +11,7 @@ import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // utilities
 import { impairmentFields, useFields } from 'config/attainsToHmwMapping';
 import { getWaterbodyCondition } from 'components/pages/LocationMap/MapFunctions';
-import { formatNumber } from 'utils/utils';
+import { formatNumber, convertAgencyCode } from 'utils/utils';
 import { fetchCheck } from 'utils/fetchUtils';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
@@ -931,28 +931,27 @@ function WaterbodyInfo({
   // jsx
   const wildScenicRiversContent = (
     <>
-      <ScenicRiverImageContainer>
-        <ScenicRiverImage
-          src={attributes.PhotoLink}
-          alt="Wild and Scenic River"
-        ></ScenicRiverImage>
-
-        <br />
-
-        <em>Photo Credit: {attributes.PhotoCredit}</em>
-      </ScenicRiverImageContainer>
-
+      {attributes.PhotoLink && attributes.PhotoCredit && (
+        <>
+          <ScenicRiverImageContainer>
+            <ScenicRiverImage
+              src={attributes.PhotoLink}
+              alt="Wild and Scenic River"
+            ></ScenicRiverImage>
+            <br />
+            <em>Photo Credit: {attributes.PhotoCredit}</em>
+          </ScenicRiverImageContainer>
+        </>
+      )}
       <p>
         <strong>Agency: </strong>
-        {attributes.AGENCY}
+        {convertAgencyCode(attributes.AGENCY)}
       </p>
-
       <p>
         <strong>Category: </strong>
         {attributes.RiverCategory}
         <br />
       </p>
-
       <div>
         <a rel="noopener noreferrer" target="_blank" href={attributes.WEBLINK}>
           <Icon className="fas fa-info-circle" aria-hidden="true" />

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -433,7 +433,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
         upstreamLayer,
         dischargersLayer,
         nonprofitsLayer,
-        wildScenicRiversLayer,
         protectedAreasLayer,
         mapView,
         homeWidget,
@@ -484,7 +483,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       if (monitoringStationsLayer) monitoringStationsLayer.graphics.removeAll();
       if (dischargersLayer) dischargersLayer.graphics.removeAll();
       if (nonprofitsLayer) nonprofitsLayer.graphics.removeAll();
-      if (wildScenicRiversLayer) wildScenicRiversLayer.graphics.removeAll();
       if (protectedAreasLayer) protectedAreasLayer.graphics.removeAll();
 
       // reset the zoom and home widget to the initial extent

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -609,7 +609,10 @@ function useSharedLayers() {
   const { FeatureLayer, GroupLayer, MapImageLayer } = React.useContext(
     EsriModulesContext,
   );
-  const { setWsioHealthIndexLayer } = React.useContext(LocationSearchContext);
+  const {
+    setWsioHealthIndexLayer,
+    setWildScenicRiversLayer,
+  } = React.useContext(LocationSearchContext);
 
   const getDynamicPopup = useDynamicPopup();
   const { getTitle, getTemplate } = getDynamicPopup();
@@ -733,6 +736,32 @@ function useSharedLayers() {
     });
 
     setWsioHealthIndexLayer(wsioHealthIndexLayer);
+
+    const wildScenicRiversRenderer = {
+      type: 'simple',
+      symbol: {
+        type: 'simple-line',
+        color: [0, 123, 255],
+        width: 3,
+      },
+    };
+
+    const wildScenicRiversLayer = new FeatureLayer({
+      id: 'wildScenicRiversLayer',
+      url: services.data.wildScenicRivers,
+      title: 'Wild and Scenic Rivers',
+      outFields: ['*'],
+      renderer: wildScenicRiversRenderer,
+      listMode: 'hide',
+      visible: false,
+      popupTemplate: {
+        title: getTitle,
+        content: getTemplate,
+        outFields: ['*'],
+      },
+    });
+
+    setWildScenicRiversLayer(wildScenicRiversLayer);
 
     // START - Tribal layers
     const renderer = {
@@ -898,6 +927,7 @@ function useSharedLayers() {
 
     return [
       wsioHealthIndexLayer,
+      wildScenicRiversLayer,
       tribalLayer,
       congressionalLayer,
       stateBoundariesLayer,

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -236,6 +236,27 @@ function browserIsCompatibleWithArcGIS() {
   return true;
 }
 
+function convertAgencyCode(agencyShortCode) {
+  if (!agencyShortCode) return 'Unknown';
+
+  // services returns multiple agencies as a string. ex: 'USFS, FWS, NPS'
+  const agencies = agencyShortCode.split(',');
+  const convertedAgencies = agencies
+    .map((agency) => {
+      const code = agency.trim();
+      if (code === 'BLM') return 'Bureau of Land Management';
+      if (code === 'NPS') return 'U.S. National Park Service';
+      if (code === 'NSFS') return 'United States Forest Service';
+      if (code === 'FWS') return 'U.S. Fish and Wildlife Service';
+      if (code === 'USFS') return 'United States Forest Service';
+      return code;
+    })
+    .join(', ');
+
+  console.log(convertedAgencies);
+  return convertedAgencies;
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -253,4 +274,5 @@ export {
   splitSuggestedSearch,
   getSimplePopupTemplate,
   browserIsCompatibleWithArcGIS,
+  convertAgencyCode,
 };

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -239,7 +239,7 @@ function browserIsCompatibleWithArcGIS() {
 function convertAgencyCode(agencyShortCode) {
   if (!agencyShortCode) return 'Unknown';
 
-  // services returns multiple agencies as a string. ex: 'USFS, FWS, NPS'
+  // Wild and Scenic Rivers service returns multiple agencies as a string. ex: 'USFS, FWS, NPS'
   const agencies = agencyShortCode.split(',');
   const convertedAgencies = agencies
     .map((agency) => {

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -253,7 +253,6 @@ function convertAgencyCode(agencyShortCode) {
     })
     .join(', ');
 
-  console.log(convertedAgencies);
   return convertedAgencies;
 }
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3671497

## Main Changes:
* Displays all Wild and Scenic Rivers regardless of them being in the HUC boundaries
* Updates Protect tab content based on feedback
* Converts Agency codes for Wild and Scenic Rivers service to their full names
* Shows and hides text when the Show Text switch is toggled on the Protect tab

## Steps To Test:
1. Navigate to http://localhost:3000/community/troutdale/protect
2. Verify Protect tab contents match mockups in ticket.
3. Turn on the Wild and Scenic Rivers layer. Verify all features in the US can be seen and clicked on.
4. Verify agency codes are correctly converted to their full names in the Wild and Scenic Rivers accordion and popups.
5. Toggle the Show Text switch and verify text is hidden and shown on Protect tab.
