### PR TITLE
Feature/hmw 73 add counts to accordion

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
+++ b/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
@@ -10,6 +10,7 @@ import WaterbodyList from 'components/shared/WaterbodyList';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+import { summarizeAssessments } from 'utils/utils';
 
 const containerStyles = css`
   padding: 1em;
@@ -22,6 +23,8 @@ function AquaticLife() {
   const waterbodies = useWaterbodyFeatures();
 
   useWaterbodyOnMap('ecological_use');
+
+  const summary = summarizeAssessments(waterbodies, 'ecological_use');
 
   return (
     <div css={containerStyles}>
@@ -36,8 +39,8 @@ function AquaticLife() {
         fieldName="ecological_use"
         title={
           <>
-            Waterbodies assessed for aquatic life in the <em>{watershed}</em>{' '}
-            watershed.
+            <strong>{summary.total.toLocaleString()}</strong> waterbodies
+            assessed for aquatic life in the <em>{watershed}</em> watershed.
           </>
         }
       />

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -22,6 +22,7 @@ import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+import { summarizeAssessments } from 'utils/utils';
 // errors
 import { countyError, withdrawerError } from 'config/errorMessages';
 import { colors } from 'styles';
@@ -243,6 +244,8 @@ function DrinkingWater() {
 
   // draw the waterbody (drinking water sources) on the map
   useWaterbodyOnMap('drinkingwater_use');
+
+  const summary = summarizeAssessments(waterbodies, 'recreation_use');
 
   // draw the drinking water providers (county) on the map
   const [countyGraphic, setCountyGraphic] = useState(null);
@@ -891,7 +894,8 @@ function DrinkingWater() {
                   fieldName="drinkingwater_use"
                   title={
                     <>
-                      Waterbodies assessed as potential future sources of
+                      <strong>{summary.total.toLocaleString()}</strong>{' '}
+                      waterbodies assessed as potential future sources of
                       drinking water in the <em>{watershed}</em> watershed.
                     </>
                   }

--- a/app/client/src/components/pages/Community/components/tabs/EatingFish.js
+++ b/app/client/src/components/pages/Community/components/tabs/EatingFish.js
@@ -13,6 +13,7 @@ import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+import { summarizeAssessments } from 'utils/utils';
 
 const containerStyles = css`
   padding: 1em;
@@ -59,6 +60,8 @@ function EatingFish() {
   const waterbodies = useWaterbodyFeatures();
 
   useWaterbodyOnMap('fishconsumption_use');
+
+  const summary = summarizeAssessments(waterbodies, 'fishconsumption_use');
 
   return (
     <div css={containerStyles}>
@@ -131,7 +134,8 @@ function EatingFish() {
         fieldName="fishconsumption_use"
         title={
           <>
-            Waterbodies assessed for fish and shellfish consumption in the{' '}
+            <strong>{summary.total.toLocaleString()}</strong> waterbodies
+            assessed for fish and shellfish consumption in the{' '}
             <em>{watershed}</em> watershed.
           </>
         }

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -292,8 +292,9 @@ function IdentifiedIssues() {
 
   // check the data quality and log a non-fatal exception to Google Analytics
   // if necessary
-  const [emptyCategoriesWithPercent, setEmptyCategoriesWithPercent] =
-    useState(false);
+  const [emptyCategoriesWithPercent, setEmptyCategoriesWithPercent] = useState(
+    false,
+  );
   const [nullPollutedWaterbodies, setNullPollutedWaterbodies] = useState(false);
   useEffect(() => {
     if (!window.gaTarget || cipSummary.status !== 'success') return;
@@ -494,8 +495,9 @@ function IdentifiedIssues() {
     }
     // one of the parameters is switched
     else {
-      tempParameterToggleObject[checkedSwitch] =
-        !parameterToggleObject[checkedSwitch];
+      tempParameterToggleObject[checkedSwitch] = !parameterToggleObject[
+        checkedSwitch
+      ];
 
       checkIfAllSwitchesToggled(cipSummary.data, tempParameterToggleObject);
     }
@@ -743,11 +745,10 @@ function IdentifiedIssues() {
                                         ),
                                       );
 
-                                      const mappedParameterName =
-                                        getMappedParameterName(
-                                          impairmentFields,
-                                          param['parameterGroupName'],
-                                        );
+                                      const mappedParameterName = getMappedParameterName(
+                                        impairmentFields,
+                                        param['parameterGroupName'],
+                                      );
                                       // if service contains a parameter we have no mapping for
                                       if (!mappedParameterName) return false;
 
@@ -818,7 +819,10 @@ function IdentifiedIssues() {
                       <AccordionList
                         title={
                           <>
-                            Dischargers with significant{' '}
+                            <strong>
+                              {violatingFacilities.length.toLocaleString()}
+                            </strong>{' '}
+                            dischargers with significant{' '}
                             <GlossaryTerm term="Effluent">
                               effluent
                             </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -110,17 +110,24 @@ function Overview() {
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
-  const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
-    useState(false);
+  const [
+    monitoringLocationsDisplayed,
+    setMonitoringLocationsDisplayed,
+  ] = useState(false);
 
-  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
-    useState(false);
+  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] = useState(
+    false,
+  );
 
-  const [monitoringAndSensorsDisplayed, setMonitoringAndSensorsDisplayed] =
-    useState(false);
+  const [
+    monitoringAndSensorsDisplayed,
+    setMonitoringAndSensorsDisplayed,
+  ] = useState(false);
 
-  const [permittedDischargersDisplayed, setPermittedDischargersDisplayed] =
-    useState(false);
+  const [
+    permittedDischargersDisplayed,
+    setPermittedDischargersDisplayed,
+  ] = useState(false);
 
   // Syncs the toggles with the visible layers on the map. Mainly
   // used for when the user toggles layers in full screen mode and then
@@ -439,8 +446,8 @@ function WaterbodiesTab() {
       fieldName={null}
       title={
         <>
-          Overall condition of waterbodies in the <em>{watershed}</em>{' '}
-          watershed.
+          <strong>{waterbodies?.length}</strong> overall condition of
+          waterbodies in the <em>{watershed}</em> watershed.
         </>
       }
     />
@@ -546,8 +553,10 @@ function MonitoringAndSensorsTab({
     plotGages(gages, usgsStreamgagesLayer);
   }, [usgsStreamgages.data, usgsStreamgagesLayer]);
 
-  const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
-    useState([]);
+  const [
+    normalizedMonitoringLocations,
+    setNormalizedMonitoringLocations,
+  ] = useState([]);
 
   // normalize monitoring stations data with USGS streamgages data,
   // and draw them on the map
@@ -590,8 +599,10 @@ function MonitoringAndSensorsTab({
     ...normalizedMonitoringLocations,
   ];
 
-  const [monitoringAndSensorsSortedBy, setMonitoringAndSensorsSortedBy] =
-    useState('locationName');
+  const [
+    monitoringAndSensorsSortedBy,
+    setMonitoringAndSensorsSortedBy,
+  ] = useState('locationName');
 
   const sortedMonitoringAndSensors = [...allMonitoringAndSensors].sort(
     (a, b) => {
@@ -839,8 +850,10 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
     }
   }, [permittedDischargers.data, dischargersLayer]);
 
-  const [permittedDischargersSortedBy, setPermittedDischargersSortedBy] =
-    useState('CWPName');
+  const [
+    permittedDischargersSortedBy,
+    setPermittedDischargersSortedBy,
+  ] = useState('CWPName');
 
   /* prettier-ignore */
   const sortedPermittedDischargers = permittedDischargers.data.Results?.Facilities

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -110,17 +110,24 @@ function Overview() {
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
-  const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
-    useState(false);
+  const [
+    monitoringLocationsDisplayed,
+    setMonitoringLocationsDisplayed,
+  ] = useState(false);
 
-  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
-    useState(false);
+  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] = useState(
+    false,
+  );
 
-  const [monitoringAndSensorsDisplayed, setMonitoringAndSensorsDisplayed] =
-    useState(false);
+  const [
+    monitoringAndSensorsDisplayed,
+    setMonitoringAndSensorsDisplayed,
+  ] = useState(false);
 
-  const [permittedDischargersDisplayed, setPermittedDischargersDisplayed] =
-    useState(false);
+  const [
+    permittedDischargersDisplayed,
+    setPermittedDischargersDisplayed,
+  ] = useState(false);
 
   // Syncs the toggles with the visible layers on the map. Mainly
   // used for when the user toggles layers in full screen mode and then
@@ -547,8 +554,10 @@ function MonitoringAndSensorsTab({
     plotGages(gages, usgsStreamgagesLayer);
   }, [usgsStreamgages.data, usgsStreamgagesLayer]);
 
-  const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
-    useState([]);
+  const [
+    normalizedMonitoringLocations,
+    setNormalizedMonitoringLocations,
+  ] = useState([]);
 
   // normalize monitoring stations data with USGS streamgages data,
   // and draw them on the map
@@ -591,8 +600,10 @@ function MonitoringAndSensorsTab({
     ...normalizedMonitoringLocations,
   ];
 
-  const [monitoringAndSensorsSortedBy, setMonitoringAndSensorsSortedBy] =
-    useState('locationName');
+  const [
+    monitoringAndSensorsSortedBy,
+    setMonitoringAndSensorsSortedBy,
+  ] = useState('locationName');
 
   const sortedMonitoringAndSensors = [...allMonitoringAndSensors].sort(
     (a, b) => {
@@ -840,8 +851,10 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
     }
   }, [permittedDischargers.data, dischargersLayer]);
 
-  const [permittedDischargersSortedBy, setPermittedDischargersSortedBy] =
-    useState('CWPName');
+  const [
+    permittedDischargersSortedBy,
+    setPermittedDischargersSortedBy,
+  ] = useState('CWPName');
 
   /* prettier-ignore */
   const sortedPermittedDischargers = permittedDischargers.data.Results?.Facilities
@@ -877,8 +890,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
           <AccordionList
             title={
               <>
-                <strong>{totalPermittedDischargers}</strong> dischargers in the{' '}
-                <em>{watershed}</em> watershed.
+                <strong>{totalPermittedDischargers}</strong> permitted
+                dischargers in the <em>{watershed}</em> watershed.
               </>
             }
             onSortChange={(sortBy) => {

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -446,8 +446,9 @@ function WaterbodiesTab() {
       fieldName={null}
       title={
         <>
-          <strong>{waterbodies?.length}</strong> overall condition of
-          waterbodies in the <em>{watershed}</em> watershed.
+          Overall condition of{' '}
+          <strong>{waterbodies?.length.toLocaleString()}</strong> waterbodies in
+          the <em>{watershed}</em> watershed.
         </>
       }
     />

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -110,24 +110,17 @@ function Overview() {
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
-  const [
-    monitoringLocationsDisplayed,
-    setMonitoringLocationsDisplayed,
-  ] = useState(false);
+  const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
+    useState(false);
 
-  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] = useState(
-    false,
-  );
+  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
+    useState(false);
 
-  const [
-    monitoringAndSensorsDisplayed,
-    setMonitoringAndSensorsDisplayed,
-  ] = useState(false);
+  const [monitoringAndSensorsDisplayed, setMonitoringAndSensorsDisplayed] =
+    useState(false);
 
-  const [
-    permittedDischargersDisplayed,
-    setPermittedDischargersDisplayed,
-  ] = useState(false);
+  const [permittedDischargersDisplayed, setPermittedDischargersDisplayed] =
+    useState(false);
 
   // Syncs the toggles with the visible layers on the map. Mainly
   // used for when the user toggles layers in full screen mode and then
@@ -554,10 +547,8 @@ function MonitoringAndSensorsTab({
     plotGages(gages, usgsStreamgagesLayer);
   }, [usgsStreamgages.data, usgsStreamgagesLayer]);
 
-  const [
-    normalizedMonitoringLocations,
-    setNormalizedMonitoringLocations,
-  ] = useState([]);
+  const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
+    useState([]);
 
   // normalize monitoring stations data with USGS streamgages data,
   // and draw them on the map
@@ -600,10 +591,8 @@ function MonitoringAndSensorsTab({
     ...normalizedMonitoringLocations,
   ];
 
-  const [
-    monitoringAndSensorsSortedBy,
-    setMonitoringAndSensorsSortedBy,
-  ] = useState('locationName');
+  const [monitoringAndSensorsSortedBy, setMonitoringAndSensorsSortedBy] =
+    useState('locationName');
 
   const sortedMonitoringAndSensors = [...allMonitoringAndSensors].sort(
     (a, b) => {
@@ -851,10 +840,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
     }
   }, [permittedDischargers.data, dischargersLayer]);
 
-  const [
-    permittedDischargersSortedBy,
-    setPermittedDischargersSortedBy,
-  ] = useState('CWPName');
+  const [permittedDischargersSortedBy, setPermittedDischargersSortedBy] =
+    useState('CWPName');
 
   /* prettier-ignore */
   const sortedPermittedDischargers = permittedDischargers.data.Results?.Facilities
@@ -890,7 +877,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
           <AccordionList
             title={
               <>
-                Dischargers in the <em>{watershed}</em> watershed.
+                <strong>{totalPermittedDischargers}</strong> dischargers in the{' '}
+                <em>{watershed}</em> watershed.
               </>
             }
             onSortChange={(sortBy) => {

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -811,118 +811,129 @@ function Protect() {
                       )}
 
                     {wildScenicRiversData.status === 'success' &&
-                      wildScenicRiversData.data.length > 0 &&
-                      wildScenicRiversData.data.map((item) => {
-                        const attributes = item.attributes;
-                        return (
-                          <FeatureItem
-                            key={attributes.GlobalID}
-                            feature={item}
-                            title={
-                              <strong>
-                                River Name: {attributes.WSR_RIVER_SHORTNAME}
-                              </strong>
-                            }
-                          >
-                            <table className="table">
-                              <tbody>
-                                <tr>
-                                  <td>
-                                    <em>Agency</em>
-                                  </td>
-                                  <td>
-                                    {convertAgencyCode(attributes.AGENCY)}
-                                  </td>
-                                </tr>
+                      wildScenicRiversData.data.length > 0 && (
+                        <>
+                          <div css={modifiedInfoBoxStyles}>
+                            <strong>
+                              {wildScenicRiversData.data.length.toLocaleString()}
+                            </strong>{' '}
+                            wild and scenic rivers in the <em>{watershed}</em>{' '}
+                            watershed.
+                          </div>
 
-                                <tr>
-                                  <td>
-                                    <em>Management Plan</em>
-                                  </td>
-                                  <td>
-                                    {attributes.MANAGEMENT_PLAN === 'Y'
-                                      ? 'Yes'
-                                      : 'No'}
-                                  </td>
-                                </tr>
-
-                                <tr>
-                                  <td>
-                                    <em>Managing Entities</em>
-                                  </td>
-                                  <td>
-                                    {convertAgencyCode(
-                                      attributes.MANAGING_ENTITIES,
-                                    )}
-                                  </td>
-                                </tr>
-
-                                <tr>
-                                  <td>
-                                    <em>Public Law Name</em>
-                                  </td>
-                                  <td>{attributes.PUBLIC_LAW_NAME}</td>
-                                </tr>
-
-                                <tr>
-                                  <td>
-                                    <em>State</em>
-                                  </td>
-                                  <td>{attributes.STATE}</td>
-                                </tr>
-
-                                <tr>
-                                  <td>
-                                    <em>River Category</em>
-                                  </td>
-                                  <td>{attributes.RiverCategory}</td>
-                                </tr>
-
-                                <tr>
-                                  <td>
-                                    <em>Website</em>
-                                  </td>
-                                  <td>
-                                    {attributes.WEBLINK ? (
-                                      <>
-                                        <a
-                                          href={attributes.WEBLINK}
-                                          target="_blank"
-                                          rel="noopener noreferrer"
-                                        >
-                                          More information
-                                        </a>{' '}
-                                        <small css={disclaimerStyles}>
-                                          (opens new browser tab)
-                                        </small>
-                                      </>
-                                    ) : (
-                                      'Not available.'
-                                    )}
-                                  </td>
-                                </tr>
-                              </tbody>
-                            </table>
-
-                            <div css={buttonContainerStyles}>
-                              <ViewOnMapButton
-                                layers={[wildScenicRiversLayer]}
+                          {wildScenicRiversData.data.map((item) => {
+                            const attributes = item.attributes;
+                            return (
+                              <FeatureItem
+                                key={attributes.GlobalID}
                                 feature={item}
-                                idField={'GlobalID'}
-                                onClick={() => {
-                                  if (wildScenicRiversDisplayed) return;
+                                title={
+                                  <strong>
+                                    River Name: {attributes.WSR_RIVER_SHORTNAME}
+                                  </strong>
+                                }
+                              >
+                                <table className="table">
+                                  <tbody>
+                                    <tr>
+                                      <td>
+                                        <em>Agency</em>
+                                      </td>
+                                      <td>
+                                        {convertAgencyCode(attributes.AGENCY)}
+                                      </td>
+                                    </tr>
 
-                                  setWildScenicRiversDisplayed(true);
-                                  updateVisibleLayers({
-                                    key: 'wildScenicRiversLayer',
-                                    newValue: true,
-                                  });
-                                }}
-                              />
-                            </div>
-                          </FeatureItem>
-                        );
-                      })}
+                                    <tr>
+                                      <td>
+                                        <em>Management Plan</em>
+                                      </td>
+                                      <td>
+                                        {attributes.MANAGEMENT_PLAN === 'Y'
+                                          ? 'Yes'
+                                          : 'No'}
+                                      </td>
+                                    </tr>
+
+                                    <tr>
+                                      <td>
+                                        <em>Managing Entities</em>
+                                      </td>
+                                      <td>
+                                        {convertAgencyCode(
+                                          attributes.MANAGING_ENTITIES,
+                                        )}
+                                      </td>
+                                    </tr>
+
+                                    <tr>
+                                      <td>
+                                        <em>Public Law Name</em>
+                                      </td>
+                                      <td>{attributes.PUBLIC_LAW_NAME}</td>
+                                    </tr>
+
+                                    <tr>
+                                      <td>
+                                        <em>State</em>
+                                      </td>
+                                      <td>{attributes.STATE}</td>
+                                    </tr>
+
+                                    <tr>
+                                      <td>
+                                        <em>River Category</em>
+                                      </td>
+                                      <td>{attributes.RiverCategory}</td>
+                                    </tr>
+
+                                    <tr>
+                                      <td>
+                                        <em>Website</em>
+                                      </td>
+                                      <td>
+                                        {attributes.WEBLINK ? (
+                                          <>
+                                            <a
+                                              href={attributes.WEBLINK}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                            >
+                                              More information
+                                            </a>{' '}
+                                            <small css={disclaimerStyles}>
+                                              (opens new browser tab)
+                                            </small>
+                                          </>
+                                        ) : (
+                                          'Not available.'
+                                        )}
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+
+                                <div css={buttonContainerStyles}>
+                                  <ViewOnMapButton
+                                    layers={[wildScenicRiversLayer]}
+                                    feature={item}
+                                    idField={'GlobalID'}
+                                    onClick={() => {
+                                      if (wildScenicRiversDisplayed) return;
+
+                                      setWildScenicRiversDisplayed(true);
+                                      updateVisibleLayers({
+                                        key: 'wildScenicRiversLayer',
+                                        newValue: true,
+                                      });
+                                    }}
+                                  />
+                                </div>
+                              </FeatureItem>
+                            );
+                          })}
+                        </>
+                      )}
                   </div>
                 </AccordionItem>
 
@@ -1010,7 +1021,17 @@ function Protect() {
 
                     {protectedAreasData.status === 'success' &&
                       protectedAreasData.data.length > 0 && (
-                        <AccordionList>
+                        <AccordionList
+                          title={
+                            <>
+                              <strong>
+                                {protectedAreasData.data.length.toLocaleString()}
+                              </strong>{' '}
+                              protected areas in the <em>{watershed}</em>{' '}
+                              watershed.
+                            </>
+                          }
+                        >
                           {protectedAreasData.data.map((item) => {
                             const attributes = item.attributes;
                             const fields = protectedAreasData.fields;
@@ -1202,10 +1223,13 @@ function Protect() {
 
                           {allProtectionProjects.length > 0 && (
                             <>
-                              <p>
+                              <div css={modifiedInfoBoxStyles}>
+                                <strong>
+                                  {allProtectionProjects.length.toLocaleString()}
+                                </strong>{' '}
                                 EPA funded protection projects in the{' '}
                                 <em>{watershed}</em> watershed.
-                              </p>
+                              </div>
 
                               {allProtectionProjects.map((item, index) => {
                                 const url = getUrlFromMarkup(item.projectLink);

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -267,9 +267,8 @@ function Protect() {
 
   const [protectedAreasDisplayed, setProtectedAreasDisplayed] = useState(false);
 
-  const [wildScenicRiversDisplayed, setWildScenicRiversDisplayed] = useState(
-    false,
-  );
+  const [wildScenicRiversDisplayed, setWildScenicRiversDisplayed] =
+    useState(false);
 
   const [waterbodyLayerDisplayed, setWaterbodyLayerDisplayed] = useState(false);
 
@@ -439,10 +438,8 @@ function Protect() {
 
   // Initialize the allWaterbodiesLayer visibility. This will be used to reset
   // the allWaterbodiesLayer visibility when the user leaves this tab.
-  const [
-    initialAllWaterbodiesVisibility,
-    setInitialAllWaterbodiesVisibility,
-  ] = useState(false);
+  const [initialAllWaterbodiesVisibility, setInitialAllWaterbodiesVisibility] =
+    useState(false);
   useEffect(() => {
     if (!allWaterbodiesLayer) return;
 
@@ -541,8 +538,10 @@ function Protect() {
                     {wsioHealthIndexData.status === 'success' &&
                       wsioHealthIndexData.data.length === 0 && (
                         <div css={modifiedInfoBoxStyles}>
-                          No Watershed Health Score data available for the{' '}
-                          {watershed} watershed.
+                          <p>
+                            No Watershed Health Score data available for the{' '}
+                            {watershed} watershed.
+                          </p>
                         </div>
                       )}
 
@@ -805,8 +804,10 @@ function Protect() {
                     {wildScenicRiversData.status === 'success' &&
                       wildScenicRiversData.data.length === 0 && (
                         <div css={modifiedInfoBoxStyles}>
-                          No Wild and Scenic River data available in the{' '}
-                          {watershed} watershed.
+                          <p>
+                            No Wild and Scenic River data available in the{' '}
+                            {watershed} watershed.
+                          </p>
                         </div>
                       )}
 
@@ -814,11 +815,13 @@ function Protect() {
                       wildScenicRiversData.data.length > 0 && (
                         <>
                           <div css={modifiedInfoBoxStyles}>
-                            <strong>
-                              {wildScenicRiversData.data.length.toLocaleString()}
-                            </strong>{' '}
-                            wild and scenic rivers in the <em>{watershed}</em>{' '}
-                            watershed.
+                            <p>
+                              <strong>
+                                {wildScenicRiversData.data.length.toLocaleString()}
+                              </strong>{' '}
+                              wild and scenic rivers in the <em>{watershed}</em>{' '}
+                              watershed.
+                            </p>
                           </div>
 
                           {wildScenicRiversData.data.map((item) => {
@@ -1014,8 +1017,10 @@ function Protect() {
                     {protectedAreasData.status === 'success' &&
                       protectedAreasData.data.length === 0 && (
                         <div css={modifiedInfoBoxStyles}>
-                          No Protected Areas Database data available for the{' '}
-                          {watershed} watershed.
+                          <p>
+                            No Protected Areas Database data available for the{' '}
+                            {watershed} watershed.
+                          </p>
                         </div>
                       )}
 
@@ -1216,19 +1221,23 @@ function Protect() {
                         <>
                           {allProtectionProjects.length === 0 && (
                             <div css={modifiedInfoBoxStyles}>
-                              There are no EPA funded protection projects in the{' '}
-                              {watershed} watershed.
+                              <p>
+                                There are no EPA funded protection projects in
+                                the {watershed} watershed.
+                              </p>
                             </div>
                           )}
 
                           {allProtectionProjects.length > 0 && (
                             <>
                               <div css={modifiedInfoBoxStyles}>
-                                <strong>
-                                  {allProtectionProjects.length.toLocaleString()}
-                                </strong>{' '}
-                                EPA funded protection projects in the{' '}
-                                <em>{watershed}</em> watershed.
+                                <p>
+                                  <strong>
+                                    {allProtectionProjects.length.toLocaleString()}
+                                  </strong>{' '}
+                                  EPA funded protection projects in the{' '}
+                                  <em>{watershed}</em> watershed.
+                                </p>
                               </div>
 
                               {allProtectionProjects.map((item, index) => {

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -217,6 +217,9 @@ function Restore() {
                         <AccordionList
                           title={
                             <>
+                              <strong>
+                                {sortedGrtsData.length.toLocaleString()}
+                              </strong>{' '}
                               EPA Funded grants under the{' '}
                               <GlossaryTerm term="Clean Water Act Section 319 Projects">
                                 Clean Water Act Section 319
@@ -375,6 +378,9 @@ function Restore() {
                       <AccordionList
                         title={
                           <>
+                            <strong>
+                              {sortedAttainsPlanData.length.toLocaleString()}
+                            </strong>{' '}
                             <GlossaryTerm term="Restoration plan">
                               Restoration plans
                             </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community/components/tabs/Swimming.js
+++ b/app/client/src/components/pages/Community/components/tabs/Swimming.js
@@ -12,6 +12,7 @@ import { errorBoxStyles } from 'components/shared/MessageBoxes';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+import { summarizeAssessments } from 'utils/utils';
 // errors
 import { huc12SummaryError } from 'config/errorMessages';
 
@@ -34,6 +35,8 @@ function Swimming() {
   // draw the waterbody (swimming) on the map
   useWaterbodyOnMap('recreation_use');
 
+  const summary = summarizeAssessments(waterbodies, 'recreation_use');
+
   return (
     <div css={containerStyles}>
       {cipSummary.status === 'failure' && (
@@ -55,8 +58,9 @@ function Swimming() {
             fieldName="recreation_use"
             title={
               <>
-                Waterbodies assessed for swimming and boating in the{' '}
-                <em>{watershed}</em> watershed.
+                <strong>{summary.total.toLocaleString()}</strong> waterbodies
+                assessed for swimming and boating in the <em>{watershed}</em>{' '}
+                watershed.
               </>
             }
           />

--- a/app/client/src/components/shared/AssessmentSummary/index.js
+++ b/app/client/src/components/shared/AssessmentSummary/index.js
@@ -14,41 +14,8 @@ import {
 import { infoBoxStyles } from 'components/shared/MessageBoxes';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
-
-function summarizeAssessments(waterbodies: Array<Object>, fieldName: string) {
-  const summary = {
-    total: 0,
-    unassessed: 0,
-    'Not Supporting': 0,
-    'Fully Supporting': 0,
-    'Insufficient Information': 0,
-    'Not Assessed': 0,
-    'Not Applicable': 0,
-  };
-
-  // ids will contain unique assessment unit id's of each waterbody,
-  // to ensure we don't count a unique waterbody more than once
-  const ids = [];
-
-  waterbodies.forEach((graphic) => {
-    const field = graphic.attributes[fieldName];
-    const { assessmentunitidentifier: id } = graphic.attributes;
-
-    if (!field || field === 'X') {
-      summary['Not Applicable']++;
-    } else {
-      if (ids.indexOf(id) === -1) {
-        ids.push(id);
-        if (field === 'Not Supporting' || field === 'Fully Supporting') {
-          summary.total++;
-        }
-        summary[field]++;
-      }
-    }
-  });
-
-  return summary;
-}
+// utils
+import { summarizeAssessments } from 'utils/utils';
 
 const modifiedInfoBoxStyles = css`
   ${infoBoxStyles};

--- a/app/client/src/components/shared/AssessmentSummary/index.js
+++ b/app/client/src/components/shared/AssessmentSummary/index.js
@@ -19,11 +19,11 @@ function summarizeAssessments(waterbodies: Array<Object>, fieldName: string) {
   const summary = {
     total: 0,
     unassessed: 0,
-    not_supporting: 0,
-    fully_supporting: 0,
-    insufficient_info: 0,
-    not_assessed: 0,
-    not_applicable: 0,
+    'Not Supporting': 0,
+    'Fully Supporting': 0,
+    'Insufficient Information': 0,
+    'Not Assessed': 0,
+    'Not Applicable': 0,
   };
 
   // ids will contain unique assessment unit id's of each waterbody,
@@ -35,11 +35,11 @@ function summarizeAssessments(waterbodies: Array<Object>, fieldName: string) {
     const { assessmentunitidentifier: id } = graphic.attributes;
 
     if (!field || field === 'X') {
-      summary.not_applicable++;
+      summary['Not Applicable']++;
     } else {
       if (ids.indexOf(id) === -1) {
         ids.push(id);
-        if (field === 'not_supporting' || field === 'fully_supporting') {
+        if (field === 'Not Supporting' || field === 'Fully Supporting') {
           summary.total++;
         }
         summary[field]++;
@@ -92,13 +92,13 @@ function AssessmentSummary({ waterbodies, fieldName, usageName }: Props) {
         <div css={keyMetricsStyles}>
           <div css={keyMetricStyles}>
             <span css={keyMetricNumberStyles}>
-              {summary.fully_supporting.toLocaleString()}
+              {summary['Fully Supporting'].toLocaleString()}
             </span>
             <p css={keyMetricLabelStyles}>Good</p>
           </div>
           <div css={keyMetricStyles}>
             <span css={keyMetricNumberStyles}>
-              {summary.not_supporting.toLocaleString()}
+              {summary['Not Supporting'].toLocaleString()}
             </span>
             <p css={keyMetricLabelStyles}>Impaired</p>
           </div>
@@ -106,8 +106,8 @@ function AssessmentSummary({ waterbodies, fieldName, usageName }: Props) {
             <span css={keyMetricNumberStyles}>
               {(
                 summary.unassessed +
-                summary.insufficient_info +
-                summary.not_assessed
+                summary['Insufficient Information'] +
+                summary['Not Assessed']
               ).toLocaleString()}
             </span>
             <p css={keyMetricLabelStyles}>Condition Unknown</p>

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -298,6 +298,42 @@ function normalizeString(str: string) {
   return str.trim().toUpperCase();
 }
 
+// Summarizes assessment counts by the status of the provided fieldname.
+function summarizeAssessments(waterbodies: Array<Object>, fieldName: string) {
+  const summary = {
+    total: 0,
+    unassessed: 0,
+    'Not Supporting': 0,
+    'Fully Supporting': 0,
+    'Insufficient Information': 0,
+    'Not Assessed': 0,
+    'Not Applicable': 0,
+  };
+
+  // ids will contain unique assessment unit id's of each waterbody,
+  // to ensure we don't count a unique waterbody more than once
+  const ids = [];
+
+  waterbodies?.forEach((graphic) => {
+    const field = graphic.attributes[fieldName];
+    const { assessmentunitidentifier: id } = graphic.attributes;
+
+    if (!field || field === 'X') {
+      summary['Not Applicable']++;
+    } else {
+      if (ids.indexOf(id) === -1) {
+        ids.push(id);
+        if (field === 'Not Supporting' || field === 'Fully Supporting') {
+          summary.total++;
+        }
+        summary[field]++;
+      }
+    }
+  });
+
+  return summary;
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -320,4 +356,5 @@ export {
   convertDomainCode,
   getSelectedCommunityTab,
   normalizeString,
+  summarizeAssessments,
 };


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-73

## Main Changes:
* Fixed the counts on the Swimming, Eating Fish, Aquatic Life, and Drinking Water tabs.
  * This was caused by c3e2ff6. I ended up reverting part of that commit, since the `field`  variable comes from the web service.
* Added counts to the accordion headers to make the app more consistent.
* Added counts to the sub accordion content on the Protect tab.

## Steps To Test:
1. Navigate to http://localhost:3000/community/040302020702/protect
2. Expand each accordion item, except for the "Watershed Health Scores" item
3. Verify each one has a count, except for the "Watrershed Health Scores"
4. Go through each main tab (i.e. Overview, Swimming, etc.)
5. Verify the accordion headers have counts in them now.

