### PR TITLE
Feature/text changes ejscreen data page

### DIFF
--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -609,7 +609,7 @@ export function getPopupContent({
 
   // EJSCREEN
   else if (attributes.T_OVR64PCT) {
-    type = 'Environmental Justice';
+    type = 'Demographic Indicators';
   }
 
   const content = (

--- a/app/client/src/components/shared/DataContent/index.js
+++ b/app/client/src/components/shared/DataContent/index.js
@@ -207,8 +207,8 @@ function Data({ ...props }: Props) {
           <GlossaryTerm term="Clean Water Act Section 319 Projects">
             Clean Water Act Section 319 Projects
           </GlossaryTerm>{' '}
-          ), Protect (Protection Projects). On the State page under Water
-          Stories.{' '}
+          ), Protect, Watershed Health and Protection (Protection Projects). On
+          the State page under Water Stories.{' '}
         </p>
       </Item>
 
@@ -288,6 +288,95 @@ function Data({ ...props }: Props) {
           Information from this database can be found on the Community page
           under the Overview tab (monitoring locations) and under the Monitoring
           tab after performing a search.
+        </p>
+      </Item>
+
+      <hr />
+
+      <Item>
+        <i className="fas fa-database" aria-hidden="true" />{' '}
+        <a
+          href="https://www.epa.gov/wsio"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Watershed Index Online (WSIO)
+        </a>
+        <p>
+          The Watershed Index Online (WSIO) is a free, publicly available data
+          library of watershed indicators and a decision-support tool, developed
+          by EPA, to assist resource managers, citizens, and other users with
+          evaluating, comparing, and prioritizing watersheds for a user-defined
+          purpose.
+        </p>
+        <br />
+        <Question>Where do I find WSIO data in How’s My Waterway?</Question>
+        <p>
+          Information from this database can be found on the Community page on
+          the protect tab under Watershed Health and Protection, Watershed
+          Health Scores.
+        </p>
+      </Item>
+
+      <hr />
+
+      <Item>
+        <i className="fas fa-database" aria-hidden="true" />{' '}
+        <a
+          href="https://www.rivers.gov/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Wild and Scenic Rivers
+        </a>
+        <p>
+          Data and GIS files on wild and scenic rivers can be found on the{' '}
+          <a
+            href="https://www.rivers.gov/mapping-gis.php"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            National Wild and Scenic Rivers System
+          </a>{' '}
+          website.
+        </p>
+        <br />
+        <Question>
+          Where do I find Wild and Scenic Rivers data in How’s My Waterway?
+        </Question>
+        <p>
+          Information from this database can be found on the Community page on
+          the protect tab under Watershed Health and Protection, Wild and Scenic
+          Rivers.
+        </p>
+      </Item>
+
+      <hr />
+
+      <Item>
+        <i className="fas fa-database" aria-hidden="true" />{' '}
+        <a
+          href="https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Protected Areas
+        </a>
+        <p>
+          The Protected Areas Database (PAD-US) is America’s official national
+          inventory of U.S. terrestrial and marine protected areas that are
+          dedicated to the preservation of biological diversity and to other
+          natural, recreation and cultural uses, managed for these purposes
+          through legal or other effective means.
+        </p>
+        <br />
+        <Question>
+          Where do I find Wild and Protected Areas data in How’s My Waterway?
+        </Question>
+        <p>
+          Information from this database can be found on the Community page on
+          the protect tab under Watershed Health and Protection, Protected
+          Areas.
         </p>
       </Item>
     </Container>

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -485,7 +485,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Less Than HS Education': {
         label: 'Percent Less than High School Education',
         glossary: (
-          <GlossaryTerm term="Percent Less than High School Education (Environmental Justice)">
+          <GlossaryTerm term="Percent Less than High School Education">
             Percent Less than High School Education
           </GlossaryTerm>
         ),
@@ -493,15 +493,13 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Minority Population': {
         label: 'Percent Minority',
         glossary: (
-          <GlossaryTerm term="Percent Minority (Environmental Justice)">
-            Percent Minority
-          </GlossaryTerm>
+          <GlossaryTerm term="Percent Minority">Percent Minority</GlossaryTerm>
         ),
       },
       'Linguistically Isolated': {
         label: 'Percent in Linguistic Isolation',
         glossary: (
-          <GlossaryTerm term="Percent in Linguistic Isolation (Environmental Justice)">
+          <GlossaryTerm term="Percent in Linguistic Isolation">
             Percent in Linguistic Isolation
           </GlossaryTerm>
         ),
@@ -509,7 +507,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Low Income': {
         label: 'Percent Low-Income',
         glossary: (
-          <GlossaryTerm term="Percent Low- Income (Environmental Justice)">
+          <GlossaryTerm term="Percent Low- Income">
             Percent Low-Income
           </GlossaryTerm>
         ),
@@ -517,7 +515,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Over Age 64': {
         label: 'Percent over age 64',
         glossary: (
-          <GlossaryTerm term="Percent over age 64 (Environmental Justice)">
+          <GlossaryTerm term="Percent over age 64">
             Percent over age 64
           </GlossaryTerm>
         ),
@@ -525,7 +523,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Under Age 5': {
         label: 'Percent under age 5',
         glossary: (
-          <GlossaryTerm term="Percent under age 5 (Environmental Justice)">
+          <GlossaryTerm term="Percent under age 5">
             Percent under age 5
           </GlossaryTerm>
         ),
@@ -533,7 +531,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
       'Demographic Index': {
         label: 'Demographic Index',
         glossary: (
-          <GlossaryTerm term="Demographic Index (Environmental Justice)">
+          <GlossaryTerm term="Demographic Index">
             Demographic Index
           </GlossaryTerm>
         ),

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -464,7 +464,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
 
   // jsx
   const ejscreenLegend = () => {
-    const layerName = 'Environmental Justice';
+    const layerName = 'Demographic Indicators';
 
     if (additionalLegendInfo.status === 'fetching') return <LoadingSpinner />;
     if (additionalLegendInfo.status === 'failure') {

--- a/app/client/src/components/shared/MapPopup/index.js
+++ b/app/client/src/components/shared/MapPopup/index.js
@@ -55,7 +55,7 @@ function MapPopup({
   const hideTypes = ['Action', 'Change Location', 'Waterbody State Overview'];
 
   let typeTitle = type;
-  if (type === 'Environmental Justice') {
+  if (type === 'Demographic Indicators') {
     typeTitle += ` - ${feature.layer.title}`;
   }
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -621,7 +621,7 @@ function MapWidgets({
     const uniqueParentItems = [];
     function defineActions(event) {
       const item = event.item;
-      if (!item.parent || item.parent.title === 'Environmental Justice') {
+      if (!item.parent || item.parent.title === 'Demographic Indicators') {
         //only add the item if it has not been added before
         if (!uniqueParentItems.includes(item.title)) {
           uniqueParentItems.push(item.title);

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1090,7 +1090,7 @@ function WaterbodyInfo({
   if (type === 'Alaska Native Village') return alaskaNativeVillageContent;
   if (type === 'Change Location') return changeLocationContent;
   if (type === 'Protected Areas') return protectedAreaContent;
-  if (type === 'Environmental Justice') return ejscreenContent;
+  if (type === 'Demographic Indicators') return ejscreenContent;
 
   return null;
 }

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -1085,7 +1085,7 @@ function useSharedLayers() {
 
     const ejscreen = new GroupLayer({
       id: 'ejscreenLayer',
-      title: 'Environmental Justice',
+      title: 'Demographic Indicators',
       listMode: 'show',
       visible: false,
       layers: [


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3804557
* https://app.breeze.pm/projects/100762/cards/3804528

## Main Changes:
* Renamed the EJSCREEN layer from "Environmental Justice" to "Demographic Indicators".
* Updated the EJSCREEN glossary term links (in legend) to not search with the layer name. I did this in case we need to change the glossary terms.
* Updated the text on the data page.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the layer list widget
3. Verify the "Environmental Justice" layer is now "Demographic Indicators"
4. Turn on the "Demographic Indicators" layer and all of the sublayers
5. Open the legend
6. Verify the legend shows the "Demographic Indicators"
7. Click on the glossary terms
8. Verify the term search works and the search does not include "(Environmental Justice)"
9. Click on the map and verify the "Demographic Indicators" popup works.
10. Navigate to http://localhost:3000/data
11. Verify the text changes

