### PR TITLE
Feature/remove within map view filter

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -6,7 +6,6 @@ import Select from 'react-select';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
-import Switch from 'components/shared/Switch';
 // contexts
 import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
@@ -92,9 +91,7 @@ const ButtonHiddenText = styled.span`
 
 const FilterContainer = styled.div`
   display: flex;
-  flex-flow: wrap;
-  justify-content: space-between;
-  align-items: center;
+  flex-wrap: wrap;
   margin: 2.5px;
 `;
 
@@ -185,7 +182,6 @@ function SearchPanel() {
   ] = React.useState(locationList[0]);
   const [search, setSearch] = React.useState('');
   const [searchText, setSearchText] = React.useState('');
-  const [withinMap, setWithinMap] = React.useState(true);
   const [mapService, setMapService] = React.useState(false);
   const [featureService, setFeatureService] = React.useState(false);
   const [imageService, setImageService] = React.useState(false);
@@ -264,15 +260,11 @@ function SearchPanel() {
       sortOrder,
     };
 
-    if (withinMap && currentExtent) queryParams.extent = currentExtent;
-
     // if a sort by (other than relevance) is selected, add it to the query params
     if (sortBy.value !== 'none') {
       queryParams.sortField = sortBy.value;
     } else {
-      if (!withinMap) {
-        queryParams.sortField = 'num-views';
-      }
+      queryParams.sortField = 'num-views';
     }
 
     // perform the query
@@ -297,7 +289,6 @@ function SearchPanel() {
     location,
     search,
     setSearchResults,
-    withinMap,
     mapService,
     featureService,
     imageService,
@@ -406,18 +397,6 @@ function SearchPanel() {
 
         <FilterContainer>
           <FilterOption>
-            <label
-              style={{ display: 'flex', alignItems: 'center', margin: '0' }}
-            >
-              <Switch
-                checked={withinMap}
-                onChange={(ev) => setWithinMap(!withinMap)}
-                ariaLabel="Within map view"
-              />{' '}
-              <span style={{ marginLeft: '5px' }}>Within map view</span>
-            </label>
-          </FilterOption>
-          <FilterOption>
             <TextSelect
               onClick={() => {
                 setShowFilterOptions(!showFilterOptions);
@@ -498,7 +477,7 @@ function SearchPanel() {
               </TypeSelect>
             )}
           </FilterOption>
-          <FilterOption style={{ textAlign: 'right' }}>
+          <FilterOption>
             <TextSelect
               onClick={() => {
                 setShowSortOptions(!showSortOptions);

--- a/app/client/src/components/shared/AddDataWidget/SearchPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/SearchPanel.js
@@ -161,8 +161,7 @@ const NewTabDisclaimer = styled.em`
 
 // --- components (SearchPanel) ---
 function SearchPanel() {
-  const { mapView } = React.useContext(LocationSearchContext);
-  const { Portal, watchUtils } = React.useContext(EsriModulesContext);
+  const { Portal } = React.useContext(EsriModulesContext);
   const {
     pageNumber,
     setPageNumber,
@@ -189,7 +188,6 @@ function SearchPanel() {
   const [kml, setKml] = React.useState(false);
   const [wms, setWms] = React.useState(false);
 
-  const [currentExtent, setCurrentExtent] = React.useState(null);
   const [sortBy, setSortBy] = React.useState({
     value: 'none',
     label: 'Relevance',
@@ -284,7 +282,6 @@ function SearchPanel() {
         setSearchResults({ status: 'failure', data: null });
       });
   }, [
-    currentExtent,
     Portal,
     location,
     search,
@@ -335,18 +332,6 @@ function SearchPanel() {
         setSearchResults({ status: 'failure', data: null });
       });
   }, [Portal, pageNumber, lastPageNumber, searchResults, setSearchResults]);
-
-  // Defines a watch event for filtering results based on the map extent
-  const [watchViewInitialized, setWatchViewInitialized] = React.useState(false);
-  React.useEffect(() => {
-    if (!mapView || watchViewInitialized) return;
-
-    watchUtils.whenTrue(mapView, 'stationary', () => {
-      setCurrentExtent(mapView.extent);
-    });
-
-    setWatchViewInitialized(true);
-  }, [mapView, watchUtils, watchViewInitialized]);
 
   const [showFilterOptions, setShowFilterOptions] = React.useState(false);
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3710390

## Main Changes:
* Removed the "Within map view" filter.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the add data widget
3. Verify the "Within map view" filter has been removed
4. Pan around on the map and verify the list of layers does not update.
