### PR TITLE
Feature/fetch usgs daily precipitation data

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -110,24 +110,17 @@ function Overview() {
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
-  const [
-    monitoringLocationsDisplayed,
-    setMonitoringLocationsDisplayed,
-  ] = useState(false);
+  const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
+    useState(false);
 
-  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] = useState(
-    false,
-  );
+  const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
+    useState(false);
 
-  const [
-    monitoringAndSensorsDisplayed,
-    setMonitoringAndSensorsDisplayed,
-  ] = useState(false);
+  const [monitoringAndSensorsDisplayed, setMonitoringAndSensorsDisplayed] =
+    useState(false);
 
-  const [
-    permittedDischargersDisplayed,
-    setPermittedDischargersDisplayed,
-  ] = useState(false);
+  const [permittedDischargersDisplayed, setPermittedDischargersDisplayed] =
+    useState(false);
 
   // Syncs the toggles with the visible layers on the map. Mainly
   // used for when the user toggles layers in full screen mode and then
@@ -562,7 +555,8 @@ function MonitoringAndSensorsTab({
   }, [usgsStreamgages.data, usgsStreamgagesLayer]);
 
   // add precipitation data (fetched from usgsDailyValues web service) to each
-  // streamgage if it exists for that particular location
+  // streamgage if it exists for that particular location and replot the
+  // streamgages on the map
   useEffect(() => {
     if (!usgsDailyPrecipitation.data.value) return;
     if (normalizedUsgsStreamgages.length === 0) return;
@@ -592,12 +586,12 @@ function MonitoringAndSensorsTab({
         });
       }
     });
-  }, [usgsDailyPrecipitation, normalizedUsgsStreamgages]);
 
-  const [
-    normalizedMonitoringLocations,
-    setNormalizedMonitoringLocations,
-  ] = useState([]);
+    plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
+  }, [usgsDailyPrecipitation, normalizedUsgsStreamgages, usgsStreamgagesLayer]);
+
+  const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
+    useState([]);
 
   // normalize monitoring stations data with USGS streamgages data,
   // and draw them on the map
@@ -640,10 +634,8 @@ function MonitoringAndSensorsTab({
     ...normalizedMonitoringLocations,
   ];
 
-  const [
-    monitoringAndSensorsSortedBy,
-    setMonitoringAndSensorsSortedBy,
-  ] = useState('locationName');
+  const [monitoringAndSensorsSortedBy, setMonitoringAndSensorsSortedBy] =
+    useState('locationName');
 
   const sortedMonitoringAndSensors = [...allMonitoringAndSensors].sort(
     (a, b) => {
@@ -901,10 +893,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
     }
   }, [permittedDischargers.data, dischargersLayer]);
 
-  const [
-    permittedDischargersSortedBy,
-    setPermittedDischargersSortedBy,
-  ] = useState('CWPName');
+  const [permittedDischargersSortedBy, setPermittedDischargersSortedBy] =
+    useState('CWPName');
 
   /* prettier-ignore */
   const sortedPermittedDischargers = permittedDischargers.data.Results?.Facilities

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -584,7 +584,7 @@ function MonitoringAndSensorsTab({
           parameterCategory: 'primary',
           parameterOrder: 5,
           parameterName: 'Total Daily Rainfall',
-          parameterCode: 'USGS Daily Value',
+          parameterCode: '00045 (USGS Daily Value)',
           measurement: observation.value,
           datetime: new Date(observation.dateTime).toLocaleDateString(),
           unitAbbr: 'in',

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -136,6 +136,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     mapView,
     setMonitoringLocations,
     setUsgsStreamgages,
+    setUsgsDailyPrecipitation,
     // setNonprofits,
     setPermittedDischargers,
     setWaterbodyLayer,
@@ -1124,6 +1125,24 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     [services, setUsgsStreamgages],
   );
 
+  const queryUsgsDailyValuesService = useCallback(
+    (huc12Param) => {
+      const url =
+        `${services.data.usgsDailyValues}?format=json&siteStatus=active` +
+        `&parameterCd=00045&statCd=00006&huc=${huc12Param.substring(0, 8)}`;
+
+      fetchCheck(url)
+        .then((res) => {
+          setUsgsDailyPrecipitation({ status: 'success', data: res });
+        })
+        .catch((err) => {
+          console.error(err);
+          setUsgsDailyPrecipitation({ status: 'failure', data: {} });
+        });
+    },
+    [services, setUsgsDailyPrecipitation],
+  );
+
   const queryPermittedDischargersService = useCallback(
     (huc12Param) => {
       fetchCheck(services.data.echoNPDES.metadata)
@@ -1517,6 +1536,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           processBoundariesData(response);
           queryMonitoringStationService(huc12Result);
           queryUsgsStreamgageService(huc12Result);
+          queryUsgsDailyValuesService(huc12Result);
           queryPermittedDischargersService(huc12Result);
           queryGrtsHuc12(huc12Result);
           queryAttainsPlans(huc12Result);
@@ -1542,6 +1562,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       queryGrtsHuc12,
       queryMonitoringStationService,
       queryUsgsStreamgageService,
+      queryUsgsDailyValuesService,
       queryPermittedDischargersService,
       setHuc12,
       setNoDataAvailable,

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1353,8 +1353,8 @@ function UsgsStreamgageParameter({ data, index }) {
         ) : (
           data.parameterName
         )}
-        &nbsp;&nbsp;
-        <small css={additionalTextStyles}>({data.parameterCode})</small>
+        <br />
+        <small css={additionalTextStyles}>{data.parameterCode}</small>
       </td>
       <td>
         {data.multiple ? (

--- a/app/client/src/config/usgsStaParameters.js
+++ b/app/client/src/config/usgsStaParameters.js
@@ -66,9 +66,9 @@ export const usgsStaParameters = [
   {
     staParameterCode: '00045',
     staDescription: 'Precipitation',
-    hmwCategory: 'exclude', // NOTE: was 'primary' but precipitation data is being pulled from a separate web service
+    hmwCategory: 'exclude', // NOTE: was 'primary' but precipitation data is being pulled from usgsDailyValues web service
     hmwOrder: 5,
-    hmwName: 'Rainfall',
+    hmwName: 'Total Daily Rainfall',
     hmwUnits: 'in',
   },
   {
@@ -164,7 +164,7 @@ export const usgsStaParameters = [
     staDescription: 'Precipitation, defined period',
     hmwCategory: 'exclude',
     hmwOrder: null,
-    hmwName: 'Rainfall',
+    hmwName: 'Total Daily Rainfall',
     hmwUnits: 'in',
   },
   {
@@ -540,7 +540,7 @@ export const usgsStaParameters = [
     staDescription: 'Precipitation, cumul',
     hmwCategory: 'exclude',
     hmwOrder: null,
-    hmwName: 'Rainfall',
+    hmwName: 'Total Daily Rainfall',
     hmwUnits: 'in',
   },
   {
@@ -548,7 +548,7 @@ export const usgsStaParameters = [
     staDescription: 'Precipitation, cumul',
     hmwCategory: 'exclude',
     hmwOrder: null,
-    hmwName: 'Rainfall',
+    hmwName: 'Total Daily Rainfall',
     hmwUnits: 'mm',
   },
   {
@@ -756,7 +756,7 @@ export const usgsStaParameters = [
     staDescription: 'Precipitation',
     hmwCategory: 'exclude',
     hmwOrder: null,
-    hmwName: 'Rainfall',
+    hmwName: 'Total Daily Rainfall',
     hmwUnits: 'mm',
   },
   {

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -76,6 +76,53 @@ type UsgsStreamgageData = {
   }[],
 };
 
+type UsgsDailyPrecipitationData = {
+  declaredType: 'org.cuahsi.waterml.TimeSeriesResponseType',
+  globalScope: true,
+  name: 'ns1:timeSeriesResponseType',
+  nil: false,
+  scope: 'javax.xml.bind.JAXBElement$GlobalScope',
+  typeSubstituted: false,
+  value: {
+    queryInfo: Object,
+    timeSeries: {
+      name: string,
+      sourceInfo: {
+        siteName: string,
+        siteCode: [
+          {
+            agencyCode: string,
+            network: string,
+            value: string, // number
+          },
+        ],
+        timeZoneInfo: Object,
+        geoLocation: Object,
+        note: [],
+        siteType: [],
+        siteProperty: Object[],
+      },
+      values: {
+        censorCode: [],
+        method: [Object],
+        offset: [],
+        qualifier: [Object],
+        qualityControlLevel: [],
+        sample: [],
+        source: [],
+        value: [
+          {
+            dateTime: string, // ISO format datetime
+            qualifiers: ['P'],
+            value: string, // number
+          },
+        ],
+      }[],
+      variable: Object,
+    }[],
+  },
+};
+
 type PermittedDischargersData = {
   Results: {
     BadSystemIDs: null,
@@ -193,6 +240,7 @@ type State = {
   assessmentUnitId: string,
   monitoringLocations: { status: Status, data: MonitoringLocationsData },
   usgsStreamgages: { status: Status, data: UsgsStreamgageData },
+  usgsDailyPrecipitation: { status: Status, data: UsgsDailyPrecipitationData },
   permittedDischargers: { status: Status, data: PermittedDischargersData },
   grts: Object,
   attainsPlans: Object,
@@ -277,6 +325,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     assessmentUnitId: '',
     monitoringLocations: { status: 'fetching', data: {} },
     usgsStreamgages: { status: 'fetching', data: {} },
+    usgsDailyPrecipitation: { status: 'fetching', data: {} },
     permittedDischargers: { status: 'fetching', data: {} },
     grts: { status: 'fetching', data: [] },
     attainsPlans: { status: 'fetching', data: [] },
@@ -355,6 +404,12 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       data: UsgsStreamgageData,
     }) => {
       this.setState({ usgsStreamgages });
+    },
+    setUsgsDailyPrecipitation: (usgsDailyPrecipitation: {
+      status: Status,
+      data: UsgsDailyPrecipitationData,
+    }) => {
+      this.setState({ usgsDailyPrecipitation });
     },
     setPermittedDischargers: (permittedDischargers: {
       status: Status,
@@ -756,6 +811,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
         hucBoundaries: '',
         monitoringLocations: { status: 'fetching', data: {} },
         usgsStreamgages: { status: 'fetching', data: {} },
+        usgsDailyPrecipitation: { status: 'fetching', data: {} },
         permittedDischargers: { status: 'fetching', data: {} },
         nonprofits: { status: 'fetching', data: [] },
         grts: { status: 'fetching', data: [] },
@@ -794,6 +850,7 @@ export class LocationSearchProvider extends React.Component<Props, State> {
           countyBoundaries: '',
           monitoringLocations: { status: 'success', data: {} },
           usgsStreamgages: { status: 'success', data: {} },
+          usgsDailyPrecipitation: { status: 'fetching', data: {} },
           permittedDischargers: { status: 'success', data: {} },
           nonprofits: { status: 'success', data: [] },
           grts: { status: 'success', data: [] },

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -23,6 +23,7 @@
     "monitoringLocationDetails": "https://www.waterqualitydata.us/provider/"
   },
   "usgsSensorThingsAPI": "https://labs.waterdata.usgs.gov/sta/v1.1/Things",
+  "usgsDailyValues": "https://waterservices.usgs.gov/nwis/dv/",
   "echoNPDES": {
     "getFacilities": "https://echodata.epa.gov/echo/cwa_rest_services.get_facilities",
     "metadata": "https://echodata.epa.gov/echo/cwa_rest_services.metadata"
@@ -183,6 +184,11 @@
       "urlLookup": "usgsSensorThingsAPI",
       "wildcardUrl": "{urlLookup}*",
       "name": "usgs – SensorThings API"
+    },
+    {
+      "urlLookup": "usgsDailyValues",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "usgs – daily values"
     },
     {
       "urlLookup": "glossaryURL",

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -23,6 +23,7 @@
     "monitoringLocationDetails": "https://www.waterqualitydata.us/provider/"
   },
   "usgsSensorThingsAPI": "https://labs.waterdata.usgs.gov/sta/v1.1/Things",
+  "usgsDailyValues": "https://waterservices.usgs.gov/nwis/dv/",
   "echoNPDES": {
     "getFacilities": "https://echodata.epa.gov/echo/cwa_rest_services.get_facilities",
     "metadata": "https://echodata.epa.gov/echo/cwa_rest_services.metadata"
@@ -183,6 +184,11 @@
       "urlLookup": "usgsSensorThingsAPI",
       "wildcardUrl": "{urlLookup}*",
       "name": "usgs – SensorThings API"
+    },
+    {
+      "urlLookup": "usgsDailyValues",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "usgs – daily values"
     },
     {
       "urlLookup": "glossaryURL",


### PR DESCRIPTION
## Related Issues:
* [HMW-82](https://jira.epa.gov/browse/HMW-82) - Created a new ticket for this

## Main Changes:
* Fetches data from USGS Daily Values web service (from the larger HUC8) and merges it with any streamgages that exist within the watershed

## Steps To Test:
1. Navigate to http://localhost:3000/community/010900010702/overview
2. Switch to the "Monitoring & Sensors" subtab, and toggle on the "Current Water Conditions" switch
3. Expand the first streamgage ("CAMBRIDGE RES., MET. STATION, NEAR LEXINGTON, MA") and verify you see a value for the "Total Daily Rainfall" parameter. The note below is a slight indication that it's coming from the USGS Daily Value service – we don't usually distinguish this to the end user, but since the others are coming from the USGS STA web service, I figured it'd be worth indicating this one is slightly different...we can always remove that distinction if EPA wants

## TODO:
- [ ] Maybe verify with EPA that the data from the USGS Daily Values web service is consistent with what's displayed on the USGS page for the streamgage (I don't see why it wouldn't be)
- [ ] I left out any error reporting for if this web service goes down...only because it's only purpose is to add data for a single parameter (precipitation) to existing streamgages shown in the app. I don't know that we _need_ to report errors with this web service to the end user, but it's something worth discussing with EPA.