### PR TITLE
Configure CircleCI to use large Docker executor resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     working_directory: ~/project/app # directory where steps will run
     docker:
       - image: cimg/node:14.17.5
+    resource_class: large
     environment:
       APP_NAME: mywaterway-dev
       APP_DOMAIN: app.cloud.gov
@@ -95,6 +96,7 @@ jobs:
     working_directory: ~/project/app # directory where steps will run
     docker:
       - image: cimg/node:14.17.5
+    resource_class: large
     environment:
       APP_NAME: mywaterway-stage
       APP_NAME_ATTAINS: mywaterway-attains


### PR DESCRIPTION
## Related Issues:
* None

## Main Changes:
* It seems there's a bug with ESRI's ES modules consuming more memory when built with webpack (see: https://community.esri.com/t5/arcgis-api-for-javascript-questions/arcgis-core-webpack-build-running-out-of-memory/td-p/1045202). The increase in memory usage on create-react-app's build was causing our CircleCI container to run out of memory, so this bumps up the CircleCI container's resource class to "Large", which hopefully has enough memory to build ESRI's ES modules for production.
