### PR TITLE
Bugfix/location search scroll…

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -655,6 +655,27 @@ function LocationSearch({ route, label }: Props) {
 
   const searchTerm = splitSuggestedSearch(Point, searchText).searchPart;
 
+  // Detect clicks outside of the search input and search suggestions list.
+  // This is used for closing the suggestions list when the user clicks outside.
+  const suggestionsRef = React.useRef();
+  React.useEffect(() => {
+    function handleClickOutside(event) {
+      if (
+        suggestionsRef.current &&
+        !suggestionsRef.current.contains(event.target)
+      ) {
+        setSuggestionsVisible(false);
+      }
+    }
+
+    // Bind the event listener
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      // Unbind the event listener on clean up
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [suggestionsRef]);
+
   return (
     <>
       {errorMessage && (
@@ -755,7 +776,7 @@ function LocationSearch({ route, label }: Props) {
                 })}
               </ul>
             </div>
-            <div className="esri-search__input-container">
+            <div className="esri-search__input-container" ref={suggestionsRef}>
               <div className="esri-search__form" role="search">
                 <input
                   id="hmw-search-input"
@@ -793,11 +814,6 @@ function LocationSearch({ route, label }: Props) {
                     setSourcesVisible(false);
                     setSuggestionsVisible(true);
                     setCursor(-1);
-                  }}
-                  onBlur={(ev) => {
-                    setTimeout(() => {
-                      setSuggestionsVisible(false);
-                    }, 250);
                   }}
                   aria-owns={
                     filteredSuggestions.length > 0 && suggestionsVisible


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3720148

## Main Changes:
* Fixed issue with location search suggestions closing when trying to use the scroll bar.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Type "town" into the search input
3. Verify the scroll bar for the search suggestions works
4. Click somewhere on the screen other than the search input and search suggestions list
5. Verify the search suggestions are closed
6. Click in the search input to open the search suggestions
7. Click a suggestion and verify it works

