### PR TITLE
Bugfix/protected areas legend issues

### DIFF
--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -191,6 +191,10 @@ export const uploadSuccessMessage = (filename, layerName = '') => {
     : `"${filename}" was successfully uploaded as "${layerName}"`;
 };
 
+// Legend //
+export const legendUnavailableError = (layerName) =>
+  `The legend for ${layerName} is temporarily unavailble, please try again later.`;
+
 // Error Boundaries //
 export const servicesLookupServiceError =
   "How's My Waterway is temporarily unavailable, please try again later.";


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3692606

## Main Changes:
* Fixed issue of protected areas legend not showing up correctly after clicking an item on the map.
  * I ended up just fetching the map server to get the legend and rebuilding the legend. This will give us more control over what gets displayed. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/1954%20Parkersburg%20Tpke,%20Swoope,%20Virginia,%2024479/protect
2. Turn the protected areas layer on
3. Open the legend
4. Verify the protected areas shows up in the legend
5. Verify the protected areas legend has a subtitle of "Protection Category"
6. Click one of the protected areas features on the map
7. Verify the protected areas legend only has one "Other" item listed\
