### PR TITLE
Feature/location search aria owns issue

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -800,7 +800,7 @@ function LocationSearch({ route, label }: Props) {
                     }, 250);
                   }}
                   aria-owns={
-                    filteredSuggestions.length > 0
+                    filteredSuggestions.length > 0 && suggestionsVisible
                       ? 'search-container-suggest-menu'
                       : ''
                   }


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3720185

## Main Changes:
* Fixes accessibility issue related to aria-owns attribute on location search input

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Run Axe and verify the aria-owns issue no longer appears
3. Open devtools and inspect the search input. Verify the aria-owns attribute updates when the suggestions appear and disappear.

