### PR TITLE
feature/update missing geometry label

### DIFF
--- a/app/client/src/components/shared/WaterbodyList/index.js
+++ b/app/client/src/components/shared/WaterbodyList/index.js
@@ -160,7 +160,7 @@ function WaterbodyList({
                   {graphic.limited && (
                     <>
                       <br />
-                      No mapping data available.
+                      [Waterbody not visible on map.]
                     </>
                   )}
                 </>

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -458,7 +458,7 @@ describe('HTTP Intercepts', () => {
     cy.visit('/community');
   });
 
-  it('Check that if GIS responds with empty features array we query and display data about the missing items.', () => {
+  it.only('Check that if GIS responds with empty features array we query and display data about the missing items.', () => {
     cy.intercept(
       'https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1/query',
       {
@@ -478,6 +478,6 @@ describe('HTTP Intercepts', () => {
 
     // Verify text explaining some waterbodies have no spatial data exists
     cy.findByText('Some waterbodies are not visible on the map.');
-    cy.findAllByText('No mapping data available.', { exact: false });
+    cy.findAllByText('[Waterbody not visible on map.]', { exact: false });
   });
 });

--- a/app/cypress/integration/community.spec.js
+++ b/app/cypress/integration/community.spec.js
@@ -458,7 +458,7 @@ describe('HTTP Intercepts', () => {
     cy.visit('/community');
   });
 
-  it.only('Check that if GIS responds with empty features array we query and display data about the missing items.', () => {
+  it('Check that if GIS responds with empty features array we query and display data about the missing items.', () => {
     cy.intercept(
       'https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1/query',
       {


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3777026

## Main Changes:
* Updates label for assessments with no geometry in accordion list.

## Steps To Test:
1. Verify HTTP Intercept cypress test passes.
2. Navigate to http://localhost:3000/community/030502010707/overview and verify the label is updated.