### PR TITLE
Feature/ie11 compatibility mode meta tag fix

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8" />
   <meta http-equiv="ImageToolbar" content="false" />
   <meta http-equiv="cleartype" content="on" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="HandheldFriendly" content="true" />
   <link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
     type="image/vnd.microsoft.icon" />


### PR DESCRIPTION
Add "X-UA-Compatible" meta tag to resolve issue with EPA IE11.