### PR TITLE
bugfix/IE11 append support

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -394,8 +394,8 @@ function MapWidgets({
   const esriLegendTemp = document.createElement('div');
   esriLegendTemp.id = 'esri-legend-container';
   esriLegendTemp.className = 'esri-legend-hidden';
-  legendTemp.append(hmwLegendTemp);
-  legendTemp.append(esriLegendTemp);
+  legendTemp.appendChild(hmwLegendTemp);
+  legendTemp.appendChild(esriLegendTemp);
   const [hmwLegendNode] = React.useState(hmwLegendTemp);
   const [esriLegendNode] = React.useState(esriLegendTemp);
   const [legendNode] = React.useState(legendTemp);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3720316

## Main Changes:
* Replaces usage of .append() with .appendChild() for IE11
* More information https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append

## Steps To Test:
1. Navigate to http://localhost:3000/community/Town%20of%20Amherst,%20NY,%20USA/overview in IE11
2. Verify map legend functions correctly with .appendChild() instead of .append()
