### PR TITLE
Feature/hmw 13 protect changes

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -162,26 +162,6 @@ const buttonContainerStyles = css`
   margin-left: 0.5em;
 `;
 
-const tableStyles = css`
-  thead {
-    background-color: #f0f6f9;
-  }
-
-  th:last-of-type,
-  td:last-of-type {
-    text-align: right;
-  }
-`;
-
-const toggleStyles = css`
-  display: flex;
-  align-items: center;
-
-  span {
-    margin-left: 0.5rem;
-  }
-`;
-
 function Protect() {
   const services = useServicesContext();
 
@@ -281,16 +261,6 @@ function Protect() {
 
   allProtectionProjects.sort((objA, objB) => {
     return objA['title'].localeCompare(objB['title']);
-  });
-
-  const [attainsDataDisplayed, setAttainsDataDisplayed] = useState(true);
-  const [grtsDataDisplayed, setGrtsDataDisplayed] = useState(true);
-
-  const filteredProtectionProjects = allProtectionProjects.filter((item) => {
-    const displayedTypes = [];
-    if (attainsDataDisplayed) displayedTypes.push('attains');
-    if (grtsDataDisplayed) displayedTypes.push('grts');
-    return displayedTypes.includes(item.source);
   });
 
   const [healthScoresDisplayed, setHealthScoresDisplayed] = useState(true);
@@ -1242,67 +1212,7 @@ function Protect() {
                                 <em>{watershed}</em> watershed.
                               </p>
 
-                              <table css={tableStyles} className="table">
-                                <thead>
-                                  <tr>
-                                    <th>
-                                      <span>Type</span>
-                                    </th>
-                                    <th>Count</th>
-                                  </tr>
-                                </thead>
-                                <tbody>
-                                  <tr>
-                                    <td>
-                                      <div css={toggleStyles}>
-                                        <Switch
-                                          checked={
-                                            normalizedAttainsProjects.length >
-                                              0 && attainsDataDisplayed
-                                          }
-                                          onChange={(checked) => {
-                                            setAttainsDataDisplayed(
-                                              !attainsDataDisplayed,
-                                            );
-                                          }}
-                                          disabled={
-                                            normalizedAttainsProjects.length ===
-                                            0
-                                          }
-                                          ariaLabel="Attains Plans"
-                                        />
-                                        <span>Attains Plans</span>
-                                      </div>
-                                    </td>
-                                    <td>{normalizedAttainsProjects.length}</td>
-                                  </tr>
-                                  <tr>
-                                    <td>
-                                      <div css={toggleStyles}>
-                                        <Switch
-                                          checked={
-                                            normalizedGrtsProjects.length > 0 &&
-                                            grtsDataDisplayed
-                                          }
-                                          onChange={(checked) => {
-                                            setGrtsDataDisplayed(
-                                              !grtsDataDisplayed,
-                                            );
-                                          }}
-                                          disabled={
-                                            normalizedGrtsProjects.length === 0
-                                          }
-                                          ariaLabel="GRTS Projects"
-                                        />
-                                        <span>GRTS Projects</span>
-                                      </div>
-                                    </td>
-                                    <td>{normalizedGrtsProjects.length}</td>
-                                  </tr>
-                                </tbody>
-                              </table>
-
-                              {filteredProtectionProjects.map((item, index) => {
+                              {allProtectionProjects.map((item, index) => {
                                 const url = getUrlFromMarkup(item.projectLink);
                                 const protectionPlans =
                                   item.watershedPlans &&
@@ -1340,6 +1250,12 @@ function Protect() {
                                     {item.source === 'grts' && (
                                       <table className="table">
                                         <tbody>
+                                          <tr>
+                                            <td>
+                                              <em>Plan Type:</em>
+                                            </td>
+                                            <td>CWA section 303(d)</td>
+                                          </tr>
                                           {item.pollutants && (
                                             <tr>
                                               <td>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -166,7 +166,7 @@ function Protect() {
   const services = useServicesContext();
 
   // draw the waterbody on the map
-  useWaterbodyOnMap('hasprotectionplan');
+  useWaterbodyOnMap('hasprotectionplan', 'overallstatus');
 
   const { setSelectedGraphic } = useContext(MapHighlightContext);
   const {

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -1250,12 +1250,6 @@ function Protect() {
                                     {item.source === 'grts' && (
                                       <table className="table">
                                         <tbody>
-                                          <tr>
-                                            <td>
-                                              <em>Plan Type:</em>
-                                            </td>
-                                            <td>CWA section 303(d)</td>
-                                          </tr>
                                           {item.pollutants && (
                                             <tr>
                                               <td>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -377,7 +377,6 @@ function Protect() {
     : null;
 
   function onWsioToggle(newValue) {
-    // const newValue = !healthScoresDisplayed;
     if (newValue) {
       allWaterbodiesLayer.visible = false;
     } else {

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -376,8 +376,8 @@ function Protect() {
     ? Math.round(wsioData.phwa_health_ndx_st_2016 * 100) / 100
     : null;
 
-  function onWsioToggle(checked, ev, id) {
-    const newValue = !healthScoresDisplayed;
+  function onWsioToggle(newValue) {
+    // const newValue = !healthScoresDisplayed;
     if (newValue) {
       allWaterbodiesLayer.visible = false;
     } else {
@@ -387,7 +387,7 @@ function Protect() {
     setHealthScoresDisplayed(newValue);
     updateVisibleLayers({
       key: 'wsioHealthIndexLayer',
-      newValue: !healthScoresDisplayed,
+      newValue,
     });
   }
 
@@ -506,11 +506,7 @@ function Protect() {
                       return;
                     }
 
-                    setHealthScoresDisplayed(true);
-                    updateVisibleLayers({
-                      key: 'wsioHealthIndexLayer',
-                      newValue: true,
-                    });
+                    onWsioToggle(true);
                   }}
                   title={
                     <label css={labelStyles}>
@@ -523,7 +519,7 @@ function Protect() {
                             healthScoresDisplayed &&
                             wsioHealthIndexData.status === 'success'
                           }
-                          onChange={onWsioToggle}
+                          onChange={() => onWsioToggle(!healthScoresDisplayed)}
                           disabled={wsioHealthIndexData.status === 'failure'}
                           ariaLabel="Watershed Health Scores"
                         />

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -129,6 +129,16 @@ function Restore() {
 
   const waterbodyCount = uniqueWaterbodies && uniqueWaterbodies.length;
 
+  const setRestoreLayerVisibility = (visible) => {
+    setRestoreLayerEnabled(visible);
+
+    // first check if layer exists and is not falsy
+    updateVisibleLayers({
+      key: 'waterbodyLayer',
+      newValue: waterbodyLayer && visible,
+    });
+  };
+
   return (
     <div css={containerStyles}>
       <StyledMetrics>
@@ -159,13 +169,7 @@ function Restore() {
             <Switch
               checked={Boolean(waterbodyCount) && restoreLayerEnabled}
               onChange={(checked) => {
-                setRestoreLayerEnabled(!restoreLayerEnabled);
-
-                // first check if layer exists and is not falsy
-                updateVisibleLayers({
-                  key: 'waterbodyLayer',
-                  newValue: waterbodyLayer && !restoreLayerEnabled,
-                });
+                setRestoreLayerVisibility(!restoreLayerEnabled);
               }}
               disabled={!Boolean(waterbodyCount)}
               ariaLabel="Waterbodies"
@@ -175,7 +179,11 @@ function Restore() {
       </StyledMetrics>
 
       <ContentTabs>
-        <Tabs>
+        <Tabs
+          onChange={(index) => {
+            if (index === 1) setRestoreLayerVisibility(true);
+          }}
+        >
           <TabList>
             <Tab>Clean Water Act Section 319 Projects</Tab>
             <Tab>Restoration Plans</Tab>

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -66,7 +66,7 @@ function Restore() {
     : [];
 
   // draw the waterbody on the map
-  useWaterbodyOnMap('restoreTab');
+  useWaterbodyOnMap('restoreTab', 'overallstatus');
 
   const [restoreLayerEnabled, setRestoreLayerEnabled] = useState(true);
 

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -375,6 +375,15 @@ function Restore() {
                         }
                       >
                         {sortedAttainsPlanData.map((item, index) => {
+                          let planType = item.actionTypeCode;
+                          if (
+                            planType === 'TMDL' ||
+                            planType === '4B Restoration Approach' ||
+                            planType === 'Alternative Restoration Approach'
+                          ) {
+                            planType = 'Restoration Plan: ' + planType;
+                          }
+
                           return (
                             <AccordionItem
                               key={index}
@@ -389,7 +398,7 @@ function Restore() {
                                     <td>
                                       <em>Plan Type:</em>
                                     </td>
-                                    <td>{item.actionTypeCode}</td>
+                                    <td>{planType}</td>
                                   </tr>
                                   <tr>
                                     <td>

--- a/app/client/src/components/pages/Community/config.js
+++ b/app/client/src/components/pages/Community/config.js
@@ -307,7 +307,7 @@ const tabs = [
     upper: restoreUpper,
     lower: <Restore />,
     layers: {
-      waterbodyLayer: true,
+      waterbodyLayer: false,
     },
   },
   {

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -685,11 +685,15 @@ export function getPopupContent({
   else if (attributes && attributes.assessmentunitname) {
     const communityTab = getSelectedCommunityTab();
     const pathname = document.location.pathname;
+    const isAllWaterbodiesLayer =
+      feature.layer?.parent?.id === 'allWaterbodiesLayer';
 
     type = 'Waterbody';
     if (pathname.includes('advanced-search')) type = 'Waterbody State Overview';
-    if (communityTab === 'restore') type = 'Restoration Plans';
-    if (communityTab === 'protect') type = 'Protection Plans';
+    if (!isAllWaterbodiesLayer) {
+      if (communityTab === 'restore') type = 'Restoration Plans';
+      if (communityTab === 'protect') type = 'Protection Plans';
+    }
   }
 
   // discharger

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { css } from 'styled-components/macro';
 import Graphic from '@arcgis/core/Graphic';
 // components
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
@@ -12,28 +11,6 @@ import WaterbodyInfo from 'components/shared/WaterbodyInfo';
 import { colors } from 'styles/index.js';
 // utilities
 import { getSelectedCommunityTab } from 'utils/utils';
-
-const popupContainerStyles = css`
-  margin: 0;
-  overflow-y: auto;
-
-  .esri-feature & p {
-    padding-bottom: 0;
-  }
-`;
-
-const popupContentStyles = css`
-  margin-top: 0.5rem;
-  margin-left: 0.625em;
-`;
-
-const popupTitleStyles = css`
-  margin-bottom: 0;
-  padding: 0.45em 0.625em !important;
-  font-size: 0.8125em;
-  font-weight: bold;
-  background-color: #f0f6f9;
-`;
 
 const waterbodyStatuses = {
   good: { condition: 'good', label: 'Good' },
@@ -789,31 +766,17 @@ export function getPopupContent({
   }
 
   const content = (
-    <div css={popupContainerStyles}>
-      {(type !== 'Action' ||
-        'Change Location' ||
-        'Waterbody State Overview') && (
-        <p css={popupTitleStyles}>
-          {type === 'Demographic Indicators'
-            ? `${type} - ${feature.layer.title}`
-            : type}
-        </p>
-      )}
-
-      <div css={popupContentStyles}>
-        <WaterbodyInfo
-          type={type}
-          feature={feature}
-          fieldName={fieldName}
-          isPopup={true}
-          extraContent={extraContent}
-          getClickedHuc={getClickedHuc}
-          resetData={resetData}
-          services={services}
-          fields={fields}
-        />
-      </div>
-    </div>
+    <WaterbodyInfo
+      type={type}
+      feature={feature}
+      fieldName={fieldName}
+      isPopup={true}
+      extraContent={extraContent}
+      getClickedHuc={getClickedHuc}
+      resetData={resetData}
+      services={services}
+      fields={fields}
+    />
   );
 
   // wrap the content for esri

--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -750,7 +750,7 @@ function AdvancedSearch({ ...props }: Props) {
     setNewDisplayOptions(newDisplayOptions);
   }, [parameterFilter, useFilter]);
 
-  useWaterbodyOnMap(selectedDisplayOption.value, 'unassessed');
+  useWaterbodyOnMap(selectedDisplayOption.value, '', 'unassessed');
 
   // jsx
   const filterControls = (

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -50,6 +50,28 @@ function renderLink(label, link) {
   );
 }
 
+const popupContainerStyles = css`
+  margin: 0;
+  overflow-y: auto;
+
+  .esri-feature & p {
+    padding-bottom: 0;
+  }
+`;
+
+const popupContentStyles = css`
+  margin-top: 0.5rem;
+  margin-left: 0.625em;
+`;
+
+const popupTitleStyles = css`
+  margin-bottom: 0;
+  padding: 0.45em 0.625em !important;
+  font-size: 0.8125em;
+  font-weight: bold;
+  background-color: #f0f6f9;
+`;
+
 const tableStyles = css`
   th:last-of-type,
   td:last-of-type {
@@ -97,7 +119,7 @@ const buttonsContainer = css`
   text-align: center;
 
   button {
-    margin: 0 0.75em 1.5em;
+    margin: 0 0.75em;
     font-size: 0.9375em;
   }
 `;
@@ -105,10 +127,6 @@ const buttonsContainer = css`
 const primaryButtonStyles = css`
   color: ${colors.white()};
   background-color: ${colors.blue()};
-`;
-
-const secondaryButtonStyles = css`
-  background-color: lightgray;
 `;
 
 const imageContainerStyles = css`
@@ -129,7 +147,18 @@ const projectsContainerStyles = css`
   margin-bottom: 0.5rem;
 `;
 
-// --- components ---
+const changeWatershedContainerStyles = css`
+  ${popupContentStyles}
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+
+  p {
+    padding-bottom: 0;
+  }
+`;
+
 type Props = {
   type: string,
   feature: ?Object,
@@ -199,77 +228,6 @@ function WaterbodyInfo({
       </p>
     );
   }
-
-  const renderChangeWatershed = () => {
-    if (!clickedHuc) return null;
-    if (clickedHuc.status === 'no-data') return <p>No Data</p>;
-    if (clickedHuc.status === 'fetching') return <LoadingSpinner />;
-    if (clickedHuc.status === 'failure') return <p>Web service error</p>;
-    if (clickedHuc.status === 'success') {
-      const huc12 = clickedHuc.data.huc12;
-      const watershed = clickedHuc.data.watershed;
-      return (
-        <>
-          {type !== 'Change Location' && (
-            <>
-              <hr />
-              <strong>Change to this location?</strong>
-              <br />
-            </>
-          )}
-
-          {labelValue('WATERSHED', `${watershed} (${huc12})`)}
-
-          <div css={buttonsContainer}>
-            {type === 'Change Location' && (
-              <button
-                css={secondaryButtonStyles}
-                title=""
-                className="btn"
-                onClick={(ev) => {
-                  if (!feature?.view) return;
-                  feature.view.popup.close();
-                }}
-              >
-                No
-              </button>
-            )}
-
-            <button
-              css={primaryButtonStyles}
-              title="Change to this location"
-              className="btn"
-              onClick={(ev) => {
-                // Clear all data before navigating.
-                // The main reason for this is better performance
-                // when doing a huc search by clicking on the state map. The app
-                // will attempt to use all of the loaded state data, then clear it
-                // then load the huc. This could take a long time if the state
-                // has a lot of waterbodies.
-                if (resetData) resetData();
-
-                let baseRoute = `/community/${huc12}`;
-
-                // community will attempt to stay on the same tab
-                // if available, stay on the same tab otherwise go to overview
-                let urlParts = window.location.pathname.split('/');
-                if (urlParts.includes('community') && urlParts.length > 3) {
-                  navigate(`${baseRoute}/${urlParts[3]}`);
-                  return;
-                }
-
-                navigate(`${baseRoute}/overview`);
-              }}
-            >
-              Yes
-            </button>
-          </div>
-        </>
-      );
-    }
-
-    return null;
-  };
 
   const waterbodyPollutionCategories = (label: string) => {
     const pollutionCategories = impairmentFields
@@ -421,15 +379,6 @@ function WaterbodyInfo({
       </>
     );
   };
-
-  // jsx
-  const waterbodyContent = (
-    <>
-      {baseWaterbodyContent()}
-
-      {renderChangeWatershed()}
-    </>
-  );
 
   // jsx
   const waterbodyStateContent = (
@@ -898,8 +847,6 @@ function WaterbodyInfo({
           <br />
           {attributes.CDFIPS} - {attributes.NAME}
         </p>
-
-        {renderChangeWatershed()}
       </>
     );
   };
@@ -913,20 +860,12 @@ function WaterbodyInfo({
           <br />
           {attributes.CNTY_FIPS} - {attributes.NAME}
         </p>
-
-        {renderChangeWatershed()}
       </>
     );
   };
 
   // jsx
-  const tribeContent = (
-    <>
-      {labelValue('Tribe Name', attributes.TRIBE_NAME)}
-
-      {renderChangeWatershed()}
-    </>
-  );
+  const tribeContent = labelValue('Tribe Name', attributes.TRIBE_NAME);
 
   // jsx
   const upstreamWatershedContent = (
@@ -935,8 +874,6 @@ function WaterbodyInfo({
         'Area',
         attributes.areasqkm && `${formatNumber(attributes.areasqkm)} sq. km.`,
       )}
-
-      {renderChangeWatershed()}
     </>
   );
 
@@ -1011,18 +948,13 @@ function WaterbodyInfo({
           </tr>
         </tbody>
       </table>
-
-      {renderChangeWatershed()}
     </>
   );
 
   // jsx
-  const alaskaNativeVillageContent = (
-    <>
-      {labelValue('Village Name', attributes.NAME)}
-
-      {renderChangeWatershed()}
-    </>
+  const alaskaNativeVillageContent = labelValue(
+    'Village Name',
+    attributes.NAME,
   );
 
   // jsx
@@ -1047,7 +979,6 @@ function WaterbodyInfo({
         'Public Access',
         convertDomainCode(fields, 'Access', attributes.Access),
       )}
-      {renderChangeWatershed()}
     </>
   );
 
@@ -1070,13 +1001,8 @@ function WaterbodyInfo({
       {labelValue('Percent Individuals Under 5', attributes.T_UNDR5PCT)}
 
       {labelValue('Percent Individuals Over 64', attributes.T_OVR64PCT)}
-
-      {renderChangeWatershed()}
     </>
   );
-
-  // jsx
-  const changeLocationContent = renderChangeWatershed();
 
   // jsx
   // This content is filled in from the getPopupContent function in MapFunctions.
@@ -1218,35 +1144,111 @@ function WaterbodyInfo({
         </div>
 
         {waterbodyReportLink}
-
-        {renderChangeWatershed()}
       </>
     );
   };
 
   if (!attributes) return null;
 
-  if (type === 'Waterbody') return waterbodyContent;
-  if (type === 'Restoration Plans') return projectContent();
-  if (type === 'Protection Plans') return projectContent();
-  if (type === 'Permitted Discharger') return dischargerContent;
-  if (type === 'Daily Water Conditions') return usgsStreamgagesContent();
-  if (type === 'Sample Location') return monitoringLocationsContent();
-  if (type === 'Nonprofit') return nonprofitContent;
-  if (type === 'Waterbody State Overview') return waterbodyStateContent;
-  if (type === 'Action') return actionContent;
-  if (type === 'County') return countyContent();
-  if (type === 'Congressional District') return congressionalDistrictContent();
-  if (type === 'Tribe') return tribeContent;
-  if (type === 'Upstream Watershed') return upstreamWatershedContent;
-  if (type === 'Wild and Scenic Rivers') return wildScenicRiversContent;
-  if (type === 'State Watershed Health Index') return wsioContent;
-  if (type === 'Alaska Native Village') return alaskaNativeVillageContent;
-  if (type === 'Change Location') return changeLocationContent;
-  if (type === 'Protected Areas') return protectedAreaContent;
-  if (type === 'Demographic Indicators') return ejscreenContent;
+  let content = null;
+  if (type === 'Waterbody') content = baseWaterbodyContent();
+  if (type === 'Restoration Plans') content = projectContent();
+  if (type === 'Protection Plans') content = projectContent();
+  if (type === 'Permitted Discharger') content = dischargerContent;
+  if (type === 'Daily Water Conditions') content = usgsStreamgagesContent();
+  if (type === 'Sample Location') content = monitoringLocationsContent();
+  if (type === 'Nonprofit') content = nonprofitContent;
+  if (type === 'Waterbody State Overview') content = waterbodyStateContent;
+  if (type === 'Action') content = actionContent;
+  if (type === 'County') content = countyContent();
+  if (type === 'Tribe') content = tribeContent;
+  if (type === 'Upstream Watershed') content = upstreamWatershedContent;
+  if (type === 'Wild and Scenic Rivers') content = wildScenicRiversContent;
+  if (type === 'State Watershed Health Index') content = wsioContent;
+  if (type === 'Alaska Native Village') content = alaskaNativeVillageContent;
+  if (type === 'Protected Areas') content = protectedAreaContent;
+  if (type === 'Demographic Indicators') content = ejscreenContent;
+  if (type === 'Congressional District') {
+    content = congressionalDistrictContent();
+  }
 
-  return null;
+  if (isPopup) {
+    const huc12 = clickedHuc?.data?.huc12;
+    const watershed = clickedHuc?.data?.watershed;
+
+    content = (
+      <div css={popupContainerStyles}>
+        {clickedHuc && (
+          <>
+            {clickedHuc.status === 'no-data' && <p>No Data</p>}
+            {clickedHuc.status === 'fetching' && <LoadingSpinner />}
+            {clickedHuc.status === 'failure' && <p>Web service error</p>}
+            {clickedHuc.status === 'success' && (
+              <>
+                {type !== 'Change Location' && (
+                  <p css={popupTitleStyles}>Change to this location?</p>
+                )}
+
+                <div css={changeWatershedContainerStyles}>
+                  <div>
+                    {labelValue('WATERSHED', `${watershed} (${huc12})`)}
+                  </div>
+
+                  <div css={buttonsContainer}>
+                    <button
+                      css={primaryButtonStyles}
+                      title="Change to this location"
+                      className="btn"
+                      onClick={(ev) => {
+                        // Clear all data before navigating.
+                        // The main reason for this is better performance
+                        // when doing a huc search by clicking on the state map. The app
+                        // will attempt to use all of the loaded state data, then clear it
+                        // then load the huc. This could take a long time if the state
+                        // has a lot of waterbodies.
+                        if (resetData) resetData();
+
+                        let baseRoute = `/community/${huc12}`;
+
+                        // community will attempt to stay on the same tab
+                        // if available, stay on the same tab otherwise go to overview
+                        let urlParts = window.location.pathname.split('/');
+                        if (
+                          urlParts.includes('community') &&
+                          urlParts.length > 3
+                        ) {
+                          navigate(`${baseRoute}/${urlParts[3]}`);
+                          return;
+                        }
+
+                        navigate(`${baseRoute}/overview`);
+                      }}
+                    >
+                      Yes
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+
+        {type !== 'Action' &&
+          type !== 'Change Location' &&
+          type !== 'Waterbody State Overview' && (
+            <p css={popupTitleStyles}>
+              {type === 'Demographic Indicators'
+                ? `${type} - ${feature.layer.title}`
+                : type}
+            </p>
+          )}
+
+        <div css={popupContentStyles}>{content}</div>
+      </div>
+    );
+  }
+
+  return content;
 }
 
 export default WaterbodyInfo;

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -124,9 +124,15 @@ const buttonsContainer = css`
   }
 `;
 
-const primaryButtonStyles = css`
+const buttonStyles = css`
   color: ${colors.white()};
   background-color: ${colors.blue()};
+
+  &:hover,
+  &:focus {
+    color: ${colors.white()};
+    background-color: ${colors.navyBlue()};
+  }
 `;
 
 const imageContainerStyles = css`
@@ -148,7 +154,7 @@ const projectsContainerStyles = css`
 `;
 
 const changeWatershedContainerStyles = css`
-  ${popupContentStyles}
+  ${popupContentStyles};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1219,7 +1225,7 @@ function WaterbodyInfo({
 
                   <div css={buttonsContainer}>
                     <button
-                      css={primaryButtonStyles}
+                      css={buttonStyles}
                       title="Change to this location"
                       className="btn"
                       onClick={(ev) => {

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -251,6 +251,28 @@ function WaterbodyInfo({
     );
   };
 
+  const getTypeTitle = () => {
+    const typesToSkip = [
+      'Action',
+      'Change Location',
+      'Waterbody State Overview',
+    ];
+    if (typesToSkip.includes(type)) return null;
+
+    let title = type;
+    if (type === 'Demographic Indicators') {
+      title = `${type} - ${feature.layer.title}`;
+    }
+    if (type === 'Restoration Plans') {
+      title = 'Restoration Plans for this Waterbody';
+    }
+    if (type === 'Protection Plans') {
+      title = 'Protection Plans for this Waterbody';
+    }
+
+    return <p css={popupTitleStyles}>{title}</p>;
+  };
+
   const waterbodyReportLink =
     !onWaterbodyReportPage && attributes.organizationid ? (
       <div>
@@ -1233,15 +1255,7 @@ function WaterbodyInfo({
           </>
         )}
 
-        {type !== 'Action' &&
-          type !== 'Change Location' &&
-          type !== 'Waterbody State Overview' && (
-            <p css={popupTitleStyles}>
-              {type === 'Demographic Indicators'
-                ? `${type} - ${feature.layer.title}`
-                : type}
-            </p>
-          )}
+        {getTypeTitle()}
 
         <div css={popupContentStyles}>{content}</div>
       </div>

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1119,7 +1119,7 @@ function WaterbodyInfo({
                   <table className="table">
                     <thead>
                       <tr>
-                        <th>Plan</th>
+                        <th>Plan (ID)</th>
                         <th>Impairments</th>
                         <th>Type</th>
                         <th>Date</th>
@@ -1137,7 +1137,8 @@ function WaterbodyInfo({
                                   target="_blank"
                                   rel="noopener noreferrer"
                                 >
-                                  {titleCaseWithExceptions(action.name)}
+                                  {titleCaseWithExceptions(action.name)} (
+                                  {action.id})
                                 </a>
                               </td>
                               <td>

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -219,6 +219,7 @@ function useWaterbodyFeaturesState() {
 // draws waterbodies on the map
 function useWaterbodyOnMap(
   attributeName: string = '',
+  allWaterbodiesAttribute: string = '',
   defaultCondition: string = 'hidden',
 ) {
   const {
@@ -234,10 +235,10 @@ function useWaterbodyOnMap(
   } = useContext(LocationSearchContext);
 
   const setRenderer = useCallback(
-    (layer, geometryType, alpha = null) => {
+    (layer, geometryType, attribute, alpha = null) => {
       const renderer = {
         type: 'unique-value',
-        field: attributeName ? attributeName : 'overallstatus',
+        field: attribute ? attribute : 'overallstatus',
         fieldDelimiter: ', ',
         defaultSymbol: createWaterbodySymbol({
           condition: defaultCondition,
@@ -249,7 +250,7 @@ function useWaterbodyOnMap(
       };
 
       // for the restore tab use 3 fields for the unique value renderer
-      if (attributeName === 'restoreTab') {
+      if (attribute === 'restoreTab') {
         renderer.field = 'hasalternativeplan';
         renderer.field2 = 'hastmdl';
         renderer.field3 = 'has4bplan';
@@ -264,29 +265,23 @@ function useWaterbodyOnMap(
       // close popup and clear highlights when the renderer changes
       closePopup({ mapView, setHighlightedGraphic, setSelectedGraphic });
     },
-    [
-      attributeName,
-      defaultCondition,
-      mapView,
-      setHighlightedGraphic,
-      setSelectedGraphic,
-    ],
+    [defaultCondition, mapView, setHighlightedGraphic, setSelectedGraphic],
   );
 
   useEffect(() => {
     if (!pointsLayer || pointsLayer === 'error') return;
-    setRenderer(pointsLayer, 'point');
-  }, [pointsLayer, setRenderer]);
+    setRenderer(pointsLayer, 'point', attributeName);
+  }, [attributeName, pointsLayer, setRenderer]);
 
   useEffect(() => {
     if (!linesLayer || linesLayer === 'error') return;
-    setRenderer(linesLayer, 'polyline');
-  }, [linesLayer, setRenderer]);
+    setRenderer(linesLayer, 'polyline', attributeName);
+  }, [attributeName, linesLayer, setRenderer]);
 
   useEffect(() => {
     if (!areasLayer || areasLayer === 'error') return;
-    setRenderer(areasLayer, 'polygon');
-  }, [areasLayer, setRenderer]);
+    setRenderer(areasLayer, 'polygon', attributeName);
+  }, [attributeName, areasLayer, setRenderer]);
 
   useEffect(() => {
     if (!allWaterbodiesLayer || allWaterbodiesLayer === 'error') return;
@@ -297,10 +292,20 @@ function useWaterbodyOnMap(
       outline: 0.05,
     };
 
-    setRenderer(allWaterbodiesLayer.layers.items[2], 'point', alpha);
-    setRenderer(allWaterbodiesLayer.layers.items[1], 'polyline', alpha);
-    setRenderer(allWaterbodiesLayer.layers.items[0], 'polygon', alpha);
-  }, [allWaterbodiesLayer, setRenderer]);
+    const layers = allWaterbodiesLayer.layers;
+    const attribute = allWaterbodiesAttribute
+      ? allWaterbodiesAttribute
+      : attributeName;
+
+    setRenderer(layers.items[2], 'point', attribute, alpha);
+    setRenderer(layers.items[1], 'polyline', attribute, alpha);
+    setRenderer(layers.items[0], 'polygon', attribute, alpha);
+  }, [
+    allWaterbodiesAttribute,
+    attributeName,
+    allWaterbodiesLayer,
+    setRenderer,
+  ]);
 }
 
 // custom hook that is used to highlight based on context. If the findOthers


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-13
* https://jira.epa.gov/browse/HMW-60

## Main Changes:
* Removed the filters from the `Protection Projects` section of the `Protect` panel.
* Moved the Change Location section of the popup to the top of the popup.
* Updated the restore tab so the waterbodies layer is not visible until the user clicks on the Restoration Plans tab.
* Added "Restoration Plan:" text in front of the `Plan Type` field for "TMDL", "Alternative Restoration Approach", and "4B Restoration Approach" plan types.
* Removed the `Plan Type` field from the GRTS Protection Projects.
* Added the `Plan ID` in parenthesis after the plan name column in the Restore/Protect tab popups.
* Updated the titles for the Restore/Protect tab popups.
* Updated the "Surrounding Waterbodies" layer on the Restore/Protect tabs to be the same as the one on the Overview tab (i.e., Red, Green, and Purple waterbodies). 

## Steps To Test:
1. Navigate to http://localhost:3000/community/040302020902/protect
2. Expand the `Protection Projects` section.
3. Verify the filter toggles are no longer displayed.
4. Navigate to http://localhost:3000/community/dc/overview
5. Click around outside of the HUC and verify the Change Location section is at the top of the popup.
6. To test the 4th bullet go to the following:
  1. 4B: http://localhost:3000/community/070700050504/restore
  2. Alternative: http://localhost:3000/community/020700110207/restore
  4. TMDL: http://localhost:3000/community/020700110207/restore