### PR TITLE
Feature/update state national uses

### DIFF
--- a/app/client/src/components/pages/State/components/SurveyResults.js
+++ b/app/client/src/components/pages/State/components/SurveyResults.js
@@ -18,7 +18,12 @@ import {
   useWaterTypeOptionsContext,
 } from 'contexts/LookupFiles';
 // utilities
-import { formatNumber, titleCase, titleCaseWithExceptions } from 'utils/utils';
+import {
+  formatNumber,
+  normalizeString,
+  titleCase,
+  titleCaseWithExceptions,
+} from 'utils/utils';
 // styles
 import { fonts, colors, reactSelectStyles } from 'styles/index.js';
 // errors
@@ -138,9 +143,9 @@ function SurveyResults({
     // find the stressor/categoryCode combo in stressorMapping if surveyMapping.js
     for (const stressorMap of mapping) {
       if (
-        stressorMap.stressor.toUpperCase() === stressor.toUpperCase() &&
-        stressorMap.surveyCategoryCode.toUpperCase() ===
-          surveyCategoryCode.toUpperCase()
+        normalizeString(stressorMap.stressor) === normalizeString(stressor) &&
+        normalizeString(stressorMap.surveyCategoryCode) ===
+          normalizeString(surveyCategoryCode)
       ) {
         return stressorMap;
       }
@@ -154,8 +159,8 @@ function SurveyResults({
     // find the surveyCategoryCode in categoryCodeMapping if surveyMapping.js
     for (const categoryMap of mapping) {
       if (
-        categoryMap.surveyCategoryCode.toUpperCase() ===
-        surveyCategoryCode.toUpperCase()
+        normalizeString(categoryMap.surveyCategoryCode) ===
+        normalizeString(surveyCategoryCode)
       ) {
         return categoryMap;
       }
@@ -191,7 +196,7 @@ function SurveyResults({
         let categoryMapping = null;
         let stressorMapping = null;
         for (const mapping of surveyMapping.data) {
-          let useSelectedUpper = useSelected.toUpperCase();
+          let useSelectedUpper = normalizeString(useSelected);
           let topicUseSelected = topicUses[useSelectedUpper];
           surveyUseSelected =
             topicUseSelected &&
@@ -210,14 +215,14 @@ function SurveyResults({
             mapSubPop &&
             mapSurveyUse &&
             waterTypeOptions.data[waterType] &&
-            mapOrgId.toUpperCase() === organizationId.toUpperCase() &&
-            mapSubPop.toUpperCase() === selectedSubPop.toUpperCase() &&
+            normalizeString(mapOrgId) === normalizeString(organizationId) &&
+            normalizeString(mapSubPop) === normalizeString(selectedSubPop) &&
             waterTypeOptions.data[waterType].includes(mapWaterGroup) &&
-            (mapSurveyUse.toUpperCase() === useSelected.toUpperCase() ||
+            (normalizeString(mapSurveyUse) === normalizeString(useSelected) ||
               (topicUseSelected &&
                 topicUseSelected.surveyuseCode &&
-                mapSurveyUse.toUpperCase() ===
-                  topicUseSelected.surveyuseCode.toUpperCase()))
+                normalizeString(mapSurveyUse) ===
+                  normalizeString(topicUseSelected.surveyuseCode)))
           ) {
             stressorMapping = mapping['stressorMapping'];
             categoryMapping = mapping['categoryCodeMapping'];
@@ -227,9 +232,9 @@ function SurveyResults({
 
         let confidenceLvlSet = false;
         waterGroup.surveyWaterGroupUseParameters.forEach((param) => {
-          let useSelectedUpper = useSelected.toUpperCase();
+          let useSelectedUpper = normalizeString(useSelected);
           let topicUseSelected = topicUses[useSelectedUpper];
-          let paramSurveyUseCode = param.surveyUseCode.toUpperCase();
+          let paramSurveyUseCode = normalizeString(param.surveyUseCode);
 
           // check the useCode
           if (
@@ -237,7 +242,7 @@ function SurveyResults({
             !topicUseSelected.hasOwnProperty('surveyuseCode') ||
             (paramSurveyUseCode !== useSelectedUpper &&
               paramSurveyUseCode !==
-                topicUseSelected.surveyuseCode.toUpperCase())
+                normalizeString(topicUseSelected.surveyuseCode))
           ) {
             return;
           }

--- a/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
+++ b/app/client/src/components/pages/State/components/tabs/WaterQualityOverview.js
@@ -31,7 +31,7 @@ import {
 } from 'contexts/LookupFiles';
 // utilities
 import { fetchCheck } from 'utils/fetchUtils';
-import { titleCase } from 'utils/utils';
+import { normalizeString, titleCase } from 'utils/utils';
 // images
 import drinkingWaterIcon from 'components/pages/Community/images/drinking-water.png';
 // errors
@@ -675,7 +675,7 @@ function WaterQualityOverview({ ...props }: Props) {
     stateNationalUses.data.forEach((item) => {
       if (item.state === activeState.code && item.category === category) {
         // make sure to use upper case to prevent duplicate uses
-        possibleUses[item.name.toUpperCase()] = item;
+        possibleUses[normalizeString(item.name)] = item;
       }
     });
 
@@ -701,7 +701,7 @@ function WaterQualityOverview({ ...props }: Props) {
             let hasUse = false;
             item.useAttainments.forEach((use) => {
               if (
-                topicUses.hasOwnProperty(use.useName.toUpperCase()) &&
+                topicUses.hasOwnProperty(normalizeString(use.useName)) &&
                 hasUseValues(use)
               ) {
                 hasUse = true;
@@ -731,7 +731,7 @@ function WaterQualityOverview({ ...props }: Props) {
     if (waterTypeData) {
       waterTypeData.forEach((waterTypeItem) => {
         waterTypeItem['useAttainments'].forEach((use) => {
-          let useName = use.useName.toUpperCase();
+          let useName = normalizeString(use.useName);
           if (topicUses.hasOwnProperty(useName) && hasUseValues(use)) {
             if (!addedUses.includes(useName)) {
               addedUses.push(useName);
@@ -749,7 +749,7 @@ function WaterQualityOverview({ ...props }: Props) {
     setUseList(useList);
     setCompleteUseList(completeUseList);
     const displayUses = useList
-      .filter((use) => topicUses.hasOwnProperty(use.useName.toUpperCase()))
+      .filter((use) => topicUses.hasOwnProperty(normalizeString(use.useName)))
       .map((use) => titleCase(use.useName))
       .sort();
     setDisplayUses(displayUses);
@@ -820,7 +820,7 @@ function WaterQualityOverview({ ...props }: Props) {
   React.useEffect(() => {
     if (useList && useList.length > 0) {
       // set to the user's selection if it is availble
-      if (useList.some((e) => e.useName.toUpperCase() === userSelectedUse)) {
+      if (useList.some((e) => normalizeString(e.useName) === userSelectedUse)) {
         setUseSelected(titleCase(userSelectedUse));
       }
 
@@ -839,7 +839,7 @@ function WaterQualityOverview({ ...props }: Props) {
       !useSelected ||
       !surveyData ||
       !waterType ||
-      !topicUses.hasOwnProperty(useSelected.toUpperCase()) ||
+      !topicUses.hasOwnProperty(normalizeString(useSelected)) ||
       waterTypeOptions.status !== 'success'
     ) {
       if (surveyData) setSubPopulationCodes([]);
@@ -859,11 +859,12 @@ function WaterQualityOverview({ ...props }: Props) {
         let useSelectedUpper = '';
         let topicSurveyUseCode = '';
         waterGroup.surveyWaterGroupUseParameters.forEach((param) => {
-          surveyUseCodeUpper = param.surveyUseCode.toUpperCase();
-          useSelectedUpper = useSelected.toUpperCase();
-          topicSurveyUseCode = topicUses[
-            useSelectedUpper
-          ].surveyuseCode.toUpperCase();
+          surveyUseCodeUpper = normalizeString(param.surveyUseCode);
+          useSelectedUpper = normalizeString(useSelected);
+          topicSurveyUseCode = normalizeString(
+            topicUses[useSelectedUpper].surveyuseCode,
+          );
+
           if (
             surveyUseCodeUpper === useSelectedUpper ||
             surveyUseCodeUpper === topicSurveyUseCode
@@ -1028,7 +1029,7 @@ function WaterQualityOverview({ ...props }: Props) {
                             : null
                         }
                         onChange={(ev) =>
-                          setUserSelectedUse(ev.value.toUpperCase())
+                          setUserSelectedUse(normalizeString(ev.value))
                         }
                         isDisabled={displayUses.length <= 0}
                         placeholder={

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -293,6 +293,11 @@ function getSelectedCommunityTab() {
   return selectedCommunityTab.toLowerCase();
 }
 
+// Normalizes string for comparisons.
+function normalizeString(str: string) {
+  return str.trim().toUpperCase();
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -314,4 +319,5 @@ export {
   convertAgencyCode,
   convertDomainCode,
   getSelectedCommunityTab,
+  normalizeString,
 };

--- a/app/server/app/public/data/state/stateNationalUses.json
+++ b/app/server/app/public/data/state/stateNationalUses.json
@@ -3334,7 +3334,7 @@
   {
     "region": 7,
     "state": "MO",
-    "name": "Protection of Warm Water Aquatic Life and Human Health--Fish Consumption ",
+    "name": "Protection of Warm Water Aquatic Life and Human Health--Fish Consumption",
     "category": "Ecological Life",
     "surveyuseCode": "AQUATIC LIFE"
   },


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-58

## Main Changes:
* Removed unnecessary white space from the stateNationalUses.json lookup file
* Added code to trim whitespace when doing these comparisons on the state water quality overview page. Before we were doing toUpperCase on all of these comparisons. I moved this code out to a separate function for easier maintainability, since this logic may need to change in the future..

## Steps To Test:
1. Navigate to http://localhost:3000/state/MO/water-quality-overview
2. Click `Aquatic Life`
3. Select `Rivers and Streams` in the `Water Type` drop down.
4. Verify the survey results pie chart is displayed.
