### PR TITLE
Feature/103 add glossary linkages

### DIFF
--- a/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
+++ b/app/client/src/components/pages/State/components/tabs/AdvancedSearch.js
@@ -1019,7 +1019,12 @@ function AdvancedSearch({ ...props }: Props) {
           <MapFooterMessage>{state303dStatusError}</MapFooterMessage>
         )}
         <MapFooterStatus>
-          <strong>303(d) List Status / Year Last Reported:</strong>
+          <strong>
+            <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+              303(d) List Status
+            </GlossaryTerm>{' '}
+            / Year Last Reported:
+          </strong>
           &nbsp;&nbsp;
           {!currentReportStatus ? (
             <LoadingSpinner />

--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -13,6 +13,7 @@ import WaterbodyIcon from 'components/shared/WaterbodyIcon';
 import ActionsMap from 'components/pages/Actions/ActionsMap';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import MapVisibilityButton from 'components/shared/MapVisibilityButton';
+import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // styled components
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import {
@@ -844,7 +845,12 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
       </div>
 
       <div css={inlineBoxSectionStyles}>
-        <h3>303(d) Listed:</h3>
+        <h3>
+          <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+            303(d) Listed
+          </GlossaryTerm>
+          :
+        </h3>
         {waterbodyStatus.status === 'fetching' && <LoadingSpinner />}
         {waterbodyStatus.status === 'failure' && (
           <div css={modifiedErrorBoxStyles}>

--- a/app/client/src/components/shared/AboutContent/index.js
+++ b/app/client/src/components/shared/AboutContent/index.js
@@ -261,13 +261,16 @@ function AboutContent({ ...props }: Props) {
                 <p>
                   On this page you will be able to find the condition of
                   waterbodies in your state all in one place. You can filter the
-                  data by 303(d) listed waters, all waters, impaired waters or
-                  find out which waters in the state have a TMDL. There is a
-                  filtering function to filter by different parameters
-                  (bacteria, acidity, abnormal flow, etc) and/or different use
-                  groups (aquatic life, fish and shellfish consumption,
-                  recreation, etc.). Results can be viewed on a map or in a
-                  list.
+                  data by{' '}
+                  <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+                    303(d) listed
+                  </GlossaryTerm>{' '}
+                  waters, all waters, impaired waters or find out which waters
+                  in the state have a TMDL. There is a filtering function to
+                  filter by different parameters (bacteria, acidity, abnormal
+                  flow, etc) and/or different use groups (aquatic life, fish and
+                  shellfish consumption, recreation, etc.). Results can be
+                  viewed on a map or in a list.
                 </p>
 
                 <h1>National Page </h1>

--- a/app/client/src/components/shared/DataContent/index.js
+++ b/app/client/src/components/shared/DataContent/index.js
@@ -206,7 +206,11 @@ function Data({ ...props }: Props) {
         <p>
           ATTAINS contains information on water quality assessments, impaired
           waters, and total maximum daily loads (TMDLs), through data submitted
-          by states under Clean Water Act sections 303(d) and 305(b).
+          by states under Clean Water Act sections{' '}
+          <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+            303(d)
+          </GlossaryTerm>{' '}
+          and 305(b).
         </p>
         <br />
         <Question>Where do I find ATTAINS data in How’s My Waterway?</Question>

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -527,7 +527,11 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
         <div css={imageContainerStyles}>
           {squareIcon({ color: 'rgb(31, 184, 255, 0.2)', strokeWidth: 2 })}
         </div>
-        <span css={labelStyles}>Upstream Watershed</span>
+        <span css={labelStyles}>
+          <GlossaryTerm term="Upstream Watershed">
+            Upstream Watershed
+          </GlossaryTerm>
+        </span>
       </div>
     </li>
   );

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -428,7 +428,9 @@ function WaterbodyInfo({
   const waterbodyStateContent = (
     <>
       {labelValue(
-        '303(d) Listed',
+        <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+          303(d) Listed
+        </GlossaryTerm>,
         attributes.on303dlist === 'Y' ? 'Yes' : 'No',
       )}
       {labelValue('TMDL', attributes.hastmdl === 'Y' ? 'Yes' : 'No')}

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -290,11 +290,7 @@ function WaterbodyInfo({
       title = 'Protection Plans for this Waterbody';
     }
     if (type === 'Upstream Watershed') {
-      title = (
-        <>
-          <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>
-        </>
-      );
+      title = <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>;
     }
 
     return <p css={popupTitleStyles}>{title}</p>;

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -289,6 +289,13 @@ function WaterbodyInfo({
     if (type === 'Protection Plans') {
       title = 'Protection Plans for this Waterbody';
     }
+    if (type === 'Upstream Watershed') {
+      title = (
+        <>
+          <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>
+        </>
+      );
+    }
 
     return <p css={popupTitleStyles}>{title}</p>;
   };


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-103

## Main Changes:
* Linked all instances of "Upstream Watershed" to the glossary.
* Linked all instances of text containing "303(d)" to the glossary, except for a couple of instances within error messages. The instances within error messages are next to "303(d)" text that is linked to the glossary.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Click the "Upstream Watershed" button that is on the map
3. Open the map legend
4. Verify "Upstream Watershed" text is linked to the glossary
5. Click the upstream watershed graphic on the map
6. Verify the "Upstream Watershed" text in the popup is linked to the glossary
7. Verify that text containing "303(d)" is linked to the glossary in the following locations:
     1. State Advanced Search page
         * Footnote below the map
         * Popups on the map
         * Accordion content in the list view
     2. Waterbody Report (ex: http://localhost:3000/waterbody-report/21AWIC/AL06030002-0201-100/2020)
     3. About page: Check paragraph under "State Page" > "Advanced Search"
     4. Data page: Check under the ATTAINS entry
