### PR TITLE
Bugfix/adw url border issue

### DIFF
--- a/app/client/src/components/shared/AddDataWidget/URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget/URLPanel.js
@@ -49,6 +49,12 @@ const AddButton = styled.button`
 
 const UrlInput = styled.input`
   width: 100%;
+  height: 36px;
+  padding: 2px 8px;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 4px;
+  border-color: hsl(0, 0%, 80%);
 `;
 
 const StyledLinkButton = styled(LinkButton)`


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3692615 - Comment about URL input border being cut off.

## Main Changes:
* Fixed issue with url input borders being cut off.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the Add Data Widget
3. Go to the URL tab
4. Resize the screen and verify the border of the URL input box does not get cut off
