### PR TITLE
Feature/waterbody icon aria labels

### DIFF
--- a/app/client/src/components/shared/WaterbodyIcon/index.js
+++ b/app/client/src/components/shared/WaterbodyIcon/index.js
@@ -66,13 +66,20 @@ function WaterbodyIcon({ condition, selected = false }: Props) {
     );
   }
 
+  const ariaLabel =
+    condition === 'good'
+      ? 'Good'
+      : condition === 'polluted'
+      ? 'Polluted'
+      : 'Condition Unknown';
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width="26"
       height="26"
       viewBox="0 0 26 26"
-      aria-hidden="true"
+      aria-label={ariaLabel}
     >
       {shape}
     </svg>

--- a/app/client/src/components/shared/WaterbodyIcon/index.js
+++ b/app/client/src/components/shared/WaterbodyIcon/index.js
@@ -66,12 +66,9 @@ function WaterbodyIcon({ condition, selected = false }: Props) {
     );
   }
 
-  const ariaLabel =
-    condition === 'good'
-      ? 'Good'
-      : condition === 'polluted'
-      ? 'Polluted'
-      : 'Condition Unknown';
+  let ariaLabel = 'Condition Unknown';
+  if (condition === 'good') ariaLabel = 'Good';
+  if (condition === 'polluted') ariaLabel = 'Polluted';
 
   return (
     <svg


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3785837

## Main Changes:
* Adds aria labels to Waterbody Icons based on their condition.
* Reasoning for this change is when viewing Community accordion lists on a screen reader there is no way to know what the status of the waterbody is until the accordion is opened.

## Steps To Test:
1. Run accessibility checker like axe or WAVE and verify there are no issues with this change.

