### PR TITLE
Bugfix/cache control issue

### DIFF
--- a/app/server/app/server/routes/proxy.js
+++ b/app/server/app/server/routes/proxy.js
@@ -72,6 +72,9 @@ module.exports = function (app) {
       delete response.headers['server'];
       delete response.headers['x-aspnet-version'];
       // end of EPA TS work around.
+
+      // Disable cache for all proxy requests
+      response.headers['cache-control'] = 'no-cache';
     }
 
     axios({


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3764213

## Main Changes:
* Fixed cache control issues by disabling it for now.

## Steps To Test:
1. Open the Chrome dev tools
2. Type `proxy` into the filter on the network tab
3. Verify the `cache-control` response header is set to `no-cache` for all of the proxy requests

