### PR TITLE
Feature/re-add glossary scrolling

### DIFF
--- a/app/client/npm-shrinkwrap.json
+++ b/app/client/npm-shrinkwrap.json
@@ -9778,7 +9778,7 @@
       }
     },
     "glossary-panel": {
-      "version": "github:Eastern-Research-Group/glossary#1aa62f79cbb5bc3de9dc1dc446f7717b48bf564d",
+      "version": "github:Eastern-Research-Group/glossary#e8a7a3e2ba979d0642058848cbbe24e179c179a3",
       "from": "github:Eastern-Research-Group/glossary",
       "requires": {
         "aria-accordion": "^1.0.0",


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3801531

## Main Changes:
* Re-adds the scrolling behavior when the glossary panel is closed and does not affect the page itself. This way the HMW full screen map will be unaffected.
