### PR TITLE
feature/switch-from-request-to-axios

### DIFF
--- a/app/server/npm-shrinkwrap.json
+++ b/app/server/npm-shrinkwrap.json
@@ -265,7 +265,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -314,6 +313,16 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bent": {
+      "version": "7.3.12",
+      "resolved": "https://registry.npmjs.org/bent/-/bent-7.3.12.tgz",
+      "integrity": "sha512-T3yrKnVGB63zRuoco/7Ybl7BwwGZR0lceoVG5XmQyMIH9s19SV5m+a8qam4if0zQuAmOQTyPTPmsQBdAorGK3w==",
+      "requires": {
+        "bytesish": "^0.4.1",
+        "caseless": "~0.12.0",
+        "is-stream": "^2.0.0"
       }
     },
     "binary-extensions": {
@@ -599,6 +608,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
+    },
+    "bytesish": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/bytesish/-/bytesish-0.4.4.tgz",
+      "integrity": "sha512-i4uu6M4zuMUiyfZN4RU2+i9+peJh//pXhd9x1oSe1LBkZ3LEbCoygu8W0bXTukU1Jme2txKuotpCZRaC3FLxcQ=="
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -1403,8 +1417,7 @@
     "follow-redirects": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
-      "dev": true
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1826,8 +1839,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-typedarray": {
       "version": "1.0.0",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -31,12 +31,12 @@
     "start": "nodemon -r dotenv/config --inspect app/server.js dotenv_config_path=./.env.local"
   },
   "dependencies": {
+    "axios": "0.21.1",
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "express-basic-auth": "1.2.0",
     "helmet": "4.4.1",
     "log4js": "6.3.0",
-    "request": "2.88.2",
     "serve-favicon": "2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I found a package to replace the `request` package. I got this working in TOTS, but I ultimately needed to test this code in HMW, since TOTS doesn't currently have anything like terminology services.

## Related Issues
* https://app.breeze.pm/projects/100762/cards/3740500

## Main Changes:
* Switched from the request package to axios.

## Steps To Test:
1. Run `npm ci` from the `app\server` folder
2. Start the app
3. Verify the glossary loads correctly
4. Verify the app works
5. Run cypress