### PR TITLE
Feature/hmw 13 final restoreprotect changes

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -16,6 +16,7 @@ import Switch from 'components/shared/Switch';
 import { gradientIcon } from 'components/pages/LocationMap/MapFunctions';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import ViewOnMapButton from 'components/shared/ViewOnMapButton';
+import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { CommunityTabsContext } from 'contexts/CommunityTabs';
@@ -1339,7 +1340,11 @@ function Protect() {
                                             <td>
                                               <em>Plan Type:</em>
                                             </td>
-                                            <td>{item.actionTypeCode}</td>
+                                            <td>
+                                              <GlossaryTerm term="Protection Approach">
+                                                Protection Approach
+                                              </GlossaryTerm>
+                                            </td>
                                           </tr>
                                           <tr>
                                             <td>

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -247,7 +247,7 @@ function Protect() {
         watershedPlans: '',
         completionDate: plan.completionDate,
         actionTypeCode: plan.actionTypeCode,
-        organizationId: plan.organizationIdentifier,
+        organizationId: plan.organizationId,
       });
     });
 

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -360,8 +360,15 @@ function Restore() {
                       >
                         {sortedAttainsPlanData.map((item, index) => {
                           let planType = item.actionTypeCode;
+                          if (planType === 'TMDL') {
+                            planType = (
+                              <>
+                                Restoration Plan:{' '}
+                                <GlossaryTerm term="TMDL">TMDL</GlossaryTerm>
+                              </>
+                            );
+                          }
                           if (
-                            planType === 'TMDL' ||
                             planType === '4B Restoration Approach' ||
                             planType === 'Alternative Restoration Approach'
                           ) {

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -9,7 +9,6 @@ import { ContentTabs } from 'components/shared/ContentTabs';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
-import Switch from 'components/shared/Switch';
 import TabErrorBoundary from 'components/shared/ErrorBoundary/TabErrorBoundary';
 // styled components
 import {
@@ -22,8 +21,7 @@ import {
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { getUrlFromMarkup, getTitleFromMarkup } from 'components/shared/Regex';
-import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
-import { getUniqueWaterbodies } from 'components/pages/LocationMap/MapFunctions';
+import { useWaterbodyOnMap } from 'utils/hooks';
 // errors
 import {
   restoreNonpointSourceError,
@@ -43,10 +41,6 @@ const disclaimerStyles = css`
   display: inline-block;
 `;
 
-const switchContainerStyles = css`
-  margin-top: 0.5em;
-`;
-
 function Restore() {
   const {
     attainsPlans,
@@ -57,13 +51,6 @@ function Restore() {
     watershed,
     waterbodyLayer,
   } = useContext(LocationSearchContext);
-
-  // set the waterbody features
-  const waterbodies = useWaterbodyFeatures();
-
-  const uniqueWaterbodies = waterbodies
-    ? getUniqueWaterbodies(waterbodies)
-    : [];
 
   // draw the waterbody on the map
   useWaterbodyOnMap('restoreTab', 'overallstatus');
@@ -127,8 +114,6 @@ function Restore() {
           .sort((a, b) => a.actionName.localeCompare(b.actionName))
       : [];
 
-  const waterbodyCount = uniqueWaterbodies && uniqueWaterbodies.length;
-
   const setRestoreLayerVisibility = (visible) => {
     setRestoreLayerEnabled(visible);
 
@@ -165,16 +150,6 @@ function Restore() {
             </StyledNumber>
           )}
           <StyledLabel>Plans</StyledLabel>
-          <div css={switchContainerStyles}>
-            <Switch
-              checked={Boolean(waterbodyCount) && restoreLayerEnabled}
-              onChange={(checked) => {
-                setRestoreLayerVisibility(!restoreLayerEnabled);
-              }}
-              disabled={!Boolean(waterbodyCount)}
-              ariaLabel="Waterbodies"
-            />
-          </div>
         </StyledMetric>
       </StyledMetrics>
 
@@ -182,6 +157,7 @@ function Restore() {
         <Tabs
           onChange={(index) => {
             if (index === 1) setRestoreLayerVisibility(true);
+            else setRestoreLayerVisibility(false);
           }}
         >
           <TabList>

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -327,6 +327,12 @@ function Restore() {
 
             <TabPanel>
               <>
+                <p>
+                  View all restoration plans for the selected watershed in the
+                  list below. Find out which plans are in place to restore each
+                  waterbody shown on the map.
+                </p>
+
                 {attainsPlans.status === 'fetching' && <LoadingSpinner />}
 
                 {attainsPlans.status === 'failure' && (
@@ -368,11 +374,25 @@ function Restore() {
                               </>
                             );
                           }
-                          if (
-                            planType === '4B Restoration Approach' ||
-                            planType === 'Alternative Restoration Approach'
-                          ) {
-                            planType = 'Restoration Plan: ' + planType;
+                          if (planType === '4B Restoration Approach') {
+                            planType = (
+                              <>
+                                Restoration Plan:{' '}
+                                <GlossaryTerm term="4B Restoration Approach">
+                                  4B Restoration Approach
+                                </GlossaryTerm>
+                              </>
+                            );
+                          }
+                          if (planType === 'Alternative Restoration Approach') {
+                            planType = (
+                              <>
+                                Restoration Plan:{' '}
+                                <GlossaryTerm term="Alternative Restoration Approach">
+                                  Alternative Restoration Approach
+                                </GlossaryTerm>
+                              </>
+                            );
                           }
 
                           return (

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -154,12 +154,7 @@ function Restore() {
       </StyledMetrics>
 
       <ContentTabs>
-        <Tabs
-          onChange={(index) => {
-            if (index === 1) setRestoreLayerVisibility(true);
-            else setRestoreLayerVisibility(false);
-          }}
-        >
+        <Tabs onChange={(index) => setRestoreLayerVisibility(index === 1)}>
           <TabList>
             <Tab>Clean Water Act Section 319 Projects</Tab>
             <Tab>Restoration Plans</Tab>


### PR DESCRIPTION
Waiting for glossary items to be added by EPA.

## Related Issues:
* https://jira.epa.gov/browse/HMW-13

## Main Changes:
* Update the restore panel so the waterbodies layer is only visible if the user is on the "Restoration Plans" tab.
* Linked the "TMDL", "4B Restoration Approach", "Alternative Restoration Approach", and "Protection Approach" plan types to the glossary.
* Fixed issue of the "Open plan summary" links not working on the "Protection Projects" item of the "Protect" tab. The problem was `undefined` was being passed in for the organization id parameter.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/restore
2. Turn off the surrounding waterbodies layer
3. Verify the waterbodies layer is not visible
4. Click on the "Restoration Plans" tab
5. Verify the waterbodies layer is visible
6. Click on the "Clean Water Act Section 319 Projects" tab
7. Verify the waterbodies layer is not visible
8. Navigate to http://localhost:3000/community/040302020801/protect
9. Expand "Protection Projects"
10. Click "Open Plan Summary"
11. Verify the "Plan Summary" page opens and loads data
12. To test the 2nd bullet go to the following:
    1. 4B: http://localhost:3000/community/070700050504/restore
    2. Alternative: http://localhost:3000/community/020700110207/restore
    3. TMDL: http://localhost:3000/community/020700110207/restore
    4. Protection: http://localhost:3000/community/040302020807/protect

## TODO:
- [x] Link "4B Restoration Approach" to the glossary
- [x] Link "Alternative Restoration Approach" to the glossary
