### PR TITLE
Bugfix/ejscreen legend visible

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -135,6 +135,23 @@ function updateVisibleLayers(
     let layer = view.map.layers.items.find((layer) => layer.id === layerId);
     if (!layer) return;
 
+    // verify there is atleast one child layer visible before adding the layer
+    // to the legend
+    if (layer.layers) {
+      let anyVisible = false;
+      layer.layers.forEach((sublayer) => {
+        if (sublayer.visible) anyVisible = true;
+      });
+      if (!anyVisible) return;
+    }
+    if (layer.sublayers) {
+      let anyVisible = false;
+      layer.sublayers.forEach((sublayer) => {
+        if (sublayer.visible) anyVisible = true;
+      });
+      if (!anyVisible) return;
+    }
+
     // add the layer if it is visible on the map. Boundaries and actions
     // waterbodies layers are handled separately here because it is always
     // hidden from the layer list widget, but still needs to be in the legend.


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3703738

## Main Changes:
* Fixed an issue where a layer would show up in the legend even when all child layers are turned off.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Turn on the "Environmental Justice" layer
3. Verify the layer is visible in the legend
4. Turn off all of the "Environmental Justice" layer
5. Verify the layer is not visible in the legend

