### PR TITLE
Bugfix/legend mismatch

### DIFF
--- a/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
+++ b/app/client/src/components/pages/Community/components/routes/CommunityIntro.js
@@ -4,6 +4,8 @@ import React from 'react';
 import styled from 'styled-components';
 // components
 import type { RouteProps } from 'routes.js';
+// contexts
+import { LocationSearchContext } from 'contexts/locationSearch';
 // styles
 import { fonts } from 'styles/index.js';
 // images
@@ -62,6 +64,14 @@ type Props = {
 
 // --- components ---
 function CommunityIntro({ ...props }: Props) {
+  const { setVisibleLayers } = React.useContext(LocationSearchContext);
+
+  // clear the community page layers when a user navigates to
+  // the community intro page
+  React.useEffect(() => {
+    setVisibleLayers({});
+  }, [setVisibleLayers]);
+
   return (
     <Container>
       <Text>

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -77,7 +77,15 @@ function MapLegend({ view, visibleLayers, additionalLegendInfo }: Props) {
   );
 
   // no legend data
-  if (filteredVisibleLayers.length === 0) return <></>;
+  if (filteredVisibleLayers.length === 0) {
+    return (
+      <Container>
+        <LegendContainer>
+          <UL>There are currently no items to display</UL>
+        </LegendContainer>
+      </Container>
+    );
+  }
 
   return (
     <Container>


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3818934
* https://app.breeze.pm/projects/100762/cards/3817798

## Main Changes:
* Fixed an issue with the legend not syncing up correctly when navigating from the community tabs page to the community intro page and vice versa. 
* Fixed an issue with the waterbodies layer still being available in the layer list when navigating from community tabs page to the community intro page.
* Added code to hide the boundaries layer from the community intro page.
* Added some "no data available..." text to the legend when there are no layers visible.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Verify the legend displays `There are currently no items to display`
3. Search "DC"
4. Verify the legend has the boundaries layer and waterbodies layer
5. Click on the Monitoring tab
6. Verify the legend has the boundaries layer and monitoring layer
7. Click on the community home page
8. Verify the legend displays `There are currently no items to display`
9. Verify the waterbodies layer is not available in the layer list widget
10. Search "DC" again
11. Verify the legend has the boundaries layer and waterbodies layer
12. Verify the waterbodies layer is available in the layer list widget

