### PR TITLE
Bugfix/disable keyboard on select menus

### DIFF
--- a/app/client/src/components/pages/State/components/SurveyResults.js
+++ b/app/client/src/components/pages/State/components/SurveyResults.js
@@ -434,6 +434,7 @@ function SurveyResults({
             <Select
               inputId={`population-${populationId}`}
               classNamePrefix="Select"
+              isSearchable={false}
               options={subPopulationCodes.map((item) => {
                 const value = item.subPopulationCode;
                 return { value, label: value };

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -786,6 +786,7 @@ function AdvancedSearch({ ...props }: Props) {
             aria-label="Parameter Groups"
             isMulti
             isLoading={!parameterGroupOptions}
+            isSearchable={false}
             options={parameterGroupOptions ? parameterGroupOptions : []}
             value={parameterFilter}
             onChange={(ev) => setParameterFilter(ev)}
@@ -800,6 +801,7 @@ function AdvancedSearch({ ...props }: Props) {
           <Select
             aria-label="Use Groups"
             isMulti
+            isSearchable={false}
             options={useFields}
             value={useFilter}
             onChange={(ev) => setUseFilter(ev)}
@@ -971,6 +973,7 @@ function AdvancedSearch({ ...props }: Props) {
           <label htmlFor="display-by">Display Waterbodies by:</label>
           <Select
             inputId="display-by"
+            isSearchable={false}
             options={displayOptions}
             value={selectedDisplayOption}
             onChange={(ev) => setSelectedDisplayOption(ev)}

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -995,6 +995,7 @@ function WaterQualityOverview({ ...props }: Props) {
                         id={`water-type-${tab.id}`}
                         inputId={`water-type-input-${tab.id}`}
                         classNamePrefix="Select"
+                        isSearchable={false}
                         options={displayWaterTypes.map((waterType) => {
                           return { value: waterType, label: waterType };
                         })}
@@ -1020,6 +1021,7 @@ function WaterQualityOverview({ ...props }: Props) {
                         id={`water-use-${tab.id}`}
                         inputId={`water-use-input-${tab.id}`}
                         classNamePrefix="Select"
+                        isSearchable={false}
                         options={displayUses.map((use) => {
                           return { value: use, label: use };
                         })}

--- a/app/client/src/components/shared/Accordion/index.js
+++ b/app/client/src/components/shared/Accordion/index.js
@@ -97,6 +97,7 @@ function AccordionList({
             <SelectLabel htmlFor={`sort-by-${uniqueID}`}>Sort By:</SelectLabel>
             <StyledSelect
               inputId={`sort-by-${uniqueID}`}
+              isSearchable={false}
               options={sortOptions}
               value={sortBy}
               onChange={(ev) => {

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -371,6 +371,7 @@ function SearchPanel() {
             </LabelHiddenText>
             <StyledSelect
               inputId="location-select"
+              isSearchable={false}
               options={locationList}
               value={location}
               onChange={(ev) => {

--- a/app/client/src/components/shared/AddDataWidget/URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/URLPanel.js
@@ -185,6 +185,7 @@ function URLPanel() {
       <label htmlFor="url-type-select">Type</label>
       <Select
         inputId="url-type-select"
+        isSearchable={false}
         value={urlType}
         onChange={(ev) => {
           setUrlType(ev);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3701259

## Main Changes:
* Updated code so that select menus don't open keyboards on mobile, except for selects with more than 15 items.

## Steps To Test:
1. Open HMW using a mobile device
2. Navigate throughout the app and verify select menus don't open the keyboard. 
  NOTE: Select menus with a lot of items will still open the keyboard. The select menus that open the keyboard are the dropdown for selecting the state on the state page, the "Watershed Names" select menu, and the "Waterbody Names" select menu.

