### PR TITLE
Feature/darker watershed boundaries

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -1321,9 +1321,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       },
       symbol: {
         type: 'simple-fill', // autocasts as new SimpleFillSymbol()
-        color: [204, 255, 255, 0.2],
+        color: [204, 255, 255, 0.5],
         outline: {
-          color: [102, 102, 102],
+          color: [0, 0, 0],
           width: 2,
           style: 'dash',
         },

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -277,8 +277,8 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
             viewBox="0 0 26 26"
             aria-hidden="true"
           >
-            <rect x="0" y="12" width="10" height="3" fill="#666666" />
-            <rect x="16" y="12" width="10" height="3" fill="#666666" />
+            <rect x="0" y="12" width="10" height="3" fill="#000" />
+            <rect x="16" y="12" width="10" height="3" fill="#000" />
           </svg>
         </ImageContainer>
         <LegendLabel>HUC12 Boundaries</LegendLabel>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3704554
* 
## Main Changes:
* Adds darker shading to the HUC12 Boundaries layer. The dotted lines are now black and the light blue inner shading is darker.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Check that the HUC12 watershed boundaries on the map have a darker inner shading and the dotted lines are black.
3. Check that the HUC12 Boundaries legend matches the dotted lines on the map.
