### PR TITLE
Bugfix/hide failed layers from layerlist…

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -355,6 +355,45 @@ function IdentifiedIssues() {
     setNullPollutedWaterbodies(nullPollutedWaterbodies);
   }, [cipSummary]);
 
+  // Updates the visible layers. This function also takes into account whether
+  // or not the underlying webservices failed.
+  const updateVisibleLayers = React.useCallback(
+    (key = null, newValue = null) => {
+      const newVisibleLayers = {};
+      if (cipSummary.status !== 'failure') {
+        newVisibleLayers['issuesLayer'] = issuesLayer && showIssuesLayer;
+      }
+      if (permittedDischargers.status !== 'failure') {
+        newVisibleLayers['dischargersLayer'] =
+          dischargersLayer && showDischargersLayer;
+      }
+
+      if (newVisibleLayers.hasOwnProperty(key)) {
+        newVisibleLayers[key] = newValue;
+      }
+
+      // set the visible layers if something changed
+      if (JSON.stringify(visibleLayers) !== JSON.stringify(newVisibleLayers)) {
+        setVisibleLayers(newVisibleLayers);
+      }
+    },
+    [
+      dischargersLayer,
+      showDischargersLayer,
+      permittedDischargers,
+      issuesLayer,
+      showIssuesLayer,
+      cipSummary,
+      visibleLayers,
+      setVisibleLayers,
+    ],
+  );
+
+  // Updates visible layers based on webservice statuses.
+  React.useEffect(() => {
+    updateVisibleLayers();
+  }, [cipSummary, permittedDischargers, visibleLayers, updateVisibleLayers]);
+
   const checkIfAllSwitchesToggled = (
     cipSummaryData: Object,
     tempParameterToggleObject: Object,
@@ -385,16 +424,10 @@ function IdentifiedIssues() {
     if (!parameters.some(checkAnyCheckedParameters)) {
       setShowIssuesLayer(false);
 
-      setVisibleLayers({
-        issuesLayer: false,
-        dischargersLayer: dischargersLayer && showDischargersLayer,
-      });
+      updateVisibleLayers('issuesLayer', false);
     } else {
       setShowIssuesLayer(true);
-      setVisibleLayers({
-        issuesLayer: issuesLayer && true,
-        dischargersLayer: dischargersLayer && showDischargersLayer,
-      });
+      updateVisibleLayers('issuesLayer', true);
     }
 
     // check if any parameters are not checked. if all parameters are checked, set the showAllParameters switch to true
@@ -423,10 +456,7 @@ function IdentifiedIssues() {
       }
 
       setShowAllPolluted(true);
-      setVisibleLayers({
-        issuesLayer: true,
-        dischargersLayer: dischargersLayer && showDischargersLayer,
-      });
+      updateVisibleLayers('issuesLayer', true);
     };
 
     // set all parameters to Off and hide the issuesLayer
@@ -439,10 +469,7 @@ function IdentifiedIssues() {
       }
 
       setShowAllPolluted(false);
-      setVisibleLayers({
-        issuesLayer: false,
-        dischargersLayer: dischargersLayer && showDischargersLayer,
-      });
+      updateVisibleLayers('issuesLayer', false);
     };
 
     // if switch at top of table is switched
@@ -470,10 +497,10 @@ function IdentifiedIssues() {
       setShowDischargersLayer(!showDischargersLayer);
       checkDischargersToDisplay();
 
-      setVisibleLayers({
-        issuesLayer: issuesLayer && showIssuesLayer,
-        dischargersLayer: dischargersLayer && !showDischargersLayer,
-      });
+      updateVisibleLayers(
+        'dischargersLayer',
+        dischargersLayer && !showDischargersLayer,
+      );
     }
     // one of the parameters is switched
     else {

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -358,14 +358,19 @@ function IdentifiedIssues() {
   // Updates the visible layers. This function also takes into account whether
   // or not the underlying webservices failed.
   const updateVisibleLayers = React.useCallback(
-    (key = null, newValue = null) => {
+    ({ key = null, newValue = null, useCurrentValue = false }) => {
       const newVisibleLayers = {};
       if (cipSummary.status !== 'failure') {
-        newVisibleLayers['issuesLayer'] = issuesLayer && showIssuesLayer;
+        newVisibleLayers['issuesLayer'] =
+          !issuesLayer || useCurrentValue
+            ? visibleLayers['issuesLayer']
+            : showIssuesLayer;
       }
       if (permittedDischargers.status !== 'failure') {
         newVisibleLayers['dischargersLayer'] =
-          dischargersLayer && showDischargersLayer;
+          !dischargersLayer || useCurrentValue
+            ? visibleLayers['dischargersLayer']
+            : showDischargersLayer;
       }
 
       if (newVisibleLayers.hasOwnProperty(key)) {
@@ -391,7 +396,7 @@ function IdentifiedIssues() {
 
   // Updates visible layers based on webservice statuses.
   React.useEffect(() => {
-    updateVisibleLayers();
+    updateVisibleLayers({ useCurrentValue: true });
   }, [cipSummary, permittedDischargers, visibleLayers, updateVisibleLayers]);
 
   const checkIfAllSwitchesToggled = (
@@ -424,10 +429,10 @@ function IdentifiedIssues() {
     if (!parameters.some(checkAnyCheckedParameters)) {
       setShowIssuesLayer(false);
 
-      updateVisibleLayers('issuesLayer', false);
+      updateVisibleLayers({ key: 'issuesLayer', newValue: false });
     } else {
       setShowIssuesLayer(true);
-      updateVisibleLayers('issuesLayer', true);
+      updateVisibleLayers({ key: 'issuesLayer', newValue: true });
     }
 
     // check if any parameters are not checked. if all parameters are checked, set the showAllParameters switch to true
@@ -456,7 +461,7 @@ function IdentifiedIssues() {
       }
 
       setShowAllPolluted(true);
-      updateVisibleLayers('issuesLayer', true);
+      updateVisibleLayers({ key: 'issuesLayer', newValue: true });
     };
 
     // set all parameters to Off and hide the issuesLayer
@@ -469,7 +474,7 @@ function IdentifiedIssues() {
       }
 
       setShowAllPolluted(false);
-      updateVisibleLayers('issuesLayer', false);
+      updateVisibleLayers({ key: 'issuesLayer', newValue: false });
     };
 
     // if switch at top of table is switched
@@ -497,10 +502,10 @@ function IdentifiedIssues() {
       setShowDischargersLayer(!showDischargersLayer);
       checkDischargersToDisplay();
 
-      updateVisibleLayers(
-        'dischargersLayer',
-        dischargersLayer && !showDischargersLayer,
-      );
+      updateVisibleLayers({
+        key: 'dischargersLayer',
+        newValue: dischargersLayer && !showDischargersLayer,
+      });
     }
     // one of the parameters is switched
     else {

--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -96,6 +96,8 @@ function Monitoring() {
     monitoringStationsLayer,
     setShowAllMonitoring,
     watershed,
+    visibleLayers,
+    setVisibleLayers,
   } = React.useContext(LocationSearchContext);
 
   const [
@@ -350,6 +352,13 @@ function Monitoring() {
     drawMap,
     storeMonitoringStations,
   ]);
+
+  // clear the visible layers if the monitoring locations service failed
+  React.useEffect(() => {
+    if (monitoringLocations.status !== 'failure') return;
+
+    if (Object.keys(visibleLayers).length > 0) setVisibleLayers({});
+  }, [monitoringLocations, visibleLayers, setVisibleLayers]);
 
   const sortedMonitoringStations = displayedMonitoringStations
     ? displayedMonitoringStations.sort((objA, objB) => {

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -126,14 +126,6 @@ function Overview() {
   // used for when the user toggles layers in full screen mode and then
   // exist full screen.
   React.useEffect(() => {
-    if (
-      !visibleLayers.hasOwnProperty('waterbodyLayer') ||
-      !visibleLayers.hasOwnProperty('monitoringStationsLayer') ||
-      !visibleLayers.hasOwnProperty('dischargersLayer')
-    ) {
-      return;
-    }
-
     const {
       waterbodyLayer,
       monitoringStationsLayer,
@@ -159,19 +151,25 @@ function Overview() {
   // Updates the visible layers. This function also takes into account whether
   // or not the underlying webservices failed.
   const updateVisibleLayers = React.useCallback(
-    (key = null, newValue = null) => {
+    ({ key = null, newValue = null, useCurrentValue = false }) => {
       const newVisibleLayers = {};
       if (monitoringLocations.status !== 'failure') {
         newVisibleLayers['monitoringStationsLayer'] =
-          monitoringStationsLayer && monitoringLocationsFilterEnabled;
+          !monitoringStationsLayer || useCurrentValue
+            ? visibleLayers['monitoringStationsLayer']
+            : monitoringLocationsFilterEnabled;
       }
       if (cipSummary.status !== 'failure') {
         newVisibleLayers['waterbodyLayer'] =
-          waterbodyLayer && waterbodiesFilterEnabled;
+          !waterbodyLayer || useCurrentValue
+            ? visibleLayers['waterbodyLayer']
+            : waterbodiesFilterEnabled;
       }
       if (permittedDischargers.status !== 'failure') {
         newVisibleLayers['dischargersLayer'] =
-          dischargersLayer && dischargersFilterEnabled;
+          !dischargersLayer || useCurrentValue
+            ? visibleLayers['dischargersLayer']
+            : dischargersFilterEnabled;
       }
 
       if (newVisibleLayers.hasOwnProperty(key)) {
@@ -200,7 +198,7 @@ function Overview() {
 
   // Updates visible layers based on webservice statuses.
   React.useEffect(() => {
-    updateVisibleLayers();
+    updateVisibleLayers({ useCurrentValue: true });
   }, [
     monitoringLocations,
     cipSummary,
@@ -256,10 +254,10 @@ function Overview() {
                     setWaterbodiesFilterEnabled(!waterbodiesFilterEnabled);
 
                     // first check if layer exists and is not falsy
-                    updateVisibleLayers(
-                      'waterbodyLayer',
-                      waterbodyLayer && !waterbodiesFilterEnabled,
-                    );
+                    updateVisibleLayers({
+                      key: 'waterbodyLayer',
+                      newValue: waterbodyLayer && !waterbodiesFilterEnabled,
+                    });
                   }}
                   disabled={!Boolean(waterbodyCount)}
                   ariaLabel="Waterbodies"
@@ -295,11 +293,12 @@ function Overview() {
                     );
 
                     // first check if layer exists and is not falsy
-                    updateVisibleLayers(
-                      'monitoringStationsLayer',
-                      monitoringStationsLayer &&
+                    updateVisibleLayers({
+                      key: 'monitoringStationsLayer',
+                      newValue:
+                        monitoringStationsLayer &&
                         !monitoringLocationsFilterEnabled,
-                    );
+                    });
                   }}
                   disabled={!Boolean(monitoringLocationCount)}
                   ariaLabel="Monitoring Locations"
@@ -332,10 +331,10 @@ function Overview() {
                     setDischargersFilterEnabled(!dischargersFilterEnabled);
 
                     // first check if layer exists and is not falsy
-                    updateVisibleLayers(
-                      'dischargersLayer',
-                      dischargersLayer && !dischargersFilterEnabled,
-                    );
+                    updateVisibleLayers({
+                      key: 'dischargersLayer',
+                      newValue: dischargersLayer && !dischargersFilterEnabled,
+                    });
                   }}
                   disabled={!Boolean(permittedDischargerCount)}
                   ariaLabel="Permitted Dischargers"

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -156,6 +156,59 @@ function Overview() {
     setWaterbodiesFilterEnabled,
   ]);
 
+  // Updates the visible layers. This function also takes into account whether
+  // or not the underlying webservices failed.
+  const updateVisibleLayers = React.useCallback(
+    (key = null, newValue = null) => {
+      const newVisibleLayers = {};
+      if (monitoringLocations.status !== 'failure') {
+        newVisibleLayers['monitoringStationsLayer'] =
+          monitoringStationsLayer && monitoringLocationsFilterEnabled;
+      }
+      if (cipSummary.status !== 'failure') {
+        newVisibleLayers['waterbodyLayer'] =
+          waterbodyLayer && waterbodiesFilterEnabled;
+      }
+      if (permittedDischargers.status !== 'failure') {
+        newVisibleLayers['dischargersLayer'] =
+          dischargersLayer && dischargersFilterEnabled;
+      }
+
+      if (newVisibleLayers.hasOwnProperty(key)) {
+        newVisibleLayers[key] = newValue;
+      }
+
+      // set the visible layers if something changed
+      if (JSON.stringify(visibleLayers) !== JSON.stringify(newVisibleLayers)) {
+        setVisibleLayers(newVisibleLayers);
+      }
+    },
+    [
+      dischargersLayer,
+      dischargersFilterEnabled,
+      permittedDischargers,
+      monitoringLocations,
+      monitoringStationsLayer,
+      monitoringLocationsFilterEnabled,
+      waterbodyLayer,
+      waterbodiesFilterEnabled,
+      cipSummary,
+      visibleLayers,
+      setVisibleLayers,
+    ],
+  );
+
+  // Updates visible layers based on webservice statuses.
+  React.useEffect(() => {
+    updateVisibleLayers();
+  }, [
+    monitoringLocations,
+    cipSummary,
+    permittedDischargers,
+    visibleLayers,
+    updateVisibleLayers,
+  ]);
+
   const waterbodyCount = uniqueWaterbodies && uniqueWaterbodies.length;
   const monitoringLocationCount =
     monitoringLocations.data.features &&
@@ -203,15 +256,10 @@ function Overview() {
                     setWaterbodiesFilterEnabled(!waterbodiesFilterEnabled);
 
                     // first check if layer exists and is not falsy
-                    setVisibleLayers({
-                      waterbodyLayer:
-                        waterbodyLayer && !waterbodiesFilterEnabled,
-                      monitoringStationsLayer:
-                        monitoringStationsLayer &&
-                        monitoringLocationsFilterEnabled,
-                      dischargersLayer:
-                        dischargersLayer && dischargersFilterEnabled,
-                    });
+                    updateVisibleLayers(
+                      'waterbodyLayer',
+                      waterbodyLayer && !waterbodiesFilterEnabled,
+                    );
                   }}
                   disabled={!Boolean(waterbodyCount)}
                   ariaLabel="Waterbodies"
@@ -247,15 +295,11 @@ function Overview() {
                     );
 
                     // first check if layer exists and is not falsy
-                    setVisibleLayers({
-                      waterbodyLayer:
-                        waterbodyLayer && waterbodiesFilterEnabled,
-                      monitoringStationsLayer:
-                        monitoringStationsLayer &&
+                    updateVisibleLayers(
+                      'monitoringStationsLayer',
+                      monitoringStationsLayer &&
                         !monitoringLocationsFilterEnabled,
-                      dischargersLayer:
-                        dischargersLayer && dischargersFilterEnabled,
-                    });
+                    );
                   }}
                   disabled={!Boolean(monitoringLocationCount)}
                   ariaLabel="Monitoring Locations"
@@ -288,15 +332,10 @@ function Overview() {
                     setDischargersFilterEnabled(!dischargersFilterEnabled);
 
                     // first check if layer exists and is not falsy
-                    setVisibleLayers({
-                      waterbodyLayer:
-                        waterbodyLayer && waterbodiesFilterEnabled,
-                      monitoringStationsLayer:
-                        monitoringStationsLayer &&
-                        monitoringLocationsFilterEnabled,
-                      dischargersLayer:
-                        dischargersLayer && !dischargersFilterEnabled,
-                    });
+                    updateVisibleLayers(
+                      'dischargersLayer',
+                      dischargersLayer && !dischargersFilterEnabled,
+                    );
                   }}
                   disabled={!Boolean(permittedDischargerCount)}
                   ariaLabel="Permitted Dischargers"

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -153,7 +153,6 @@ function Protect() {
     statesData,
     visibleLayers,
     setVisibleLayers,
-    wsioHealthIndexLayer,
     wsioHealthIndexData,
     wildScenicRiversLayer,
     wildScenicRiversData,
@@ -191,34 +190,51 @@ function Protect() {
     setWildScenicRiversDisplayed,
   ] = React.useState(false);
 
-  const [tabIndex, setTabIndex] = React.useState(null);
-  // toggle map layers' visibility when a tab changes
+  // Updates the visible layers. This function also takes into account whether
+  // or not the underlying webservices failed.
+  const updateVisibleLayers = React.useCallback(
+    (key = null, newValue = null) => {
+      const newVisibleLayers = {};
+      if (wsioHealthIndexData.status !== 'failure') {
+        newVisibleLayers['wsioHealthIndexLayer'] = false;
+      }
+      if (protectedAreasData.status !== 'failure') {
+        newVisibleLayers['protectedAreasLayer'] = false;
+      }
+      if (wildScenicRiversData.status !== 'failure') {
+        newVisibleLayers['wildScenicRiversLayer'] = false;
+      }
+
+      if (newVisibleLayers.hasOwnProperty(key)) {
+        newVisibleLayers[key] = newValue;
+      }
+
+      // set the visible layers if something changed
+      if (JSON.stringify(visibleLayers) !== JSON.stringify(newVisibleLayers)) {
+        setVisibleLayers(newVisibleLayers);
+      }
+    },
+    [
+      wsioHealthIndexData,
+      protectedAreasData,
+      wildScenicRiversData,
+      visibleLayers,
+      setVisibleLayers,
+    ],
+  );
+
+  // Updates visible layers based on webservice statuses.
   React.useEffect(() => {
-    if (!wsioHealthIndexLayer || !wildScenicRiversLayer || !protectedAreasLayer)
-      return;
-
-    if (tabIndex === 0) {
-      setVisibleLayers({
-        wsioHealthIndexLayer: false,
-        wildScenicRiversLayer: false,
-        protectedAreasLayer: false,
-      });
-    }
-
-    if (tabIndex === 1) {
-      setVisibleLayers({
-        wsioHealthIndexLayer: false,
-        wildScenicRiversLayer: false,
-        protectedAreasLayer: false,
-      });
-    }
+    updateVisibleLayers();
   }, [
-    tabIndex,
-    setVisibleLayers,
-    wsioHealthIndexLayer,
-    wildScenicRiversLayer,
-    protectedAreasLayer,
+    wsioHealthIndexData,
+    protectedAreasData,
+    wildScenicRiversData,
+    visibleLayers,
+    updateVisibleLayers,
   ]);
+
+  const [tabIndex, setTabIndex] = React.useState(null);
 
   // toggle the switches setting when the map layer's visibility changes
   React.useEffect(() => {
@@ -255,6 +271,7 @@ function Protect() {
         <Tabs
           onChange={(index) => {
             setTabIndex(index);
+            updateVisibleLayers();
           }}
           defaultIndex={tabIndex}
         >
@@ -287,9 +304,7 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setHealthScoresDisplayed(checked);
-                          setVisibleLayers({
-                            wsioHealthIndexLayer: checked,
-                          });
+                          updateVisibleLayers('wsioHealthIndexLayer', checked);
                         }}
                         disabled={
                           wsioHealthIndexData.status === 'failure' ||
@@ -545,9 +560,7 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setProtectedAreasDisplayed(checked);
-                          setVisibleLayers({
-                            protectedAreasLayer: checked,
-                          });
+                          updateVisibleLayers('protectedAreasLayer', checked);
                         }}
                         disabled={
                           protectedAreasData.status === 'failure' ||
@@ -691,9 +704,10 @@ function Protect() {
                                   if (protectedAreasDisplayed) return;
 
                                   setProtectedAreasDisplayed(true);
-                                  setVisibleLayers({
-                                    protectedAreasLayer: true,
-                                  });
+                                  updateVisibleLayers(
+                                    'protectedAreasLayer',
+                                    true,
+                                  );
                                 }}
                               />
                             </ViewButtonContainer>
@@ -739,9 +753,7 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setWildScenicRiversDisplayed(checked);
-                          setVisibleLayers({
-                            wildScenicRiversLayer: checked,
-                          });
+                          updateVisibleLayers('wildScenicRiversLayer', checked);
                         }}
                         disabled={wildScenicRiversData.status === 'failure'}
                         ariaLabel="Wild and Scenic Rivers"
@@ -870,9 +882,10 @@ function Protect() {
                                   if (wildScenicRiversDisplayed) return;
 
                                   setWildScenicRiversDisplayed(true);
-                                  setVisibleLayers({
-                                    wildScenicRiversLayer: true,
-                                  });
+                                  updateVisibleLayers(
+                                    'wildScenicRiversLayer',
+                                    true,
+                                  );
                                 }}
                               />
                             </ViewButtonContainer>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -193,16 +193,22 @@ function Protect() {
   // Updates the visible layers. This function also takes into account whether
   // or not the underlying webservices failed.
   const updateVisibleLayers = React.useCallback(
-    (key = null, newValue = null) => {
+    ({ key = null, newValue = null, useCurrentValue = false }) => {
       const newVisibleLayers = {};
       if (wsioHealthIndexData.status !== 'failure') {
-        newVisibleLayers['wsioHealthIndexLayer'] = false;
+        newVisibleLayers['wsioHealthIndexLayer'] = useCurrentValue
+          ? visibleLayers['wsioHealthIndexLayer']
+          : false;
       }
       if (protectedAreasData.status !== 'failure') {
-        newVisibleLayers['protectedAreasLayer'] = false;
+        newVisibleLayers['protectedAreasLayer'] = useCurrentValue
+          ? visibleLayers['protectedAreasLayer']
+          : false;
       }
       if (wildScenicRiversData.status !== 'failure') {
-        newVisibleLayers['wildScenicRiversLayer'] = false;
+        newVisibleLayers['wildScenicRiversLayer'] = useCurrentValue
+          ? visibleLayers['wildScenicRiversLayer']
+          : false;
       }
 
       if (newVisibleLayers.hasOwnProperty(key)) {
@@ -225,7 +231,7 @@ function Protect() {
 
   // Updates visible layers based on webservice statuses.
   React.useEffect(() => {
-    updateVisibleLayers();
+    updateVisibleLayers({ useCurrentValue: true });
   }, [
     wsioHealthIndexData,
     protectedAreasData,
@@ -304,7 +310,10 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setHealthScoresDisplayed(checked);
-                          updateVisibleLayers('wsioHealthIndexLayer', checked);
+                          updateVisibleLayers({
+                            key: 'wsioHealthIndexLayer',
+                            newValue: checked,
+                          });
                         }}
                         disabled={
                           wsioHealthIndexData.status === 'failure' ||
@@ -560,7 +569,10 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setProtectedAreasDisplayed(checked);
-                          updateVisibleLayers('protectedAreasLayer', checked);
+                          updateVisibleLayers({
+                            key: 'protectedAreasLayer',
+                            newValue: checked,
+                          });
                         }}
                         disabled={
                           protectedAreasData.status === 'failure' ||
@@ -704,10 +716,10 @@ function Protect() {
                                   if (protectedAreasDisplayed) return;
 
                                   setProtectedAreasDisplayed(true);
-                                  updateVisibleLayers(
-                                    'protectedAreasLayer',
-                                    true,
-                                  );
+                                  updateVisibleLayers({
+                                    key: 'protectedAreasLayer',
+                                    newValue: true,
+                                  });
                                 }}
                               />
                             </ViewButtonContainer>
@@ -753,7 +765,10 @@ function Protect() {
                         }
                         onChange={(checked) => {
                           setWildScenicRiversDisplayed(checked);
-                          updateVisibleLayers('wildScenicRiversLayer', checked);
+                          updateVisibleLayers({
+                            key: 'wildScenicRiversLayer',
+                            newValue: checked,
+                          });
                         }}
                         disabled={wildScenicRiversData.status === 'failure'}
                         ariaLabel="Wild and Scenic Rivers"
@@ -882,10 +897,10 @@ function Protect() {
                                   if (wildScenicRiversDisplayed) return;
 
                                   setWildScenicRiversDisplayed(true);
-                                  updateVisibleLayers(
-                                    'wildScenicRiversLayer',
-                                    true,
-                                  );
+                                  updateVisibleLayers({
+                                    key: 'wildScenicRiversLayer',
+                                    newValue: true,
+                                  });
                                 }}
                               />
                             </ViewButtonContainer>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3474014

## Main Changes:
* Fixed an issue where layers that failed to load where still selectable in the layer list.
* Updated the protect tab so that all layers are available in the layer list, unless one of the underlying services has an issue. This was done so that users in full screen mode don't need to exit to turn on the other layers on the Protect tab.

## Steps To Test:
1. Navigate to http://localhost:3000/community/050500020908/overview
2. Block the "gispub.epa.gov" domain and reload the page
3. Verify the "Waterbodies" layer is not available in the layer list
4. Select a different tab and then click on the overview tab again
5. Verify the "Waterbodies" layer is not available in the layer list
6. Turn on the "Monitoring Locations" layer 
7. Verify the "Waterbodies" layer is not available in the layer list
8. Repeat the above steps for the following:
  * Waterbodies on the issues tab: gispub.epa.gov
  * Monitoring locations on the overview tab:  www.waterqualitydata.us
  * Monitoring locations on the monitoring tab: www.waterqualitydata.us
  * Permitted dischargers on the overview tab: ofmpub.epa.gov
  * Permitted dischargers on the issues tab: ofmpub.epa.gov
  * WSIO layer on the protect tab: gispub.epa.gov
  * Protected Areas layer on the protect tab: gis1.usgs.gov
  * Wild and Scenic Rivers layer on the protect tab: services1.arcgis.com
