### PR TITLE
Bugfix/waterbody report displaying 2018 instead of 2020

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -996,7 +996,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
                 rel="noopener noreferrer"
               >
                 <Icon className="fas fa-file-alt" aria-hidden="true" />
-                View Waterbody Report for 2018
+                View Waterbody Report for {mapReportingCycle}
               </a>
               &nbsp;&nbsp;
               <NewTabDisclaimer>(opens new browser tab)</NewTabDisclaimer>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3785868

## Main Changes:
* Fixed an issue with the more recent data available message always displaying 2018 because of hardcoded text.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/DOEE/DCTCO01L_00/2018
2. Verify the message at the top says 2020 instead of 2018.
3. Click the link and verify it opens the report for 2020.

