### PR TITLE
bugfix/hmw15-crop-geometry-completely-outside-of-huc

### DIFF
--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -1446,7 +1446,7 @@ function useGeometryUtils() {
         subtractor,
       );
 
-      feature.geometry = newGeometry ?? feature.geometry;
+      feature.geometry = newGeometry;
       features.push(feature);
     });
 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-15

## Main Changes:
* HMW-15 Fixed issue with geometry that is completely outside of the huc being displayed on the map.
  * This issue was caused by some null checking logic that I added. I removed this logic so the geometry is set to null when the waterbody is entirely outside of the selected huc.

## Steps To Test:
1. Navigate to http://localhost:3000/community/Washington%20DC,%20DC,%20USA/overview
2. Verify no waterbodies extend outside of the huc. 
3. Mouse over the waterbodies ("POTTF - Upper Potomac River Tidal Fresh" in particular) and verify the entire original waterbody is highlighted on the map

