### PR TITLE
bugfix/glossary-scrolling-issue

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -9778,7 +9778,7 @@
       }
     },
     "glossary-panel": {
-      "version": "github:Eastern-Research-Group/glossary#1aa62f79cbb5bc3de9dc1dc446f7717b48bf564d",
+      "version": "github:Eastern-Research-Group/glossary#be946bdf28bda993134ee9055fb64dd3d6c12866",
       "from": "github:Eastern-Research-Group/glossary",
       "requires": {
         "aria-accordion": "^1.0.0",


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3801531

## Main Changes:
* Removed scrollTo code from glossary component to prevent issues with HMW full screen map.

## Steps To Test:
1. Navigate to https://mywaterway-dev.app.cloud.gov/community/dc/overview
2. Enter the full screen map by clicking the Full Screen button in the bottom right-hand corner of the map.
3. Select a waterbody on the map until you find one that has at least 1 Impairment Category.
4. Click on the Glossary link for the Impairment Category to open the Glossary.
5. Close the Glossary by clicking outside of the Glossary panel or click the X in the top right corner of the Glossary.
6. Verify the page header does not appear and the full screen mode functions normally.
