### PR TITLE
Bugfix/ga errors

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -317,6 +317,11 @@ function IdentifiedIssues() {
   React.useEffect(() => {
     if (!window.gaTarget || cipSummary.status !== 'success') return;
 
+    if (!cipSummary.data?.items?.length > 0) {
+      setNullPollutedWaterbodies(true);
+      return;
+    }
+
     const {
       assessedCatchmentAreaSqMi,
       containImpairedWatersCatchmentAreaPercent,
@@ -650,7 +655,8 @@ function IdentifiedIssues() {
             <TabPanels>
               <TabPanel>
                 {cipSummary.status === 'fetching' && <LoadingSpinner />}
-                {cipSummary.status === 'failure' && (
+                {(cipSummary.status === 'failure' ||
+                  !cipSummary.data?.items) && (
                   <StyledErrorBox>
                     <p>{huc12SummaryError}</p>
                   </StyledErrorBox>

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -12,7 +12,12 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // helpers
 import { useKeyPress } from 'utils/hooks';
-import { containsScriptTag, isHuc12, splitSuggestedSearch } from 'utils/utils';
+import {
+  containsScriptTag,
+  escapeRegex,
+  isHuc12,
+  splitSuggestedSearch,
+} from 'utils/utils';
 // styles
 import { colors } from 'styles/index.js';
 // errors
@@ -556,7 +561,7 @@ function LocationSearch({ route, label }: Props) {
                 }}
               >
                 {result.text
-                  .split(new RegExp(`(${inputText})`, 'gi'))
+                  .split(new RegExp(`(${escapeRegex(inputText)})`, 'gi'))
                   .map((part, textIndex) => {
                     if (part.toLowerCase() === inputText.toLowerCase()) {
                       return (

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { escapeRegex } from 'utils/utils';
+
 const defaultTimeout = 60000;
 
 export function fetchCheck(apiUrl: string, timeout: number = defaultTimeout) {
@@ -227,7 +229,6 @@ export function logCallToGoogleAnalytics(
 }
 
 function wildcardIncludes(str, rule) {
-  var escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\]\\])/g, '\\$1');
   return new RegExp(
     '^' + rule.split('*').map(escapeRegex).join('.*') + '$',
   ).test(str);

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -275,9 +275,15 @@ function convertDomainCode(fields, name, value) {
   return value;
 }
 
+// Escapes special characters for usage with regex
+function escapeRegex(str) {
+  return str.replace(/([.*+?^=!:${}()|\]\\])/g, '\\$1');
+}
+
 export {
   chunkArray,
   containsScriptTag,
+  escapeRegex,
   formatNumber,
   getExtensionFromPath,
   isHuc12,


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3753992

## Main Changes:
* Fixed issues with users entering special regex characters in the community search input.
* Fixed issue with huc12Summary service executing successfully but with no data.

## Steps To Test:
1. Navigate to http://localhost:3000/community/131%20oak%20st%2015748/overview
2. Add a ")" to the end of the search text (i.e., "131 oak st 15748" goes to "131 oak st 15748)")
3. Verify the search suggestions update without the app crashing.
4. Update line 858 in the LocationMap component to be `data: [],` to force an error situation.
5. Navigate to http://localhost:3000/community/pine%20river%20pond,%20nh,%20usa/identified-issues
6. Verify the app doesn't crash
7. Verify the "of Assessed Waters are Impaired" value is "N/A" and an error message is displayed.

