### PR TITLE
Feature/identified issues switches bug

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -448,8 +448,7 @@ function IdentifiedIssues() {
 
   const toggleSwitch = (checkedSwitch: SwitchNames) => {
     // create a temporary object with the previous state
-    // const tempParameterToggleObject = { ...parameterToggleObject };
-    const tempParameterToggleObject = parameterToggleObject;
+    const tempParameterToggleObject = { ...parameterToggleObject };
 
     // set all paramters to On and show the issuesLayer
     const toggleOn = () => {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3747400

## Main Changes:
* Fixed an issue with only the first switch toggled on updating the graphics on the map.

## Steps To Test:
1. Navigate to http://localhost:3000/community/020700100204/identified-issues
2. Turn off all of the toggles
3. Turn on Sediment
4. Verify a new waterbody is displayed on the map
5. Turn on Chlorine
6. Verify a new waterbody is displayed on the map
7. Turn on Salts
8. Verify a new waterbody is displayed on the map
9. Turn off Salts
10. Verify the waterbodies displayed in step 8 are removed from the map

