### PR TITLE
Bugfix/hmw36 drinking water providers issue

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -384,15 +384,11 @@ function DrinkingWater() {
   let bothCount = 0;
   if (drinkingWater.data) {
     // handle providers separately
-    const allProviders = drinkingWater.data.filter(
-      (system) => !system.hasOwnProperty('huc12') || !system.huc12,
-    );
+    const allProviders = drinkingWater.data.filter((system) => !system.huc12);
     allProviders.forEach((provider) => providers.push(provider));
 
     // find all withdrawers
-    const allWithdrawers = drinkingWater.data.filter(
-      (system) => system.hasOwnProperty('huc12') && system.huc12,
-    );
+    const allWithdrawers = drinkingWater.data.filter((system) => system.huc12);
 
     // find duplicate withdrawers based on pwsid
     const lookup = allWithdrawers.reduce((a, e) => {

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -390,8 +390,8 @@ function DrinkingWater() {
     allProviders.forEach((provider) => providers.push(provider));
 
     // find all withdrawers
-    const allWithdrawers = drinkingWater.data.filter((system) =>
-      system.hasOwnProperty('huc12'),
+    const allWithdrawers = drinkingWater.data.filter(
+      (system) => system.hasOwnProperty('huc12') && system.huc12,
     );
 
     // find duplicate withdrawers based on pwsid

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -385,7 +385,7 @@ function DrinkingWater() {
   if (drinkingWater.data) {
     // handle providers separately
     const allProviders = drinkingWater.data.filter(
-      (system) => !system.hasOwnProperty('huc12'),
+      (system) => !system.hasOwnProperty('huc12') || !system.huc12,
     );
     allProviders.forEach((provider) => providers.push(provider));
 


### PR DESCRIPTION
## Related Issues:
* [HMW-36](https://jira.epa.gov/browse/HMW-36) - This PR addresses comment on this ticket.
* [HMW-66](https://jira.epa.gov/browse/HMW-66) - This ticket is what actually caused this issue. The updated DWMAPS service call now always returns the huc12 property. Before we were checking whether or not the huc12 property exists.

## Main Changes:
* Fixed an issue with Drinking Water providers not showing up.

## Steps To Test:
1. Navigate to http://localhost:3000/community/Campbell%20County,%20VA,%20USA/drinking-water
2. Click on the Drinking Water tab
3. Verify there are 26 drinking water providers
4. Click on the `Who withdraws water for drinking here?` tab
5. Verify there are 3 drinking water withdrawers
6. Compare other locations with production, they should match 

