### PR TITLE
bugfix/111_infinite-loading-spinner-outisde-huc

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1148,7 +1148,7 @@ function WaterbodyInfo({
       <div css={popupContainerStyles}>
         {clickedHuc && (
           <>
-            {clickedHuc.status === 'no-data' && <p>No Data</p>}
+            {clickedHuc.status === 'no-data' && null}
             {clickedHuc.status === 'fetching' && <LoadingSpinner />}
             {clickedHuc.status === 'failure' && <p>Web service error</p>}
             {clickedHuc.status === 'success' && (

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -226,13 +226,8 @@ function useWaterbodyOnMap(
     setHighlightedGraphic,
     setSelectedGraphic, //
   } = useContext(MapHighlightContext);
-  const {
-    allWaterbodiesLayer,
-    pointsLayer,
-    linesLayer,
-    areasLayer,
-    mapView,
-  } = useContext(LocationSearchContext);
+  const { allWaterbodiesLayer, pointsLayer, linesLayer, areasLayer, mapView } =
+    useContext(LocationSearchContext);
 
   const setRenderer = useCallback(
     (layer, geometryType, attribute, alpha = null) => {
@@ -407,11 +402,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     else if (selectedGraphic) graphic = selectedGraphic;
 
     // save the state into separate variables for now
-    let {
-      currentHighlight,
-      currentSelection,
-      cachedHighlights,
-    } = highlightState;
+    let { currentHighlight, currentSelection, cachedHighlights } =
+      highlightState;
 
     // verify that we have a graphic before continuing
     if (!graphic || !graphic.attributes) {
@@ -768,7 +760,13 @@ function useDynamicPopup() {
         new QueryTask({ url: services.data.wbd })
           .execute(query)
           .then((boundaries) => {
-            if (boundaries.features.length === 0) return;
+            if (boundaries.features.length === 0) {
+              resolve({
+                status: 'no-data',
+                data: null,
+              });
+              return;
+            }
 
             const { attributes } = boundaries.features[0];
             hucInfo = {


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-111

## Main Changes:
* Fixed issue with infinite loading spinner displaying when clicking offshore assessments.

## Steps To Test:
1. Navigate to http://localhost:3000/community/210100040109/overview
2. Click an assessment in the ocean that is outside of the selected HUC
3. Verify the "Change to this location" section is not displayed in the popup

