### PR TITLE
Feature/94 update popup messages when no plans

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport/index.js
+++ b/app/client/src/components/pages/WaterbodyReport/index.js
@@ -1195,7 +1195,7 @@ function WaterbodyReport({ fullscreen, orgId, auId, reportingCycle }) {
                       {waterbodyActions.status === 'success' && (
                         <>
                           {waterbodyActions.data.length === 0 ? (
-                            <p>No plans for this waterbody.</p>
+                            <p>No plans specified for this waterbody.</p>
                           ) : (
                             <>
                               <em>Links below open in a new browser tab.</em>

--- a/app/client/src/components/shared/WaterbodyInfo/index.js
+++ b/app/client/src/components/shared/WaterbodyInfo/index.js
@@ -1055,7 +1055,7 @@ function WaterbodyInfo({
           {attainsProjects.status === 'success' && (
             <>
               {projects.length === 0 ? (
-                <p>No plans for this waterbody.</p>
+                <p>No plans specified for this waterbody.</p>
               ) : (
                 <>
                   <em>Links below open in a new browser tab.</em>


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-94

## Main Changes:
* HMW-94 Updated the "No plans for this waterbody" text to say "No plans specified for this waterbody".

## Steps To Test:
1. Navigate to http://localhost:3000/community/020700110207/restore
2. Click the "Restoration Plans" sub tab
3. Click on the blue graphic on the map
4. Verify the popup says "No plans specified for this waterbody"
5. Navigate to http://localhost:3000/waterbody-report/21AWIC/AL03150110-0202-102/2020
6. Verify the "Plans to Restore Water Quality" section says "No plans specified for this waterbody"

