### PR TITLE
Bugfix/add data widget issues

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/FilePanel.js
+++ b/app/client/src/components/shared/AddDataWidget/FilePanel.js
@@ -516,11 +516,9 @@ function FilePanel() {
       // create the feature layer
       const layerToAdd = new FeatureLayer(layerProps);
       featureLayers.push(layerToAdd);
-
-      setWidgetLayers((widgetLayers) => [...widgetLayers, layerToAdd]);
     });
 
-    mapView.map.addMany(featureLayers);
+    setWidgetLayers((widgetLayers) => [...widgetLayers, ...featureLayers]);
 
     setUploadStatus('success');
   }, [

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -786,6 +786,18 @@ function ResultCard({ result }: ResultCardProps) {
 
             if (mapView) {
               layer.visible = true;
+
+              // make all child layers visible, if applicable
+              if (layer.layers) {
+                layer.layers.items.forEach((layer) => {
+                  layer.visible = true;
+                });
+              }
+              if (layer.sublayers) {
+                layer.sublayers.items.forEach((layer) => {
+                  layer.visible = true;
+                });
+              }
             }
           } else if (loadStatus === 'failed') {
             setStatus('error');

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -796,7 +796,6 @@ function ResultCard({ result }: ResultCardProps) {
       setWatcher(watcher);
 
       // add the layer to the map
-      mapView.map.add(layer);
       setWidgetLayers((widgetLayers) => [...widgetLayers, layer]);
     });
   }

--- a/app/client/src/components/shared/AddDataWidget/URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/URLPanel.js
@@ -94,25 +94,8 @@ function URLPanel() {
     if (!mapView || !layer) return;
 
     // add the layer to the map
-    mapView.map.add(layer);
-
-    const createHandler = layer.on('layerview-create', (event) => {
-      setWidgetLayers((widgetLayers) => [...widgetLayers, layer]);
-      setStatus('success');
-
-      createHandler.remove();
-    });
-
-    const errorHandler = layer.on('layerview-create-error', (event) => {
-      console.error('create error event: ', event);
-
-      mapView.map.remove(layer);
-
-      setStatus('failure');
-
-      errorHandler.remove();
-    });
-
+    setWidgetLayers((widgetLayers) => [...widgetLayers, layer]);
+    setStatus('success');
     setLayer(null);
   }, [mapView, layer, setWidgetLayers, widgetLayers, url, urlType]);
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3704616

## Main Changes:
* Fixed an issue where layers added from the Add Data Widget always show up on top. 
* Added code to ensure make all child layers visible.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the Add Data Widget
3. Turn off the "Within map view" filter
4. Add the "EJSCREEN Demographic Indicators 2018" layer
5. Close the Add Data Widget
6. Open the Layer List Widget
7. Verify the "EJSCREEN Demographic Indicators 2018" layer is at the bottom of the list and that all child layers are visible
8. Verify the "EJSCREEN Demographic Indicators 2018" shows up on the map 

