### PR TITLE
Bugfix/infinite loading spinner gispub error

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -1108,6 +1108,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
                 setAddress(newAddress); // preserve the user's search so it is displayed
                 setNoDataAvailable();
                 setErrorMessage(watersgeoError);
+                setMapLoading(false);
               });
           }
 
@@ -1155,6 +1156,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             .catch((err) => {
               console.error(err);
               setCountyBoundaries(null);
+              setMapLoading(false);
               setDrinkingWater({
                 data: [],
                 status: 'failure',
@@ -1173,6 +1175,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             setAddress(newAddress); // preserve the user's search so it is displayed
             setNoDataAvailable();
             setErrorMessage(geocodeError);
+            setMapLoading(false);
             return;
           }
 


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3809423

## Main Changes:
* Fixed issue of infinite loading spinner when the gispub services fail.

## Steps To Test:
1. Open the dev tools
2. Navigate to http://localhost:3000/community/dc/overview
3. On the network tab, block the "gispub.epa.gov" domain
4. Refresh
5. Verify an error message is displayed and the loading spinner shuts off

