### PR TITLE
Feature/update esri api endpoint

### DIFF
--- a/app/client/src/config/esriConfig.js
+++ b/app/client/src/config/esriConfig.js
@@ -1,1 +1,1 @@
-export const esriApiUrl = 'https://js.arcgis.com/4.16';
+export const esriApiUrl = 'https://js.arcgis.com/4.16/dojo/dojo.js';


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3685332

## Main Changes:
* Updates the ArcGIS endpoint URL to prevent a 301 redirect.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the developer tools network tab and do a hard refresh.
3. Enter "4.16" in the filter and look for the dojo.js request.
4. There should be no 301 redirect prior to it as seen below.
![image](https://user-images.githubusercontent.com/17204883/105716325-a8125a80-5eec-11eb-8e0f-0efe0990674a.png)
5. Verify map behaves normally.


