### PR TITLE
Feature/one epa template changes

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -350,16 +350,13 @@
                   <a href="https://www.epa.gov/accessibility">Accessibility</a>
                 </li>
                 <li>
-                  <a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a>
-                </li>
-                <li>
                   <a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a>
                 </li>
                 <li>
                   <a href="https://www.epa.gov/contracts">Contracting</a>
                 </li>
                 <li>
-                  <a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+                  <a href="https://www.epa.gov/grants">Grants</a>
                 </li>
                 <li>
                   <a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
@@ -371,6 +368,9 @@
                 </li>
                 <li>
                   <a href="https://www.epa.gov/privacy">Privacy</a>
+                </li>
+                <li>
+                  <a href="https://www.epa.gov/privacy/privacy-and-security-notice">Privacy and Security Notice</a>
                 </li>
               </ul>
             </div>
@@ -389,9 +389,6 @@
                 </li>
                 <li>
                   <a href="https://www.epa.gov/newsroom">Newsroom</a>
-                </li>
-                <li>
-                  <a href="https://www.epa.gov/open">Open Government</a>
                 </li>
                 <li>
                   <a href="https://www.regulations.gov/">Regulations.gov</a>

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -124,10 +124,9 @@
 							</div>
 							<ul class="menu">
 								<li><a href="https://www.epa.gov/accessibility">Accessibility</a></li>
-								<li><a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a></li>
 								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+								<li><a href="https://www.epa.gov/grants">Grants</a>
 								</li>
 								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
 								</li>
@@ -135,6 +134,7 @@
 										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
 										FEAR Act Data</a></li>
 								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
+								<li><a href="https://www.epa.gov/privacy/privacy-and-security-notice">Privacy and Security Notice</a></li>
 							</ul>
 						</div>
 						<div class="col size-1of3">
@@ -148,7 +148,6 @@
 										General</a></li>
 								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
 								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
-								<li><a href="https://www.epa.gov/open">Open Government</a></li>
 								<li><a href="https://www.regulations.gov/">Regulations.gov</a></li>
 								<li><a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a></li>
 								<li><a href="https://www.usa.gov/">USA.gov</a></li>

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -136,10 +136,9 @@
 							</div>
 							<ul class="menu">
 								<li><a href="https://www.epa.gov/accessibility">Accessibility</a></li>
-								<li><a href="https://www.epa.gov/aboutepa/epas-administrator">EPA Administrator</a></li>
 								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/home/grants-and-other-funding-opportunities">Grants</a>
+								<li><a href="https://www.epa.gov/grants">Grants</a>
 								</li>
 								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
 								</li>
@@ -147,6 +146,7 @@
 										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
 										FEAR Act Data</a></li>
 								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
+								<li><a href="https://www.epa.gov/privacy/privacy-and-security-notice">Privacy and Security Notice</a></li>
 							</ul>
 						</div>
 						<div class="col size-1of3">
@@ -160,7 +160,6 @@
 										General</a></li>
 								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
 								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
-								<li><a href="https://www.epa.gov/open">Open Government</a></li>
 								<li><a href="https://www.regulations.gov/">Regulations.gov</a></li>
 								<li><a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a></li>
 								<li><a href="https://www.usa.gov/">USA.gov</a></li>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3705587

## Main Changes:
* Updated the one epa template footer to match epa.gov.

## Steps To Test:
1. Navigate to http://localhost:3000/
2. In a separate tab, open https://www.epa.gov/
3. Verify the links in the One EPA template footer match up. Key differences noted in the ticket.
4. Verify that all modified/added links work
5. To test the 404 page, navigate to http://localhost:9090/404.html
6. Repeat steps 3 and 4

