### PR TITLE
Bugfix/initially hide upstream layer legend

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -202,6 +202,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       id: 'upstreamWatershed',
       title: 'Upstream Watershed',
       listMode: 'hide',
+      visible: false,
     });
 
     setUpstreamLayer(upstreamLayer);


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3809536

## Main Changes:
* Hide Upstream Watershed in map legend until the layer is displayed.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the map legend. Verify Upstream Watershed is not displayed.
3. Search a location like DC. Toggle the Upstream Watershed layer on using the button in the top right corner of the map.
4. Verify the Upstream Watershed appears in the legend.
5. Toggle the Upstream Watershed layer off. 
6. Verify the layer is no longer displayed in the legend.
