### PR TITLE
Bugfix/county service change

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -465,7 +465,7 @@ function DrinkingWater() {
     countyBoundaries.features &&
     countyBoundaries.features.length > 0
   ) {
-    county = countyBoundaries.features[0].attributes.COUNTY;
+    county = countyBoundaries.features[0].attributes.NAME;
   }
 
   const [providersSortBy, setProvidersSortBy] = React.useState('population');


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3714936

## Main Changes:
* Fixed an issue with "undefined" being displayed instead of the county name. This was due to a change at the service endpoint.

## Steps To Test:
1. Navigate to http://localhost:3000/community/protland%20or/drinking-water
2. Verify the message above the accordions says "Public water systems serving Multnomah County" instead of "Public water systems serving undefined County"
3. Check other locations and verify the county is not "undefined"

