### PR TITLE
Feature/waterbody report min height map

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -611,6 +611,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                     <StickyBox offsetTop={20} offsetBottom={20}>
                       {infoBox}
                       <div
+                        id="plan-summary-map"
                         style={{
                           height: height - infoHeight - 70,
                           minHeight: '400px',

--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -610,7 +610,12 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                   ) : (
                     <StickyBox offsetTop={20} offsetBottom={20}>
                       {infoBox}
-                      <div style={{ height: height - infoHeight - 70 }}>
+                      <div
+                        style={{
+                          height: height - infoHeight - 70,
+                          minHeight: '400px',
+                        }}
+                      >
                         <ActionsMap
                           layout="wide"
                           unitIds={unitIds}

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -1032,6 +1032,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
                     <StickyBox offsetTop={20} offsetBottom={20}>
                       {infoBox}
                       <div
+                        id="waterbody-report-map"
                         style={{
                           height: height - infoHeight - 70,
                           minHeight: '400px',

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -1031,7 +1031,12 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
                   ) : (
                     <StickyBox offsetTop={20} offsetBottom={20}>
                       {infoBox}
-                      <div style={{ height: height - infoHeight - 70 }}>
+                      <div
+                        style={{
+                          height: height - infoHeight - 70,
+                          minHeight: '400px',
+                        }}
+                      >
                         <ActionsMap
                           layout="wide"
                           unitIds={unitIds}

--- a/app/cypress/integration/plan_summary.spec.js
+++ b/app/cypress/integration/plan_summary.spec.js
@@ -67,4 +67,20 @@ describe('Plan Summary (Actions) page', () => {
     cy.findByText(linkText).should('have.attr', 'target', '_blank');
     cy.findByText(linkText).should('have.attr', 'rel', 'noopener noreferrer');
   });
+
+  it('Verify the maps height does not go below 400 pixels', () => {
+    // shrink the viewport to test min height
+    cy.viewport(1100, 600);
+
+    cy.visit('/plan-summary/CA_SWRCB/66264');
+
+    // wait for the web services to finish (attains/plans is sometimes slow)
+    // the timeout chosen is the same timeout used for the attains/plans fetch
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 20000 }).should(
+      'not.exist',
+    );
+
+    // verify the map height is 400 pixels or greater
+    cy.get('#plan-summary-map').invoke('outerHeight').should('be.gt', 399);
+  });
 });

--- a/app/cypress/integration/waterbody_report.spec.js
+++ b/app/cypress/integration/waterbody_report.spec.js
@@ -92,4 +92,20 @@ describe('Waterbody Report page', () => {
 
     cy.findAllByText('DC_02_DCANA00E_02').should('be.visible');
   });
+
+  it('Verify the maps height does not go below 400 pixels', () => {
+    // shrink the viewport to test min height
+    cy.viewport(1100, 600);
+
+    cy.visit('/waterbody-report/DOEE/DCANA00E_02/2020');
+
+    // wait for the web services to finish (attains/plans is sometimes slow)
+    // the timeout chosen is the same timeout used for the attains/plans fetch
+    cy.findAllByTestId('hmw-loading-spinner', { timeout: 20000 }).should(
+      'not.exist',
+    );
+
+    // verify the map height is 400 pixels or greater
+    cy.get('#waterbody-report-map').invoke('outerHeight').should('be.gt', 399);
+  });
 });


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3804560

## Main Changes:
* Added a minimum height (400px) to the map on the waterbody report page.
* Added a minimum height (400px) to the map on the plan summary page.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/DOEE/DCANA00E_02/2020
2. Shrink the height of your browser
3. Verify the map height does not go below 400px.
4. Navigate to http://localhost:3000/plan-summary/CA_SWRCB/66264
5. Shrink the height of your browser
6. Verify the map height does not go below 400px.
7. Run the `waterbody_report.spec.js` and `plan_summary.spec.js` cypress tests. 
  * Change `it(` to `it.only(` to skip unnecessary tests. 

