### PR TITLE
Bugfix/monitoring location

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -515,7 +515,10 @@ function Monitoring() {
                           Organization ID: {prop['OrganizationIdentifier']}
                           <br />
                           Monitoring Site ID:{' '}
-                          {prop['MonitoringLocationIdentifier'].split('-')[1]}
+                          {prop['MonitoringLocationIdentifier'].replace(
+                            `${prop['OrganizationIdentifier']}-`,
+                            '',
+                          )}
                           <br />
                           Monitoring Measurements:{' '}
                           {Number(prop['resultCount']).toLocaleString()}

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -701,7 +701,12 @@ function WaterbodyInfo({
               <td>
                 <em>Monitoring Site ID:</em>
               </td>
-              <td>{attributes.MonitoringLocationIdentifier.split('-')[1]}</td>
+              <td>
+                {attributes.MonitoringLocationIdentifier.replace(
+                  `${attributes.OrganizationIdentifier}-`,
+                  '',
+                )}
+              </td>
             </tr>
             <tr>
               <td>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3817272

## Main Changes:
* Fixed an issue with only a portion of the monitoring location id being displayed.
  * Note - There was an older [ticket](https://app.breeze.pm/projects/100762/cards/3051919) that was created to split the monitoring location id into two separate parts (organization id and monitoring location id). This is why the MNPCA part of the monitoring location id does not show up in this current version.

## Steps To Test:
1. Navigate to http://localhost:3000/community/070101030702/monitoring
2. Find `HILL (NORTH BASIN)` in the list
3. Verify the monitoring location id is `01-0142-01-204` in the header and content
4. Verify the organization id is `MNPCA` in the header
