### PR TITLE
Feature/hmw 77 fix grammer issues

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
+++ b/app/client/src/components/pages/Community/components/tabs/AquaticLife.js
@@ -39,8 +39,9 @@ function AquaticLife() {
         fieldName="ecological_use"
         title={
           <>
-            <strong>{summary.total.toLocaleString()}</strong> waterbodies
-            assessed for aquatic life in the <em>{watershed}</em> watershed.
+            <strong>{summary.total.toLocaleString()}</strong>{' '}
+            {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
+            aquatic life in the <em>{watershed}</em> watershed.
           </>
         }
       />

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -245,7 +245,7 @@ function DrinkingWater() {
   // draw the waterbody (drinking water sources) on the map
   useWaterbodyOnMap('drinkingwater_use');
 
-  const summary = summarizeAssessments(waterbodies, 'recreation_use');
+  const summary = summarizeAssessments(waterbodies, 'drinkingwater_use');
 
   // draw the drinking water providers (county) on the map
   const [countyGraphic, setCountyGraphic] = useState(null);
@@ -651,7 +651,8 @@ function DrinkingWater() {
                           title={
                             <>
                               <strong>{providers.length}</strong> public water
-                              systems serving <em>{county}</em> county.
+                              system{providers.length === 1 ? '' : 's'} serving{' '}
+                              <em>{county}</em> county.
                             </>
                           }
                           onSortChange={(sortBy) =>
@@ -895,8 +896,9 @@ function DrinkingWater() {
                   title={
                     <>
                       <strong>{summary.total.toLocaleString()}</strong>{' '}
-                      waterbodies assessed as potential future sources of
-                      drinking water in the <em>{watershed}</em> watershed.
+                      {summary.total === 1 ? 'waterbody' : 'waterbodies'}{' '}
+                      assessed as potential future sources of drinking water in
+                      the <em>{watershed}</em> watershed.
                     </>
                   }
                 />

--- a/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
+++ b/app/client/src/components/pages/Community/components/tabs/DrinkingWater.js
@@ -650,9 +650,9 @@ function DrinkingWater() {
                         <AccordionList
                           title={
                             <>
-                              <strong>{providers.length}</strong> public water
-                              system{providers.length === 1 ? '' : 's'} serving{' '}
-                              <em>{county}</em> county.
+                              <strong>{providers.length}</strong> public water{' '}
+                              {providers.length === 1 ? 'system' : 'systems'}{' '}
+                              serving <em>{county}</em> county.
                             </>
                           }
                           onSortChange={(sortBy) =>

--- a/app/client/src/components/pages/Community/components/tabs/EatingFish.js
+++ b/app/client/src/components/pages/Community/components/tabs/EatingFish.js
@@ -134,9 +134,10 @@ function EatingFish() {
         fieldName="fishconsumption_use"
         title={
           <>
-            <strong>{summary.total.toLocaleString()}</strong> waterbodies
-            assessed for fish and shellfish consumption in the{' '}
-            <em>{watershed}</em> watershed.
+            <strong>{summary.total.toLocaleString()}</strong>{' '}
+            {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
+            fish and shellfish consumption in the <em>{watershed}</em>{' '}
+            watershed.
           </>
         }
       />

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -292,9 +292,8 @@ function IdentifiedIssues() {
 
   // check the data quality and log a non-fatal exception to Google Analytics
   // if necessary
-  const [emptyCategoriesWithPercent, setEmptyCategoriesWithPercent] = useState(
-    false,
-  );
+  const [emptyCategoriesWithPercent, setEmptyCategoriesWithPercent] =
+    useState(false);
   const [nullPollutedWaterbodies, setNullPollutedWaterbodies] = useState(false);
   useEffect(() => {
     if (!window.gaTarget || cipSummary.status !== 'success') return;
@@ -495,9 +494,8 @@ function IdentifiedIssues() {
     }
     // one of the parameters is switched
     else {
-      tempParameterToggleObject[checkedSwitch] = !parameterToggleObject[
-        checkedSwitch
-      ];
+      tempParameterToggleObject[checkedSwitch] =
+        !parameterToggleObject[checkedSwitch];
 
       checkIfAllSwitchesToggled(cipSummary.data, tempParameterToggleObject);
     }
@@ -745,10 +743,11 @@ function IdentifiedIssues() {
                                         ),
                                       );
 
-                                      const mappedParameterName = getMappedParameterName(
-                                        impairmentFields,
-                                        param['parameterGroupName'],
-                                      );
+                                      const mappedParameterName =
+                                        getMappedParameterName(
+                                          impairmentFields,
+                                          param['parameterGroupName'],
+                                        );
                                       // if service contains a parameter we have no mapping for
                                       if (!mappedParameterName) return false;
 
@@ -822,7 +821,9 @@ function IdentifiedIssues() {
                             <strong>
                               {violatingFacilities.length.toLocaleString()}
                             </strong>{' '}
-                            dischargers with significant{' '}
+                            discharger
+                            {violatingFacilities.length === 1 ? '' : 's'} with
+                            significant{' '}
                             <GlossaryTerm term="Effluent">
                               effluent
                             </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community/components/tabs/IdentifiedIssues.js
@@ -821,9 +821,10 @@ function IdentifiedIssues() {
                             <strong>
                               {violatingFacilities.length.toLocaleString()}
                             </strong>{' '}
-                            discharger
-                            {violatingFacilities.length === 1 ? '' : 's'} with
-                            significant{' '}
+                            {violatingFacilities.length === 1
+                              ? 'discharger'
+                              : 'dischargers'}{' '}
+                            with significant{' '}
                             <GlossaryTerm term="Effluent">
                               effluent
                             </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -931,9 +931,9 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
           <AccordionList
             title={
               <>
-                <strong>{totalPermittedDischargers}</strong> permitted
-                discharger{totalPermittedDischargers === 1 ? '' : 's'} in the{' '}
-                <em>{watershed}</em> watershed.
+                <strong>{totalPermittedDischargers}</strong> permitted{' '}
+                {totalPermittedDischargers === 1 ? 'discharger' : 'dischargers'}{' '}
+                in the <em>{watershed}</em> watershed.
               </>
             }
             onSortChange={(sortBy) => {

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -440,8 +440,9 @@ function WaterbodiesTab() {
       title={
         <div data-testid="overview-waterbodies-accordion-title">
           Overall condition of{' '}
-          <strong>{waterbodies?.length.toLocaleString()}</strong> waterbodies in
-          the <em>{watershed}</em> watershed.
+          <strong>{waterbodies?.length.toLocaleString()}</strong>{' '}
+          {waterbodies?.length === 1 ? 'waterbody' : 'waterbodies'} in the{' '}
+          <em>{watershed}</em> watershed.
         </div>
       }
     />
@@ -931,7 +932,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
             title={
               <>
                 <strong>{totalPermittedDischargers}</strong> permitted
-                dischargers in the <em>{watershed}</em> watershed.
+                discharger{totalPermittedDischargers === 1 ? '' : 's'} in the{' '}
+                <em>{watershed}</em> watershed.
               </>
             }
             onSortChange={(sortBy) => {

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -270,9 +270,8 @@ function Protect() {
 
   const [protectedAreasDisplayed, setProtectedAreasDisplayed] = useState(false);
 
-  const [wildScenicRiversDisplayed, setWildScenicRiversDisplayed] = useState(
-    false,
-  );
+  const [wildScenicRiversDisplayed, setWildScenicRiversDisplayed] =
+    useState(false);
 
   const [waterbodyLayerDisplayed, setWaterbodyLayerDisplayed] = useState(false);
 
@@ -442,10 +441,8 @@ function Protect() {
 
   // Initialize the allWaterbodiesLayer visibility. This will be used to reset
   // the allWaterbodiesLayer visibility when the user leaves this tab.
-  const [
-    initialAllWaterbodiesVisibility,
-    setInitialAllWaterbodiesVisibility,
-  ] = useState(false);
+  const [initialAllWaterbodiesVisibility, setInitialAllWaterbodiesVisibility] =
+    useState(false);
   useEffect(() => {
     if (!allWaterbodiesLayer) return;
 
@@ -825,8 +822,11 @@ function Protect() {
                               <strong>
                                 {wildScenicRiversData.data.length.toLocaleString()}
                               </strong>{' '}
-                              wild and scenic rivers in the <em>{watershed}</em>{' '}
-                              watershed.
+                              wild and scenic river
+                              {wildScenicRiversData.data.length === 1
+                                ? ''
+                                : 's'}{' '}
+                              in the <em>{watershed}</em> watershed.
                             </p>
                           </div>
 
@@ -1038,8 +1038,11 @@ function Protect() {
                               <strong>
                                 {protectedAreasData.data.length.toLocaleString()}
                               </strong>{' '}
-                              protected areas in the <em>{watershed}</em>{' '}
-                              watershed.
+                              protected area
+                              {protectedAreasData.data.length === 1
+                                ? ''
+                                : 's'}{' '}
+                              in the <em>{watershed}</em> watershed.
                             </>
                           }
                         >
@@ -1241,8 +1244,11 @@ function Protect() {
                                   <strong>
                                     {allProtectionProjects.length.toLocaleString()}
                                   </strong>{' '}
-                                  EPA funded protection projects in the{' '}
-                                  <em>{watershed}</em> watershed.
+                                  EPA funded protection project
+                                  {allProtectionProjects.length === 1
+                                    ? ''
+                                    : 's'}{' '}
+                                  in the <em>{watershed}</em> watershed.
                                 </p>
                               </div>
 

--- a/app/client/src/components/pages/Community/components/tabs/Protect.js
+++ b/app/client/src/components/pages/Community/components/tabs/Protect.js
@@ -822,10 +822,10 @@ function Protect() {
                               <strong>
                                 {wildScenicRiversData.data.length.toLocaleString()}
                               </strong>{' '}
-                              wild and scenic river
+                              wild and scenic{' '}
                               {wildScenicRiversData.data.length === 1
-                                ? ''
-                                : 's'}{' '}
+                                ? 'river'
+                                : 'rivers'}{' '}
                               in the <em>{watershed}</em> watershed.
                             </p>
                           </div>
@@ -1038,10 +1038,10 @@ function Protect() {
                               <strong>
                                 {protectedAreasData.data.length.toLocaleString()}
                               </strong>{' '}
-                              protected area
+                              protected{' '}
                               {protectedAreasData.data.length === 1
-                                ? ''
-                                : 's'}{' '}
+                                ? 'area'
+                                : 'areas'}{' '}
                               in the <em>{watershed}</em> watershed.
                             </>
                           }
@@ -1244,10 +1244,10 @@ function Protect() {
                                   <strong>
                                     {allProtectionProjects.length.toLocaleString()}
                                   </strong>{' '}
-                                  EPA funded protection project
+                                  EPA funded protection{' '}
                                   {allProtectionProjects.length === 1
-                                    ? ''
-                                    : 's'}{' '}
+                                    ? 'project'
+                                    : 'projects'}{' '}
                                   in the <em>{watershed}</em> watershed.
                                 </p>
                               </div>

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -191,7 +191,8 @@ function Restore() {
                               <strong>
                                 {sortedGrtsData.length.toLocaleString()}
                               </strong>{' '}
-                              EPA Funded grants under the{' '}
+                              EPA Funded grant
+                              {sortedGrtsData.length === 1 ? '' : 's'} under the{' '}
                               <GlossaryTerm term="Clean Water Act Section 319 Projects">
                                 Clean Water Act Section 319
                               </GlossaryTerm>{' '}
@@ -359,7 +360,8 @@ function Restore() {
                               {sortedAttainsPlanData.length.toLocaleString()}
                             </strong>{' '}
                             <GlossaryTerm term="Restoration plan">
-                              Restoration plans
+                              Restoration plan
+                              {sortedAttainsPlanData.length === 1 ? '' : 's'}
                             </GlossaryTerm>{' '}
                             in the <em>{watershed}</em> watershed.
                           </>

--- a/app/client/src/components/pages/Community/components/tabs/Restore.js
+++ b/app/client/src/components/pages/Community/components/tabs/Restore.js
@@ -191,8 +191,9 @@ function Restore() {
                               <strong>
                                 {sortedGrtsData.length.toLocaleString()}
                               </strong>{' '}
-                              EPA Funded grant
-                              {sortedGrtsData.length === 1 ? '' : 's'} under the{' '}
+                              EPA Funded{' '}
+                              {sortedGrtsData.length === 1 ? 'grant' : 'grants'}{' '}
+                              under the{' '}
                               <GlossaryTerm term="Clean Water Act Section 319 Projects">
                                 Clean Water Act Section 319
                               </GlossaryTerm>{' '}
@@ -360,8 +361,10 @@ function Restore() {
                               {sortedAttainsPlanData.length.toLocaleString()}
                             </strong>{' '}
                             <GlossaryTerm term="Restoration plan">
-                              Restoration plan
-                              {sortedAttainsPlanData.length === 1 ? '' : 's'}
+                              Restoration{' '}
+                              {sortedAttainsPlanData.length === 1
+                                ? 'plan'
+                                : 'plans'}
                             </GlossaryTerm>{' '}
                             in the <em>{watershed}</em> watershed.
                           </>

--- a/app/client/src/components/pages/Community/components/tabs/Swimming.js
+++ b/app/client/src/components/pages/Community/components/tabs/Swimming.js
@@ -58,9 +58,9 @@ function Swimming() {
             fieldName="recreation_use"
             title={
               <>
-                <strong>{summary.total.toLocaleString()}</strong> waterbodies
-                assessed for swimming and boating in the <em>{watershed}</em>{' '}
-                watershed.
+                <strong>{summary.total.toLocaleString()}</strong>{' '}
+                {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
+                swimming and boating in the <em>{watershed}</em> watershed.
               </>
             }
           />

--- a/app/client/src/components/shared/AssessmentSummary/index.js
+++ b/app/client/src/components/shared/AssessmentSummary/index.js
@@ -45,8 +45,9 @@ function AssessmentSummary({ waterbodies, fieldName, usageName }: Props) {
     <>
       <div css={modifiedInfoBoxStyles}>
         <p>
-          <strong>{summary.total.toLocaleString()}</strong> waterbodies have
-          been assessed for{' '}
+          <strong>{summary.total.toLocaleString()}</strong>{' '}
+          {summary.total === 1 ? 'waterbody has' : 'waterbodies have'} been
+          assessed for{' '}
           {glossaryUsageNames.includes(usageName) ? (
             <GlossaryTerm term={usageName}>{usageName}</GlossaryTerm>
           ) : (


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-77

## Main Changes:
* Updated code to fix grammar issues for accordion titles when there is only 1 item.

## Steps To Test:
1. Navigate to http://localhost:3000/community/031501100301/overview (this location will work for testing most tabs)
2. Verify the waterbody grammar for the accordion header counts is correct (i.e., singular)
3. Switch to http://localhost:3000/community/031501100202/overview
4. Verify the waterbody grammar for the accordion header counts is correct (i.e., plural)
5. Repeat steps 1 - 4 for swimming, eating fish, and aquatic life.

NOTE: I had a hard time finding examples for testing the other tabs. I did test these by modifying the data fetching code to only return one item, so the other items should be good as well. 

