### PR TITLE
bugfix/add-data-widget-layers-gone-after-fullscreen

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/URLPanel.js
@@ -96,17 +96,21 @@ function URLPanel() {
     // add the layer to the map
     mapView.map.add(layer);
 
-    layer.on('layerview-create', (event) => {
+    const createHandler = layer.on('layerview-create', (event) => {
       setWidgetLayers((widgetLayers) => [...widgetLayers, layer]);
       setStatus('success');
+
+      createHandler.remove();
     });
 
-    layer.on('layerview-create-error', (event) => {
+    const errorHandler = layer.on('layerview-create-error', (event) => {
       console.error('create error event: ', event);
 
       mapView.map.remove(layer);
 
       setStatus('failure');
+
+      errorHandler.remove();
     });
 
     setLayer(null);

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -246,7 +246,8 @@ function MapWidgets({
 
     map.removeAll();
     map.addMany(layers);
-  }, [layers, map]);
+    map.addMany(widgetLayers);
+  }, [layers, map, widgetLayers]);
 
   // put the home widget back on the ui after the window is resized
   React.useEffect(() => {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3692512

## Main Changes:
* Fixed issue with layers, from add data widget, disappearing after toggling full screen mode.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the Add Data Widget
3. Add a layer from the Search panel
4. Add a layer from the URL panel
5. Add a layer from the File panel
6. Go to full screen mode
7. Verify that all layers are visible
8. Go back to normal mode
9. Verify that all layers are visible

## TODO:
- [ ] Change this
- [ ] Update that
- [ ] Remove this
