### PR TITLE
Feature/esri search widget overlap

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -109,6 +109,10 @@ const SearchBox = styled.div`
     color: rgb(204, 204, 204);
     font-weight: 900;
   }
+
+  .esri-menu {
+    z-index: 1000;
+  }
 `;
 
 // --- components ---


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3683298

Image of issue:
![image](https://user-images.githubusercontent.com/17204883/105541108-4623dc00-5cc5-11eb-9c52-06efcaceeee8.png)


## Main Changes:
* Increases z-index of Esri Search menu to ensure it is always on top.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open dev tools and set screen size to a mobile device.
3. Search a location and verify the results dropdown is above the selected Community tab.
4. Expand the "Search in" dropdown and verify the dropdown is above the selected Community tab.
