### PR TITLE
Feature/minor changes

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -359,7 +359,7 @@
                   <a href="https://www.epa.gov/grants">Grants</a>
                 </li>
                 <li>
-                  <a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+                  <a href="https://www.epa.gov/home/wwwepagov-snapshots">EPA www Web Snapshots</a>
                 </li>
                 <li>
                   <a

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -61,10 +61,6 @@ const Container = styled.div`
   padding: 1em;
 `;
 
-const Text = styled.p`
-  text-align: center;
-`;
-
 const List = styled.ul`
   padding-bottom: 1.5rem;
 `;
@@ -653,10 +649,7 @@ function Protect() {
 
                     {wildScenicRiversData.status === 'success' &&
                       wildScenicRiversData.data.length === 0 && (
-                        <p>
-                          No Wild and Scenic River data available for this
-                          location.
-                        </p>
+                        <p>No Wild and Scenic River data available.</p>
                       )}
 
                     {wildScenicRiversData.status === 'success' &&
@@ -789,10 +782,10 @@ function Protect() {
                     {grts.status === 'success' && (
                       <>
                         {sortedGrtsData.length === 0 && (
-                          <Text>
+                          <p>
                             There are no EPA funded protection projects in the{' '}
                             {watershed} watershed.
-                          </Text>
+                          </p>
                         )}
 
                         {sortedGrtsData.length > 0 && (

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -128,7 +128,7 @@
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
 								<li><a href="https://www.epa.gov/grants">Grants</a>
 								</li>
-								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+								<li><a href="https://www.epa.gov/home/wwwepagov-snapshots">EPA www Web Snapshots</a>
 								</li>
 								<li><a
 										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -140,7 +140,7 @@
 								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
 								<li><a href="https://www.epa.gov/grants">Grants</a>
 								</li>
-								<li><a href="https://19january2017snapshot.epa.gov">January 19, 2017 Web Snapshot</a>
+								<li><a href="https://www.epa.gov/home/wwwepagov-snapshots">EPA www Web Snapshots</a>
 								</li>
 								<li><a
 										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3714876
* https://app.breeze.pm/projects/100762/cards/3717100

## Main Changes:
* Updated the "No Wild and Scenic River data..." message
* Left justified the "There are no EPA funded protection projects..." message
* Updated the footer of the One EPA Template to match up with the footer on https://www.epa.gov/

## Steps To Test:
1. Navigate to http://localhost:3000/community/050500020908/protect
2. Verify the protect panel text changes have been made
3. Scroll down to the one EPA template footer
4. Verify the "January 19, 2017 Web Snapshot" link was changed to "EPA www Web Snapshots"
5. Verify the "EPA www Web Snapshots" links to https://www.epa.gov/home/wwwepagov-snapshots

