### PR TITLE
Fixed issue with layer ordering from the Add Data Widget.

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -826,7 +826,6 @@ function ResultCard({ result }: ResultCardProps) {
 
     // remove the layers from the map and session storage.
     if (layersToRemove.length > 0) {
-      mapView.map.removeMany(layersToRemove.toArray());
       setWidgetLayers((widgetLayers) =>
         widgetLayers.filter(
           (widgetLayer) => widgetLayer?.portalItem?.id !== result.id,

--- a/app/client/src/components/shared/AddDataWidget/index.js
+++ b/app/client/src/components/shared/AddDataWidget/index.js
@@ -268,7 +268,6 @@ function AddDataWidget() {
                                   widgetLayer.id !== item.layer.id,
                               ),
                             );
-                            mapView.map.remove(item.layer);
                             return;
                           }
 
@@ -284,7 +283,6 @@ function AddDataWidget() {
                                   widgetLayer.id !== item.layer.parent.id,
                               ),
                             );
-                            mapView.map.remove(item.layer.parent);
                           }
                         }}
                       >

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -255,6 +255,56 @@ function MapWidgets({
     map.removeAll();
     map.addMany(layers);
     map.addMany(widgetLayers);
+
+    // gets a layer type value used for sorting
+    function getLayerType(layer: __esri.Layer) {
+      // if the layer is in orderedLayers, then classify it as an hmw
+      // layer
+      if (orderedLayers.indexOf(layer.id) > -1) return 'hmw';
+
+      const imageryTypes = ['imagery', 'tile', 'vector-tile'];
+      let type = 'other';
+
+      let groupType = '';
+      if (layer.type === 'group') {
+        const groupLayer = layer;
+        groupLayer.layers.forEach((layer, index) => {
+          if (groupType === 'combo') return;
+
+          if (index === 0) {
+            groupType = layer.type;
+            return;
+          }
+
+          if (groupType !== layer.type) {
+            groupType = 'combo';
+          }
+        });
+      }
+
+      if (layer.type === 'graphics' || groupType === 'graphics') {
+        type = 'graphics';
+      } else if (layer.type === 'feature' || groupType === 'feature') {
+        type = 'feature';
+      } else if (
+        imageryTypes.includes(type) ||
+        imageryTypes.includes(groupType)
+      ) {
+        type = 'imagery';
+      }
+
+      return type;
+    }
+
+    // the layers are ordered as follows:
+    // graphicsLayers (top)
+    // featureLayers
+    // otherLayers
+    // imageryLayers (bottom)
+    const sortBy = ['other', 'imagery', 'feature', 'graphics', 'hmw'];
+    map.layers.sort((a: __esri.Layer, b: __esri.Layer) => {
+      return sortBy.indexOf(getLayerType(a)) - sortBy.indexOf(getLayerType(b));
+    });
   }, [layers, map, widgetLayers]);
 
   // put the home widget back on the ui after the window is resized
@@ -755,71 +805,6 @@ function MapWidgets({
       upstreamWidget.style.cursor = 'pointer';
     }
   }, [upstreamWidget, upstreamWidgetDisabled]);
-
-  // Creates a watch event that is used for reordering the layers
-  const [watchInitialized, setWatchInitialized] = React.useState(false);
-  React.useEffect(() => {
-    if (!map || watchInitialized) return;
-
-    // whenever layers are added, reorder them
-    map.layers.on('change', ({ added }) => {
-      if (added.length === 0) return;
-
-      // gets a layer type value used for sorting
-      function getLayerType(layer: __esri.Layer) {
-        // if the layer is in orderedLayers, then classify it as an hmw
-        // layer
-        if (orderedLayers.indexOf(layer.id) > -1) return 'hmw';
-
-        const imageryTypes = ['imagery', 'tile', 'vector-tile'];
-        let type = 'other';
-
-        let groupType = '';
-        if (layer.type === 'group') {
-          const groupLayer = layer;
-          groupLayer.layers.forEach((layer, index) => {
-            if (groupType === 'combo') return;
-
-            if (index === 0) {
-              groupType = layer.type;
-              return;
-            }
-
-            if (groupType !== layer.type) {
-              groupType = 'combo';
-            }
-          });
-        }
-
-        if (layer.type === 'graphics' || groupType === 'graphics') {
-          type = 'graphics';
-        } else if (layer.type === 'feature' || groupType === 'feature') {
-          type = 'feature';
-        } else if (
-          imageryTypes.includes(type) ||
-          imageryTypes.includes(groupType)
-        ) {
-          type = 'imagery';
-        }
-
-        return type;
-      }
-
-      // the layers are ordered as follows:
-      // graphicsLayers (top)
-      // featureLayers
-      // otherLayers
-      // imageryLayers (bottom)
-      const sortBy = ['other', 'imagery', 'feature', 'graphics', 'hmw'];
-      map.layers.sort((a: __esri.Layer, b: __esri.Layer) => {
-        return (
-          sortBy.indexOf(getLayerType(a)) - sortBy.indexOf(getLayerType(b))
-        );
-      });
-    });
-
-    setWatchInitialized(true);
-  }, [map, watchInitialized]);
 
   // watch for changes to upstream layer visibility and update visible layers accordingly
   React.useEffect(() => {


### PR DESCRIPTION
## Related Issues:
* Bugfix/add data widget issues

## Main Changes:
* Fixed an issue with layer ordering when removing layers using the add data widget. I found this issue while testing the previous add data widget changes on the dev site.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the add data widget
3. Turn off the "Within map view" toggle
4. Add the "EJSCREEN Demographic Indicators 2018" layer
5. Add the "Percent developed land in areas of high water accumulation" layer
6. Open the layer list
7. Verify the added layers are at the bottom of the list
8. Remove the "EJSCREEN Demographic Indicators 2018" layer
9. Verify the "Percent developed land in areas of high water accumulation" layer is still at the bottom. Currently, on the dev site this layer would be moved to the top, which shouldn't happen.

