### PR TITLE
bugfix/assessments missing from GIS and ATTAINS

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -430,6 +430,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           (assessment) => assessment.assessmentUnitIdentifier,
         );
 
+        // if no IDs are found in the Assessment Units service, do not call the Assessments service. 
+        // the Assessments service will return ALL assessments in the organization if none are passed in
+        if (!ids || ids.length === 0) {
+          return;
+        }
+
         const url =
           `${services.data.attains.serviceUrl}` +
           `assessments?organizationId=${orgId}&assessmentUnitIdentifier=${ids.join(

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -385,7 +385,7 @@ function WaterbodyInfo({
             )
           : ''}
 
-        {!onWaterbodyReportPage && (
+        {!onWaterbodyReportPage && attributes.organizationid ? (
           <div>
             <a
               rel="noopener noreferrer"
@@ -394,7 +394,7 @@ function WaterbodyInfo({
                 `/waterbody-report/` +
                 `${attributes.organizationid}/` +
                 `${attributes.assessmentunitidentifier}/` +
-                `${attributes.reportingcycle}`
+                `${attributes.reportingcycle || ''}`
               }
             >
               <Icon className="fas fa-file-alt" aria-hidden="true" />
@@ -403,6 +403,8 @@ function WaterbodyInfo({
             &nbsp;&nbsp;
             <NewTabDisclaimer>(opens new browser tab)</NewTabDisclaimer>
           </div>
+        ) : (
+          <p>Unable to find a waterbody report for this waterbody.</p>
         )}
       </>
     );


### PR DESCRIPTION
## Related Issues:
* https://app.breeze.pm/projects/100762/cards/3833336

## Main Changes:
* Adds support for Assessments that are missing from the GIS but are not found in the ATTAINS Assessment Units and/or Assessments services.

## Steps To Test:
1. Test the following locations. These are locations where the Assessments service has no data for the assessment IDs missing from the GIS. But the Assessment Units service does have data including the Org Name, Org Type, Org ID, and Assessment Name.
- http://localhost:3000/community/san%20diego%20ca/overview
- http://localhost:3000/community/fair%20oaks%20ca/overview
- http://localhost:3000/community/27127,%20Winston%20Salem,%20North%20Carolina/overview

2. Verify a GA event is being logged using GA Debug Chrome extension or similar: "The Assessments and GIS services did not return data for the following assessment IDs..."
3. On line 396, add a line 397 with the content `res.items = [];`. This tests how the app handles Assessments being missing from both the Assessments and Assessment Units services. Re-test a location from above. The missing assessments should now have names of "Unknown" and the Waterbody Report links hidden.
4. Replace the line from step 3 with `res.items[0].assessmentUnits = [];`. This is a better test for checking how the code handles an empty response from the Assessment Units service. The missing assessments should now have names of "Unknown" and the Waterbody Report links hidden.
5. Replace the line from steps 3 and 4 with `res.items[0].assessmentUnits.length = 2;`. Navigate to  http://localhost:3000/community/fair%20oaks%20ca/overview. This checks how the code handles a mix of some assessments being in the Assessment Units service and some being missing. You should now see 2 of the missing assessments have their name and Organization info while the other 4 are missing.

## TODO:
- [ ] Add Cypress tests for the following scenarios:
- Where the Assessment Units service data does not include data for 1 or more of the Assessment IDs missing from the GIS services.
- Where the Assessments service does not include data for 1 or more of the Assessment IDs missing from the GIS services.