### PR TITLE
HMW-17 Changed the "No permits found" text to "Not specified".

### DIFF
--- a/app/client/src/components/pages/Actions/index.js
+++ b/app/client/src/components/pages/Actions/index.js
@@ -397,7 +397,7 @@ function Actions({ fullscreen, orgId, actionId, ...props }: Props) {
                           <em>Permits: </em>
 
                           {permits.length === 0 ? (
-                            <>No permits found.</>
+                            <>Not specified.</>
                           ) : (
                             permits.map((permit, index) => (
                               <React.Fragment key={index}>


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-17

## Main Changes:
* Changed the "No permits found" text to "Not specified" on the plan summary page.

## Steps To Test:
1. Navigate to http://localhost:3000/plan-summary/21VASWCB/39463
2. Expand `Cameron Run/Hunting Creek` under Waters Covered
3. Verify the Permits field says `Not specified.`
