### PR TITLE
Bugfix/infinite loading spinner nashville

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -418,10 +418,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         ? getUniqueWaterbodies(allFeatures)
         : [];
 
-      if (uniqueWaterbodies.length === assessmentUnitCount) {
-        setWaterbodyCountMismatch(false);
-        return;
-      }
       if (uniqueWaterbodies.length < assessmentUnitCount) {
         if (waterbodyCountMismatch) return;
         if (assessmentUnitIDs.length === 0) return;
@@ -482,6 +478,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             console.error(err);
             setOrphanFeatures({ features: [], status: 'error' });
           });
+      } else {
+        setWaterbodyCountMismatch(false);
       }
     }
   }, [

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -1207,7 +1207,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         status: 'success',
         data: results,
       });
-      setAssessmentUnitCount(results.items[0].assessmentUnitCount);
+      setAssessmentUnitCount(results.items[0].assessmentUnits.length);
 
       const ids = results.items[0].assessmentUnits.map((item) => {
         return item.assessmentUnitId;


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3832890

## Main Changes:
The root cause of this issue is because the huc12summary service returns 12 in the `assessmentUnitCount` value and 13 assessments in the `assessmentUnits` value. This mismatch causes HMW to query the GIS services for 13 assessments and then expect only 12 assessments to come back from GIS, which then causes an infinite loading spinner to display. 

* Added code to account for more assessments coming from the GIS services than the huc12summary service.
* Updated the `assessmentUnitCount` value to use the length of the `assessmentUnits` array, instead of the `assessmentUnitCount` value. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/nashville,%20tn/overview
2. Verify the page loads
3. Verify the `Waterbodies` count is 13.

