### PR TITLE
Bugfix/tabs in searches

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -480,6 +480,8 @@ function LocationSearch({ route, label }: Props) {
     setSuggestionsVisible(false);
     setCursor(-1);
 
+    newSearchTerm = newSearchTerm.replace(/[\n\r\t]/g, ' ');
+
     if (containsScriptTag(newSearchTerm)) {
       setErrorMessage(invalidSearchError);
       return;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3817370

## Main Changes:
* Fixed an issue with including tab characters in the search. Tab was the main problem, but I could see newlines or carriage returns causing similar issues so I went ahead and replaced those with space. 

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Copy/paste  `-93.5933 47.00295` into notepad and replace the space with a tab
  * Github keeps replacing my tab character with a space
3. Copy/paste the tabbed version of the coordinates into the search box and click go
4. Verify the page loads
5. Click on of the other tabs 
6. Verify the tab correctly loads
