### PR TITLE
Feature/hmw 14 allow dischargers layer on monitoring tab

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -18,7 +18,10 @@ import { EsriModulesContext } from 'contexts/EsriModules';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
-import { plotStations } from 'components/pages/LocationMap/MapFunctions';
+import {
+  plotFacilities,
+  plotStations,
+} from 'components/pages/LocationMap/MapFunctions';
 import { useWaterbodyOnMap } from 'utils/hooks';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
@@ -97,6 +100,8 @@ function Monitoring() {
     monitoringGroups,
     showAllMonitoring,
     setMonitoringGroups,
+    dischargersLayer,
+    permittedDischargers,
     monitoringStationsLayer,
     setShowAllMonitoring,
     watershed,
@@ -363,6 +368,21 @@ function Monitoring() {
 
     if (Object.keys(visibleLayers).length > 0) setVisibleLayers({});
   }, [monitoringLocations, visibleLayers, setVisibleLayers]);
+
+  // draw the permitted dischargers on the map
+  React.useEffect(() => {
+    // wait until permitted dischargers data is set in context
+    if (
+      permittedDischargers.data['Results'] &&
+      permittedDischargers.data['Results']['Facilities']
+    ) {
+      plotFacilities({
+        Graphic,
+        facilities: permittedDischargers.data['Results']['Facilities'],
+        layer: dischargersLayer,
+      });
+    }
+  }, [permittedDischargers.data, Graphic, dischargersLayer]);
 
   const sortedMonitoringStations = displayedMonitoringStations
     ? displayedMonitoringStations.sort((objA, objB) => {

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -290,6 +290,7 @@ const tabs = [
     upper: monitoringUpper,
     lower: <Monitoring />,
     layers: {
+      dischargersLayer: false,
       monitoringStationsLayer: true,
       waterbodyLayer: false,
     },


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-14

## Main Changes:
* Added the dischargers layer to the layer list on the monitoring tab.

## Steps To Test:
1. Navigate to http://localhost:3000/community/020700100102/monitoring
2. Verify the Dischargers layer is available in the layer list
3. Verify the Dischargers layer works and shows 5 dischargers on the map
4. Click on the Identified Issues tab
5. Verify there is one discharger on the map
6. Click on the Monitoring tab
7. Turn the Dischargers layer back on (via layer list)
8. Verify the Dischargers layer shows 5 dischargers on the map

