### PR TITLE
Bugfix/fix google analytics bug

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -135,6 +135,7 @@
 
     // Wrapper for logging to GA which adds the target to the command
     function logToGa(command, ...props) {
+      if (!window.ga) return;
       ga(`${window.gaTarget}.${command}`, ...props);
     }
 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-97

## Main Changes:
If Google Analytics is blocked on the client and there's an error in the app, the app will currently crash (NOTE: bug in the index.html file itself, not in the React codebase). The fix is to first check that the Google Analytics `ga` method exists before calling it.

There's a global error event listener on the page that calls the `logToGa` method (line 269) on any errors. I've updated that method to first check if the `ga` method exists before calling it.

NOTE: see the first TODO item for the two errors that are currently being thrown by ESRI. We should look into fixing those as part of a separate PR.

## Steps To Test:
1. The easiest way to test this locally is to temporarily comment out the `addGoogleAnalyticsObject()` method call on line 177 of `app/client/public/index.html` to prevent the google analytics initialization code from being setup.

## TODO:
- [ ] Fix the errors that were causing the call to GA in the first place:
    - [ ] `esri.widgets.Search.support.layerSearchUtils] invalid-field: outField is invalid.`
    - [ ] `[esri.layers.support.fieldProperties] field-attributes-layer:invalid-field Invalid field TRIBE_NAME found in outFields`
- [ ] Update/refactor some of the code on the `app/client/public/index.html` file unrelated to this bugfix. Some things to do: be consistent with accessing the global location object (prefer window.location over document.location, and stick to one), don't leak so many variables into the global scope/make better use of closures, prefer ternary/conditional variable assignment over re-assignment, simplify if/else statements.
