### PR TITLE
Bugfix/fix duplicate streamgages on map

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -485,6 +485,8 @@ function MonitoringAndSensorsTab({
     setMonitoringAndSensorsDisplayed,
   ]);
 
+  const [usgsStreamgagesPlotted, setUsgsGtreamgagesPlotted] = useState(false);
+
   const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
     [],
   );
@@ -553,13 +555,16 @@ function MonitoringAndSensorsTab({
 
     setNormalizedUsgsStreamgages(gages);
 
-    plotGages(gages, usgsStreamgagesLayer);
+    plotGages(gages, usgsStreamgagesLayer).then((result) => {
+      if (result.addFeatureResults.length > 0) setUsgsGtreamgagesPlotted(true);
+    });
   }, [usgsStreamgages.data, usgsStreamgagesLayer]);
 
-  // add precipitation data (fetched from usgsDailyValues web service) to each
-  // streamgage if it exists for that particular location and replot the
-  // streamgages on the map
+  // once streamgages have been plotted initially, add precipitation data
+  // (fetched from usgsDailyValues web service) to each streamgage if it exists
+  // for that particular location and replot the streamgages on the map
   useEffect(() => {
+    if (!usgsStreamgagesPlotted) return;
     if (!usgsDailyPrecipitation.data.value) return;
     if (normalizedUsgsStreamgages.length === 0) return;
 
@@ -591,7 +596,12 @@ function MonitoringAndSensorsTab({
     });
 
     plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
-  }, [usgsDailyPrecipitation, normalizedUsgsStreamgages, usgsStreamgagesLayer]);
+  }, [
+    usgsStreamgagesPlotted,
+    usgsDailyPrecipitation,
+    normalizedUsgsStreamgages,
+    usgsStreamgagesLayer,
+  ]);
 
   const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
     useState([]);

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -409,8 +409,8 @@ export function plotGages(gages: Object[], layer: any) {
     });
   });
 
-  layer.queryFeatures().then((featureSet) => {
-    layer.applyEdits({
+  return layer.queryFeatures().then((featureSet) => {
+    return layer.applyEdits({
       deleteFeatures: featureSet.features,
       addFeatures: graphics,
     });

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1250,15 +1250,11 @@ function UsgsStreamgagesContent({ feature }: { feature: Object }) {
 
   const sortedPrimaryMeasurements = [...primaryMeasurements]
     .sort((a, b) => a.parameterOrder - b.parameterOrder)
-    .map((data, index) => (
-      <UsgsStreamgageParameter url={locationUrl} data={data} index={index} />
-    ));
+    .map((data) => <UsgsStreamgageParameter url={locationUrl} data={data} />);
 
   const sortedSecondaryMeasurements = [...secondaryMeasurements]
     .sort((a, b) => a.parameterName.localeCompare(b.parameterName))
-    .map((data, index) => (
-      <UsgsStreamgageParameter url={locationUrl} data={data} index={index} />
-    ));
+    .map((data) => <UsgsStreamgageParameter url={locationUrl} data={data} />);
 
   const sortedMeasurements = [
     ...sortedPrimaryMeasurements,
@@ -1364,9 +1360,9 @@ function UsgsStreamgagesContent({ feature }: { feature: Object }) {
   );
 }
 
-function UsgsStreamgageParameter({ url, data, index }) {
+function UsgsStreamgageParameter({ url, data }) {
   return (
-    <tr key={index}>
+    <tr key={data.parameterCode}>
       <td>
         {data.parameterCategory === 'primary' ? (
           <GlossaryTerm term={data.parameterName}>


### PR DESCRIPTION
## Related Issues:
* TODO

## Main Changes:
* Fixes an issue where streamgages would be rendered multiple times on the map (each gague would sometimes be rendered twice). We didn't catch this before as they share the exact same lat/long so it was only really evident when you clicked a streamgage and saw the "1 of X" in the ESRI popup. Other than cycling through the list and seeing the duplicate streamgage, you can also easily see the duplicated streamgage by clicking the "1 of X" popup and seeing the duplicate in the list of all nearby ESRI features.
* Also fixes a (non-visual) issue w/ streamgage parameters in the parameters table not having unique keys.

## Steps To Test:
1. Navigate to http://localhost:3000/community/22201/overview
2. Switch to the "Monitoring & Sensors" subtab, and toggle on the "Current Water Conditions" switch
3. Click on the streamgage on the map and confirm that the map popup doesn't indicate there are duplicate streamgages at this lat/long. It'll still say "1 of 4" depending on your zoom level, as it's picking up nearly waterbodies (which is a separate bug that needs to be fixed). Contrast this with the production site (#) which shows the duplicate streamgages ("1 of 5")

## TODO:
- [ ] Fix issue of surrounding waterbodies being picked up when a streamgages is clicked (e.g. "1 of 4" shows nearby waterbodies from the "surrounding waterbodies" layer since it's turned on). @cschwinderg can you look into this, as you've done work on the surrounding waterbodies feature?
