### PR TITLE
Bugfix/waterbody report issue

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -505,6 +505,8 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
             'Not enough information': categories.insufficentInfo,
             'Not Applicable': categories.otherObserved,
             Threatened: categories.ofConcern,
+            'Meeting threshold': categories.assessedGood,
+            'Not meeting threshold': categories.pollutants,
           };
 
           // allAssociatedActionIds will contain all parameters' associated action ids


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3818297

## Main Changes:
* Fixed an issue with the waterbody report showing impaired for fish consumption but doesn't show any causes.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/IL_EPA/IL_QLM-01
2. Expand "Fish Consumption"
3. Verify there are causes being displayed below.
