### PR TITLE
Feature/110 add org name monitoring station

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -533,12 +533,12 @@ function Monitoring() {
                     value: 'locationName',
                   },
                   {
-                    label: 'Organization ID',
-                    value: 'orgId',
-                  },
-                  {
                     label: 'Organization Name',
                     value: 'orgName',
+                  },
+                  {
+                    label: 'Organization ID',
+                    value: 'orgId',
                   },
                   {
                     label: 'Monitoring Site ID',

--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -537,6 +537,10 @@ function Monitoring() {
                     value: 'orgId',
                   },
                   {
+                    label: 'Organization Name',
+                    value: 'orgName',
+                  },
+                  {
                     label: 'Monitoring Site ID',
                     value: 'siteId',
                   },
@@ -564,6 +568,9 @@ function Monitoring() {
                         <>
                           <em>Organization ID:</em>&nbsp;&nbsp;
                           {item.orgId}
+                          <br />
+                          <em>Organization Name:</em>&nbsp;&nbsp;
+                          {item.orgName}
                           <br />
                           <em>Monitoring Site ID:</em>&nbsp;&nbsp;
                           {item.siteId.replace(`${item.orgId}-`, '')}

--- a/app/client/src/components/pages/Community/components/tabs/Monitoring.js
+++ b/app/client/src/components/pages/Community/components/tabs/Monitoring.js
@@ -566,11 +566,11 @@ function Monitoring() {
                       title={<strong>{item.locationName || 'Unknown'}</strong>}
                       subTitle={
                         <>
-                          <em>Organization ID:</em>&nbsp;&nbsp;
-                          {item.orgId}
-                          <br />
                           <em>Organization Name:</em>&nbsp;&nbsp;
                           {item.orgName}
+                          <br />
+                          <em>Organization ID:</em>&nbsp;&nbsp;
+                          {item.orgId}
                           <br />
                           <em>Monitoring Site ID:</em>&nbsp;&nbsp;
                           {item.siteId.replace(`${item.orgId}-`, '')}

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -810,6 +810,10 @@ function MonitoringAndSensorsTab({
                   value: 'orgId',
                 },
                 {
+                  label: 'Organization Name',
+                  value: 'orgName',
+                },
+                {
                   label: 'Monitoring Site ID',
                   value: 'siteId',
                 },
@@ -844,6 +848,9 @@ function MonitoringAndSensorsTab({
                         {item.monitoringType}
                         <br />
                         <em>Organization ID:</em>&nbsp;&nbsp;{item.orgId}
+                        <br />
+                        <em>Organization Name:</em>&nbsp;&nbsp;
+                        {item.orgName}
                         <br />
                         <em>Monitoring Site ID:</em>&nbsp;&nbsp;
                         {item.siteId.replace(`${item.orgId}-`, '')}

--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -806,12 +806,12 @@ function MonitoringAndSensorsTab({
                   value: 'locationName',
                 },
                 {
-                  label: 'Organization ID',
-                  value: 'orgId',
-                },
-                {
                   label: 'Organization Name',
                   value: 'orgName',
+                },
+                {
+                  label: 'Organization ID',
+                  value: 'orgId',
                 },
                 {
                   label: 'Monitoring Site ID',
@@ -847,10 +847,10 @@ function MonitoringAndSensorsTab({
                         <em>Monitoring Type:</em>&nbsp;&nbsp;
                         {item.monitoringType}
                         <br />
-                        <em>Organization ID:</em>&nbsp;&nbsp;{item.orgId}
-                        <br />
                         <em>Organization Name:</em>&nbsp;&nbsp;
                         {item.orgName}
+                        <br />
+                        <em>Organization ID:</em>&nbsp;&nbsp;{item.orgId}
                         <br />
                         <em>Monitoring Site ID:</em>&nbsp;&nbsp;
                         {item.siteId.replace(`${item.orgId}-`, '')}

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -627,7 +627,7 @@ function WaterbodyInfo({
           <tbody>
             <tr>
               <td>
-                <em>Organization:</em>
+                <em>Organ&shy;ization Name:</em>
               </td>
               <td>{attributes.orgName}</td>
             </tr>
@@ -1267,7 +1267,7 @@ function UsgsStreamgagesContent({ feature }: { feature: Object }) {
         <tbody>
           <tr>
             <td>
-              <em>Organization:</em>
+              <em>Organ&shy;ization Name:</em>
             </td>
             <td>{orgName}</td>
           </tr>


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-110

## Main Changes:
* Added the Organization Name to the accordions on the Overview and Monitoring tabs.
* Added the Organization Name to the sort by drop down on the Overview and Monitoring tabs.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Click on the "Monitoring & Sensors" sub tab
3. Toggle on the "Sample Locations" switch
4. Verify the accordion subtitles now show "Organization Name"
5. Verify the Sort By dropdown contains "Organization Name" and that the sort works
6. Click on the "Monitoring" tab
7. Verify the accordion subtitles now show "Organization Name"
8. Verify the Sort By dropdown contains "Organization Name" and that the sort works

