### PR TITLE
Feature/waterbodies layer on other tabs

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -19,6 +19,7 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { plotStations } from 'components/pages/LocationMap/MapFunctions';
+import { useWaterbodyOnMap } from 'utils/hooks';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
 // errors
@@ -87,6 +88,9 @@ function Monitoring() {
   const { Graphic } = React.useContext(EsriModulesContext);
 
   const services = useServicesContext();
+
+  // draw the waterbody on the map
+  useWaterbodyOnMap();
 
   const {
     monitoringLocations,

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -21,6 +21,7 @@ import { MapHighlightContext } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { getUrlFromMarkup, getTitleFromMarkup } from 'components/shared/Regex';
+import { useWaterbodyOnMap } from 'utils/hooks';
 import { convertAgencyCode, convertDomainCode } from 'utils/utils';
 // styles
 import { fonts } from 'styles/index.js';
@@ -149,6 +150,9 @@ const ViewButtonContainer = styled.div`
 function Protect() {
   const services = useServicesContext();
 
+  // draw the waterbody on the map
+  useWaterbodyOnMap();
+
   const { Query, QueryTask, SimpleFillSymbol } = React.useContext(
     EsriModulesContext,
   );
@@ -167,6 +171,8 @@ function Protect() {
     protectedAreasLayer,
     protectedAreasData,
     protectedAreasHighlightLayer,
+    waterbodyLayer,
+    cipSummary,
   } = React.useContext(LocationSearchContext);
 
   const { infoToggleChecked } = React.useContext(CommunityTabsContext);
@@ -221,6 +227,12 @@ function Protect() {
             ? visibleLayers['wildScenicRiversLayer']
             : wildScenicRiversDisplayed;
       }
+      if (cipSummary.status !== 'failure') {
+        newVisibleLayers['waterbodyLayer'] =
+          !waterbodyLayer || useCurrentValue
+            ? visibleLayers['waterbodyLayer']
+            : false;
+      }
 
       if (newVisibleLayers.hasOwnProperty(key)) {
         newVisibleLayers[key] = newValue;
@@ -241,6 +253,8 @@ function Protect() {
       wildScenicRiversDisplayed,
       wildScenicRiversLayer,
       wildScenicRiversData,
+      waterbodyLayer,
+      cipSummary,
       visibleLayers,
       setVisibleLayers,
     ],

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -21,6 +21,7 @@ import {
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { getUrlFromMarkup, getTitleFromMarkup } from 'components/shared/Regex';
+import { useWaterbodyOnMap } from 'utils/hooks';
 // errors
 import {
   restoreNonpointSourceError,
@@ -45,6 +46,9 @@ function Restore() {
   const { attainsPlans, grts, watershed } = React.useContext(
     LocationSearchContext,
   );
+
+  // draw the waterbody on the map
+  useWaterbodyOnMap();
 
   const sortedGrtsData =
     grts.data.items && grts.data.items.length > 0

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -289,7 +289,10 @@ const tabs = [
     icon: monitoringIcon,
     upper: monitoringUpper,
     lower: <Monitoring />,
-    layers: { monitoringStationsLayer: true },
+    layers: {
+      monitoringStationsLayer: true,
+      waterbodyLayer: false,
+    },
   },
   {
     title: 'Identified Issues',
@@ -305,7 +308,9 @@ const tabs = [
     icon: restoreIcon,
     upper: restoreUpper,
     lower: <Restore />,
-    layers: {},
+    layers: {
+      waterbodyLayer: false,
+    },
   },
   {
     title: 'Protect',
@@ -317,6 +322,7 @@ const tabs = [
       wsioHealthIndexLayer: false,
       wildScenicRiversLayer: false,
       protectedAreasLayer: false,
+      waterbodyLayer: false,
     },
   },
 ];


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3713158

## Main Changes:
* Added the "Waterbodies" layer to the Monitoring, Restore, and Protect tabs.

## Steps To Test:
1. Navigate to http://localhost:3000/community/2-98%20E%20Beverly%20St,%20Staunton,%20Virginia,%2024401/monitoring
2. Verify the "Waterbodies" layer is available in the layer list
3. Go to the "Drinking Water" tab and then back to the "Monitoring" tab
4. Turn on the "Waterbodies" layer and verify all of the waterbodies show on the map
  * Note: This test is here because I noticed an issue where the drinking water tab's filter was left applied which resulted in no waterbodies showing up on the monitoring tab.
5. Go to the "Restore" tab
6. Verify the "Waterbodies" layer is available in the layer list
7. Go to the "Drinking Water" tab and then back to the "Restore" tab
8. Turn on the "Waterbodies" layer and verify all of the waterbodies show on the map
9. Go to the "Protect" tab
10. Verify the "Waterbodies" layer is available in the layer list
11. Go to the "Drinking Water" tab and then back to the "Protect" tab

