### PR TITLE
feature/update streamgage linewrapping

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1383,13 +1383,13 @@ function UsgsStreamgageParameter({ url, data, index }) {
       <td>
         {data.multiple ? (
           <>
-            <em>multiple measurements found</em>
+            <em>multiple&nbsp;measurements&nbsp;found</em>
             <br />
             <small css={additionalTextStyles}>
               <a rel="noopener noreferrer" target="_blank" href={url}>
                 More Information
               </a>
-              &nbsp;&nbsp;
+              <br />
               <span>(opens new browser tab)</span>
             </small>
           </>


### PR DESCRIPTION
## Related Issues:
* TODO

## Main Changes:
* Update text displayed for streamgages with multiple measurements for a parameter to not wrap "multiple measurements found" text, and always display "(opens new browser tab)" text below the "More Information" link

## Steps To Test:
1. Navigate to http://localhost:3000/community/180500010403/overview and expand the second streamgage (**SUISUN BAY A BENICIA BRIDGE NR BENICIA CA**), and ensure the text below the "multiple measurements founds" text is displayed on separate lines and not wrapping (shrink your browser window to test).
