### PR TITLE
Bugfix/gpra service error

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -1080,7 +1080,7 @@ function WaterQualityOverview({ ...props }: Props) {
 
                   <h4>EPA has defined three types of public water systems:</h4>
 
-                  {tab.id === 'drinking' && (
+                  {tab.id === 'drinking' && activeState.code && (
                     <WaterSystemSummary state={activeState} />
                   )}
 

--- a/app/client/src/components/shared/WaterSystemSummary/index.js
+++ b/app/client/src/components/shared/WaterSystemSummary/index.js
@@ -146,9 +146,14 @@ function WaterSystemSummary({ state }: Props) {
           if (item.primacy_agency_code !== state.code) return;
 
           const { pws_type_code, number_of_systems } = item;
-          if (pws_type_code === 'CWS') cwsCount = number_of_systems;
-          if (pws_type_code === 'NTNCWS') ntncwsCount = number_of_systems;
-          if (pws_type_code === 'TNCWS') tncwsCount = number_of_systems;
+          switch (pws_type_code) {
+            case 'CWS':
+              cwsCount = number_of_systems;
+            case 'NTNCWS':
+              ntncwsCount = number_of_systems;
+            case 'TNCWS':
+              tncwsCount = number_of_systems;
+          }
         });
 
         setSystemTypeRes({

--- a/app/client/src/components/shared/WaterSystemSummary/index.js
+++ b/app/client/src/components/shared/WaterSystemSummary/index.js
@@ -105,6 +105,7 @@ type Props = {
 function WaterSystemSummary({ state }: Props) {
   const services = useServicesContext();
 
+  const [lastCountsCode, setLastCountsCode] = React.useState(null);
   const [systemTypeRes, setSystemTypeRes] = React.useState({
     status: 'fetching',
     data: {
@@ -114,6 +115,16 @@ function WaterSystemSummary({ state }: Props) {
     },
   });
   React.useEffect(() => {
+    if (
+      !state.code ||
+      lastCountsCode === state.code ||
+      services.status !== 'success'
+    ) {
+      return;
+    }
+
+    setLastCountsCode(state.code);
+
     fetchCheck(`${services.data.dwmaps.getGPRASystemCountsByType}${state.code}`)
       .then((res) => {
         if (!res || !res.items || res.items.length === 0) {
@@ -160,19 +171,30 @@ function WaterSystemSummary({ state }: Props) {
           },
         });
       });
-  }, [state, services]);
+  }, [state, services, lastCountsCode]);
 
   // fetch GPRA data
+  const [lastSummaryCode, setLastSummaryCode] = React.useState(null);
   const [gpraData, setGpraData] = React.useState({
     status: 'fetching',
     data: {},
   });
 
   React.useEffect(() => {
+    if (
+      !state.code ||
+      lastSummaryCode === state.code ||
+      services.status !== 'success'
+    ) {
+      return;
+    }
+
+    setLastSummaryCode(state.code);
+
     fetchCheck(`${services.data.dwmaps.getGPRASummary}${state.code}`)
       .then((res) => setGpraData({ status: 'success', data: res.items[0] }))
       .catch((err) => setGpraData({ status: 'failure', data: {} }));
-  }, [state, services]);
+  }, [state, services, lastSummaryCode]);
 
   return (
     <>

--- a/app/client/src/components/shared/WaterSystemSummary/index.js
+++ b/app/client/src/components/shared/WaterSystemSummary/index.js
@@ -149,10 +149,13 @@ function WaterSystemSummary({ state }: Props) {
           switch (pws_type_code) {
             case 'CWS':
               cwsCount = number_of_systems;
+              break;
             case 'NTNCWS':
               ntncwsCount = number_of_systems;
+              break;
             case 'TNCWS':
               tncwsCount = number_of_systems;
+              break;
           }
         });
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3764037

## Main Changes:
* Fixed an issue with GPRA services failing because the state parameter wasn't being passed in.
* Fixed an issue with GPRA services being called twice on the national page.

## Steps To Test:
1. Open the Chrome dev tools
2. Put `ofmpub.epa.gov/apex/sfdw_rest/` in the filter on the network tab
3. In the `components/pages/National/index.js` file replace line 542 with `<WaterSystemSummary state={{ name: '', code: '' }} />`
4. Navigate to http://localhost:3000/national
5. Verify no calls are made
6. In the `components/pages/National/index.js` file replace line 542 with `<WaterSystemSummary state={{ name: 'US', code: 'National' }} />`
7. Verify there are only two calls. Currently there are four calls in production
8. Navigate to http://localhost:3000/state/AL/water-quality-overview
9. Verify there are only two calls

