### PR TITLE
Feature/combine tribes sources

### DIFF
--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -204,3 +204,7 @@
 .hidden {
   display: none !important;
 }
+
+.esri-menu__list-item:first-child {
+  border-top: solid 1px rgba(110, 110, 110, 0.3);
+}

--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -205,6 +205,6 @@
   display: none !important;
 }
 
-.esri-menu__list-item:first-child {
+/* .esri-menu__list-item:first-child {
   border-top: solid 1px rgba(110, 110, 110, 0.3);
-}
+} */

--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -204,7 +204,3 @@
 .hidden {
   display: none !important;
 }
-
-/* .esri-menu__list-item:first-child {
-  border-top: solid 1px rgba(110, 110, 110, 0.3);
-} */

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -11,34 +11,21 @@ import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // helpers
+import { useKeyPress } from 'utils/hooks';
 import { containsScriptTag, isHuc12, splitSuggestedSearch } from 'utils/utils';
 // styles
 import { colors } from 'styles/index.js';
 // errors
 import { invalidSearchError } from 'config/errorMessages';
 
-// Polls the dom, based on provided classname and timeout, until the esri search
-// input is added. Once the input is added this calls the provided callback.
-function poll({
-  className,
-  checkText = false,
-  timeout = 250,
-  callback,
-}: {
-  className: string,
-  checkText: boolean,
-  timeout: number,
-  callback: Function,
-}) {
-  const items = document.getElementsByClassName(className);
-  if (items.length === 0 || (checkText && items[0].innerText === '')) {
-    setTimeout(
-      () => poll({ className, checkText, timeout, callback }),
-      timeout,
-    );
-  } else {
-    callback(items);
-  }
+// Finds the source of the suggestion
+function findSource(name, suggestions) {
+  let source = null;
+  suggestions.forEach((item) => {
+    if (item.source.name === name) source = item;
+  });
+
+  return source;
 }
 
 // --- styled components ---
@@ -133,6 +120,14 @@ const SearchBox = styled.div`
     color: rgb(204, 204, 204);
     font-weight: 900;
   }
+
+  .esri-menu__list-item::hover {
+    background-color: #f3f3f3;
+  }
+
+  .esri-menu__list-item-active {
+    background-color: #e2f1fb;
+  }
 `;
 
 // --- components ---
@@ -143,6 +138,10 @@ type Props = {
 
 function LocationSearch({ route, label }: Props) {
   const services = useServicesContext();
+  const searchBox = React.createRef();
+  const downPress = useKeyPress('ArrowDown', searchBox);
+  const upPress = useKeyPress('ArrowUp', searchBox);
+  const enterPress = useKeyPress('Enter', searchBox);
   const { FeatureLayer, Locator, Point, Search, watchUtils } = React.useContext(
     EsriModulesContext,
   );
@@ -150,32 +149,15 @@ function LocationSearch({ route, label }: Props) {
     LocationSearchContext,
   );
 
-  // geolocating state for updating the 'Use My Location' button
-  const [geolocating, setGeolocating] = React.useState(false);
-
-  // geolocationError state for disabling the 'Use My Location' button
-  const [geolocationError, setGeolocationError] = React.useState(false);
-
-  // initialize inputText from searchText context
-  const [inputText, setInputText] = React.useState(searchText);
-  const [selectedResult, setSelectedResult] = React.useState(null);
-
-  // update inputText whenever searchText changes (i.e. Form onSubmit)
-  React.useEffect(() => setInputText(searchText), [searchText]);
-
-  const [errorMessage, setErrorMessage] = React.useState('');
-
-  // Initialize the esri search widget
-  const [searchWidget, setSearchWidget] = React.useState(null);
-  React.useEffect(() => {
-    if (searchWidget) return;
-
-    const placeholder = 'Search by address, zip code, or place...';
-    const search = new Search({
-      allPlaceholder: placeholder,
-      container: 'search-container',
-      locationEnabled: false,
-      label: 'Search',
+  const placeholder = 'Search by address, zip code, or place...';
+  const [allSources] = React.useState([
+    {
+      type: 'default',
+      name: 'All',
+    },
+    {
+      type: 'group',
+      name: 'EPA Tribal Areas',
       sources: [
         {
           layer: new FeatureLayer({
@@ -214,19 +196,41 @@ function LocationSearch({ route, label }: Props) {
           name: 'EPA Tribal Areas - Alaska Reservations',
         },
       ],
+    },
+  ]);
+
+  // geolocating state for updating the 'Use My Location' button
+  const [geolocating, setGeolocating] = React.useState(false);
+
+  // geolocationError state for disabling the 'Use My Location' button
+  const [geolocationError, setGeolocationError] = React.useState(false);
+
+  // initialize inputText from searchText context
+  const [inputText, setInputText] = React.useState(searchText);
+  const [selectedResult, setSelectedResult] = React.useState(null);
+
+  // update inputText whenever searchText changes (i.e. Form onSubmit)
+  React.useEffect(() => setInputText(searchText), [searchText]);
+
+  const [errorMessage, setErrorMessage] = React.useState('');
+
+  // Initialize the esri search widget
+  const [searchWidget, setSearchWidget] = React.useState(null);
+  const [suggestions, setSuggestions] = React.useState([]);
+  React.useEffect(() => {
+    if (searchWidget) return;
+
+    const sources = [];
+    allSources.forEach((source) => {
+      if (source.type === 'default') return;
+      sources.push(...source.sources);
     });
 
-    // poll until the sources menu is visible
-    poll({
-      className: 'esri-search__source',
-      checkText: true,
-      callback: (sources) => {
-        sources.forEach((source) => {
-          if (source.innerText === 'ArcGIS World Geocoding Service') {
-            source.innerText = 'Address, zip code, and place search';
-          }
-        });
-      },
+    const search = new Search({
+      allPlaceholder: placeholder,
+      locationEnabled: false,
+      label: 'Search',
+      sources,
     });
 
     // create a watcher for the input text
@@ -236,51 +240,15 @@ function LocationSearch({ route, label }: Props) {
       (newVal, oldVal, propName, event) => {
         setSelectedResult(null);
         setInputText(newVal);
-
-        // poll until the suggestion div is visible
-        poll({
-          className: 'esri-menu__header',
-          callback: (headers) => {
-            headers.forEach((header) => {
-              if (header.innerText === 'ArcGIS World Geocoding Service') {
-                header.innerText = 'Address, zip code, and place search';
-              }
-            });
-          },
-        });
       },
     );
 
+    // create a watcher for the suggestions based on search input
     watchUtils.watch(
       search,
       'suggestions',
       (newVal, oldVal, propName, event) => {
-        // poll until the suggestion div is visible
-        poll({
-          className: 'esri-menu__header',
-          callback: (headers) => {
-            setTimeout(() => {
-              let first = true;
-
-              headers.forEach((header) => {
-                if (header.innerText === 'ArcGIS World Geocoding Service') {
-                  header.innerText = 'Address, zip code, and place search';
-                }
-
-                if (header.innerText.indexOf('EPA Tribal Areas') > -1) {
-                  if (first) {
-                    header.style.display = 'block';
-                    header.innerText = 'EPA Tribal Areas';
-                    first = false;
-                    return;
-                  }
-
-                  header.style.display = 'none';
-                }
-              });
-            }, 100);
-          },
-        });
+        setSuggestions(newVal ? newVal : []);
       },
     );
 
@@ -310,6 +278,7 @@ function LocationSearch({ route, label }: Props) {
     searchWidget,
     services,
     searchText,
+    allSources,
   ]);
 
   // Initialize the esri search widget value with the search text.
@@ -323,35 +292,172 @@ function LocationSearch({ route, label }: Props) {
     ).searchPart;
   }, [Point, searchWidget, searchText]);
 
-  // Adds additional info to search box if the search was a huc12
+  // Updates the search widget sources whenever the user selects a source.
+  const [sourcesVisible, setSourcesVisible] = React.useState(false);
+  const [selectedSource, setSelectedSource] = React.useState('All');
+  const [suggestionsVisible, setSuggestionsVisible] = React.useState(false);
   React.useEffect(() => {
     if (!searchWidget) return;
 
-    // Remove coordinates if search text was from non-esri suggestions
-    const searchTerm = splitSuggestedSearch(Point, searchText).searchPart;
+    const sources = [];
 
-    // Set the input text to be more detailed if the search is a huc
-    if (inputText === searchTerm && isHuc12(inputText) && watershed && huc12) {
-      searchWidget.searchTerm = `WATERSHED: ${watershed} (${huc12})`;
+    if (selectedSource === 'All') {
+      allSources.forEach((source) => {
+        if (source.type === 'default') return;
+        sources.push(...source.sources);
+      });
+      searchWidget.includeDefaultSources = true;
+      searchWidget.sources = sources;
+    } else {
+      allSources.forEach((source) => {
+        if (source.name !== selectedSource) return;
+        sources.push(...source.sources);
+      });
+      searchWidget.includeDefaultSources = false;
+      searchWidget.sources = sources;
     }
-  }, [Point, searchWidget, searchText, huc12, inputText, watershed]);
 
-  // Starts a poll which eventually sets the id of the esri search input.
-  // This code is needed to work aroudn a 508 compliance issue. Adding the
-  // id to the Search constructor (above) does not add an id to the DOM element.
-  const [pollInitialized, setPollInitialized] = React.useState(false);
+    if (searchWidget.searchTerm) {
+      searchWidget.suggest();
+    }
+  }, [allSources, searchWidget, selectedSource]);
+
+  // filter the suggestions down to just sources that have results
+  // and combine grouped sources
+  const [filteredSuggestions, setFilteredSuggestions] = React.useState([]);
+  const [resultsCombined, setResultsCombined] = React.useState([]);
   React.useEffect(() => {
-    if (pollInitialized) return;
+    const filteredSuggestions = [];
+    const resultsCombined = [];
 
-    setPollInitialized(true);
+    allSources.forEach((item) => {
+      if (item.type === 'default') {
+        const sug = findSource('ArcGIS World Geocoding Service', suggestions);
+        if (sug && sug.results.length > 0) {
+          filteredSuggestions.push(sug);
+          resultsCombined.push(...sug.results);
+        }
+        return;
+      }
 
-    poll({
-      className: 'esri-search__input',
-      callback: (searchInputs) => {
-        searchInputs[0].setAttribute('id', 'hmw-search-input');
-      },
+      // combine group sources into a single source, i.e. combine the 3 tribes
+      // sources into one source
+      const results = [];
+      let source = null;
+      let sourceIndex = -1;
+      item.sources.forEach((item2) => {
+        const sug = findSource(item2.name, suggestions);
+        if (!sug) return;
+
+        if (!source) {
+          source = sug.source;
+          sourceIndex = sug.sourceIndex;
+        }
+        results.push(...sug.results);
+      });
+
+      if (results.length > 0) {
+        filteredSuggestions.push({
+          results,
+          source,
+          sourceIndex,
+        });
+        resultsCombined.push(...results);
+      }
     });
-  }, [pollInitialized]);
+    setFilteredSuggestions(filteredSuggestions);
+    setResultsCombined(resultsCombined);
+  }, [allSources, suggestions]);
+
+  const [cursor, setCursor] = React.useState(-1);
+
+  // Handle arrow down key press
+  React.useEffect(() => {
+    if (resultsCombined.length > 0 && downPress) {
+      setCursor((prevState) => {
+        const newIndex =
+          prevState < resultsCombined.length - 1 ? prevState + 1 : 0;
+
+        // scroll to the suggestion
+        const elm = document.getElementById(`search-suggestion-${newIndex}`);
+        const panel = document.getElementById('search-container-suggest-menu');
+        if (elm && panel) panel.scrollTop = elm.offsetTop;
+
+        return newIndex;
+      });
+    }
+  }, [resultsCombined, downPress]);
+
+  // Handle arrow up key press
+  React.useEffect(() => {
+    if (resultsCombined.length > 0 && upPress) {
+      setCursor((prevState) => {
+        const newIndex =
+          prevState > 0 ? prevState - 1 : resultsCombined.length - 1;
+
+        // scroll to the suggestion
+        const elm = document.getElementById(`search-suggestion-${newIndex}`);
+        const panel = document.getElementById('search-container-suggest-menu');
+        if (elm && panel) panel.scrollTop = elm.offsetTop;
+
+        return newIndex;
+      });
+    }
+  }, [resultsCombined, upPress]);
+
+  // Handle enter key press
+  React.useEffect(() => {
+    if (resultsCombined.length > 0 && enterPress) {
+      setInputText(resultsCombined[cursor].text);
+    }
+  }, [cursor, enterPress, resultsCombined]);
+
+  let index = -1;
+  function LayerSuggestions({ title, results }) {
+    return (
+      <>
+        <div className="esri-menu__header">{title}</div>
+        <ul
+          role="presentation"
+          className="esri-menu__list esri-search__suggestions-list"
+        >
+          {results.map((result) => {
+            index = index + 1;
+            return (
+              <li
+                id={`search-suggestion-${index}`}
+                role="menuitem"
+                className={`esri-menu__list-item ${
+                  index === cursor ? 'esri-menu__list-item-active' : ''
+                }`}
+                key={result.key}
+                onClick={() => {
+                  setInputText(result.text);
+                  setSuggestionsVisible(false);
+
+                  if (!searchWidget) return;
+                  searchWidget.searchTerm = result.text;
+                  searchWidget.search(result.text);
+                }}
+              >
+                {result.text
+                  .split(new RegExp(`(${inputText})`, 'gi'))
+                  .map((part) => {
+                    if (part.toLowerCase() === inputText.toLowerCase()) {
+                      return <strong>{part}</strong>;
+                    } else {
+                      return part;
+                    }
+                  })}
+              </li>
+            );
+          })}
+        </ul>
+      </>
+    );
+  }
+
+  const searchTerm = splitSuggestedSearch(Point, searchText).searchPart;
 
   return (
     <>
@@ -364,6 +470,8 @@ function LocationSearch({ route, label }: Props) {
       <Form
         onSubmit={(ev) => {
           ev.preventDefault();
+
+          setSuggestionsVisible(false);
 
           if (containsScriptTag(inputText)) {
             setErrorMessage(invalidSearchError);
@@ -391,7 +499,189 @@ function LocationSearch({ route, label }: Props) {
           }
         }}
       >
-        <SearchBox id="search-container" />
+        <SearchBox>
+          <div
+            role="presentation"
+            className={`esri-search-multiple-sources esri-search__container ${
+              sourcesVisible ? 'esri-search--sources' : ''
+            } ${
+              filteredSuggestions.length > 0
+                ? 'esri-search--show-suggestions'
+                : ''
+            }`}
+          >
+            <div
+              role="button"
+              title="Search in"
+              aria-haspopup="true"
+              aria-controls="search-container-source-menu"
+              className="esri-search__sources-button esri-widget--button"
+              tabIndex="0"
+              data-node-ref="_sourceMenuButtonNode"
+              onClick={() => {
+                setSourcesVisible(!sourcesVisible);
+                setSuggestionsVisible(false);
+              }}
+            >
+              <span
+                aria-hidden="true"
+                role="presentation"
+                className="esri-icon-down-arrow esri-search__sources-button--down"
+              ></span>
+              <span
+                aria-hidden="true"
+                role="presentation"
+                className="esri-icon-up-arrow esri-search__sources-button--up"
+              ></span>
+              <span
+                aria-hidden="true"
+                role="presentation"
+                className="esri-search__source-name"
+              >
+                {selectedSource}
+              </span>
+            </div>
+            <div tabIndex="0" className="esri-menu esri-search__sources-menu">
+              <ul
+                id="search-container-source-menu"
+                role="menu"
+                data-node-ref="_sourceListNode"
+                className="esri-menu__list"
+              >
+                {allSources.map((source, index) => {
+                  return (
+                    <li
+                      role="menuitem"
+                      className={`esri-search__source esri-menu__list-item ${
+                        selectedSource === source.name
+                          ? 'esri-menu__list-item--active'
+                          : ''
+                      }`}
+                      tabIndex="-1"
+                      key={index}
+                      onClick={() => {
+                        setSelectedSource(source.name);
+                        setSourcesVisible(false);
+                      }}
+                    >
+                      {source.name}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+            <div className="esri-search__input-container">
+              <div className="esri-search__form" role="search">
+                <input
+                  id="hmw-search-input"
+                  type="text"
+                  ref={searchBox}
+                  placeholder={placeholder}
+                  aria-label="Search"
+                  autoComplete="off"
+                  tabIndex="0"
+                  className="esri-input esri-search__input"
+                  aria-autocomplete="list"
+                  aria-haspopup="true"
+                  data-node-ref="_inputNode"
+                  title={placeholder}
+                  value={
+                    inputText === searchTerm &&
+                    isHuc12(inputText) &&
+                    watershed &&
+                    huc12
+                      ? `WATERSHED: ${watershed} (${huc12})`
+                      : inputText.indexOf('|') > -1
+                      ? inputText.split('|')[0]
+                      : inputText
+                  }
+                  onChange={(ev) => {
+                    setInputText(ev.target.value);
+                    setSuggestionsVisible(true);
+
+                    if (!searchWidget) return;
+                    searchWidget.searchTerm = ev.target.value;
+                    searchWidget.suggest();
+                  }}
+                  onFocus={(ev) => {
+                    setSourcesVisible(false);
+                    setSuggestionsVisible(true);
+                  }}
+                  aria-owns={
+                    filteredSuggestions.length > 0
+                      ? 'search-container-suggest-menu'
+                      : ''
+                  }
+                />
+              </div>
+              {filteredSuggestions.length > 0 && suggestionsVisible && (
+                <div
+                  id="search-container-suggest-menu"
+                  className="esri-menu esri-search__suggestions-menu"
+                  role="menu"
+                  data-node-ref="_suggestionListNode"
+                >
+                  {filteredSuggestions.map((source, index) => {
+                    function findGroupName() {
+                      if (
+                        source.source.name === 'ArcGIS World Geocoding Service'
+                      ) {
+                        return 'Esri World GeoCoder';
+                      }
+
+                      let title = '';
+                      allSources.forEach((item) => {
+                        if (item.type === 'default') return;
+
+                        item.sources.forEach((nestedItem) => {
+                          if (nestedItem.name === source.source.name) {
+                            title = item.name;
+                          }
+                        });
+                      });
+                      return title;
+                    }
+                    if (source.results.length === 0) return null;
+
+                    const title = findGroupName();
+                    return (
+                      <LayerSuggestions
+                        title={title}
+                        results={source.results}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+              {inputText && (
+                <div
+                  role="button"
+                  className="esri-search__clear-button esri-widget--button"
+                  tabIndex="0"
+                  title="Clear search"
+                  onClick={() => {
+                    if (searchWidget) searchWidget.searchTerm = '';
+                    setInputText('');
+                    setSourcesVisible(false);
+                    setSuggestionsVisible(false);
+                  }}
+                >
+                  <span aria-hidden="true" className="esri-icon-close"></span>
+                </div>
+              )}
+            </div>
+            <div className="esri-menu esri-search__warning-menu">
+              <div className="esri-search__warning-body">
+                <div>
+                  <div className="esri-search__warning-header">No results</div>
+                  <div className="esri-search__warning-text">
+                    There were no results found for {inputText}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </SearchBox>
 
         <Button
           className="btn"

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -251,6 +251,39 @@ function LocationSearch({ route, label }: Props) {
       },
     );
 
+    watchUtils.watch(
+      search,
+      'suggestions',
+      (newVal, oldVal, propName, event) => {
+        // poll until the suggestion div is visible
+        poll({
+          className: 'esri-menu__header',
+          callback: (headers) => {
+            setTimeout(() => {
+              let first = true;
+
+              headers.forEach((header) => {
+                if (header.innerText === 'ArcGIS World Geocoding Service') {
+                  header.innerText = 'Address, zip code, and place search';
+                }
+
+                if (header.innerText.indexOf('EPA Tribal Areas') > -1) {
+                  if (first) {
+                    header.style.display = 'block';
+                    header.innerText = 'EPA Tribal Areas';
+                    first = false;
+                    return;
+                  }
+
+                  header.style.display = 'none';
+                }
+              });
+            }, 100);
+          },
+        });
+      },
+    );
+
     // create a watcher for the selected suggestion. This is used for getting
     // the lat/long of the selected suggestion, to ensure the locator zooms to the
     // suggestion rather than the highest scored text.

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -643,7 +643,7 @@ function LocationSearch({ route, label }: Props) {
             </div>
             <div
               id="search-container-source-menu-div"
-              tabIndex="0"
+              tabIndex="-1"
               className="esri-menu esri-search__sources-menu"
             >
               <ul
@@ -720,6 +720,11 @@ function LocationSearch({ route, label }: Props) {
                     setSourcesVisible(false);
                     setSuggestionsVisible(true);
                     setCursor(-1);
+                  }}
+                  onBlur={(ev) => {
+                    setTimeout(() => {
+                      setSuggestionsVisible(false);
+                    }, 250);
                   }}
                   aria-owns={
                     filteredSuggestions.length > 0

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -315,7 +315,6 @@ function LocationSearch({ route, label }: Props) {
     poll({
       className: 'esri-search__input',
       callback: (searchInputs) => {
-        console.log('searchInputs: ', searchInputs);
         searchInputs[0].setAttribute('id', 'hmw-search-input');
       },
     });

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -938,6 +938,39 @@ function useSharedLayers() {
   };
 }
 
+// Custom hook that is used for handling key presses. This can be used for
+// navigating lists with a keyboard.
+function useKeyPress(targetKey: string, ref: Object) {
+  const [keyPressed, setKeyPressed] = React.useState(false);
+
+  function downHandler({ key }: { key: string }) {
+    if (key === targetKey) {
+      setKeyPressed(true);
+    }
+  }
+
+  const upHandler = ({ key }: { key: string }) => {
+    if (key === targetKey) {
+      setKeyPressed(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!ref?.current?.addEventListener) return;
+    const tempRef = ref.current;
+
+    ref.current.addEventListener('keydown', downHandler);
+    ref.current.addEventListener('keyup', upHandler);
+
+    return function cleanup() {
+      tempRef.removeEventListener('keydown', downHandler);
+      tempRef.removeEventListener('keyup', upHandler);
+    };
+  });
+
+  return keyPressed;
+}
+
 export {
   useSharedLayers,
   useWaterbodyFeatures,
@@ -945,4 +978,5 @@ export {
   useWaterbodyOnMap,
   useWaterbodyHighlight,
   useDynamicPopup,
+  useKeyPress,
 };


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3672373
* https://app.breeze.pm/projects/100762/cards/3672364

## Main Changes:
* Renamed the default "Esri World Geocoder" to "Address, zip code, and place search".
* Combined the Tribes search sources into a single source.
  * I kept running into issues trying to use JavaScript/CSS to accomplish this. I ended up making my own Search widget that utilizes the Esri Search widget to get the suggestions. This will be more flexible and make it easier for us to make changes to this search widget.

## Steps To Test:
1. Type something into the location search
2. Verify the first header says "Address, zip code, and place search" instead of "ArcGIS World Geocoding Service"
3. Type "reserv" in the location search widget
4. Verify the results only displays one "EPA Tribal Areas" header
  * The current version of HMW displays "EPA Tribal Areas - Lower 48 States" and "EPA Tribal Areas - Alaska Reservations" 
5. Click the down arrow to the left of the search widget
6. Verify the following items are visible: "All", "Address, zip code, and place search", and "EPA Tribal Areas". 
7. Test keyboard navigation around the search widget

