### PR TITLE
Feature/canonical link issue

### DIFF
--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -130,7 +130,7 @@ function updateCanonicalLink(huc12) {
 
 function resetCanonicalLink() {
   const canonicalLink = document.querySelector('[rel="canonical"]');
-  if (canonicalLink) canonicalLink.href = '';
+  if (canonicalLink) canonicalLink.href = window.location.href;
 }
 
 function removeJsonLD() {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3808238

## Main Changes:
* Update the canonical link for pages other than the community details page.

## Steps To Test:
1. Open the dev tools
2. Navigate around the app and verify the canonical link updates appropriately
  * For community page with a search it should be something like: `https://geoconnex.us/epa/hmw/<huc12>`
  * For all other pages it should be a copy of the url in the browser's address bar (i.e. localhost:3000/state). 

