### PR TITLE
Feature/102 map image layer surrounding waterbodies

### DIFF
--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -31,7 +31,7 @@ import {
 
 let dynamicPopupFields = [];
 
-const alpha = {
+const allWaterbodiesAlpha = {
   base: 1,
   poly: 0.4,
   outline: 1,
@@ -292,9 +292,9 @@ function useWaterbodyOnMap(
       ? allWaterbodiesAttribute
       : attributeName;
 
-    setRenderer(layers.items[2], 'point', attribute, alpha);
-    setRenderer(layers.items[1], 'polyline', attribute, alpha);
-    setRenderer(layers.items[0], 'polygon', attribute, alpha);
+    setRenderer(layers.items[2], 'point', attribute, allWaterbodiesAlpha);
+    setRenderer(layers.items[1], 'polyline', attribute, allWaterbodiesAlpha);
+    setRenderer(layers.items[0], 'polygon', attribute, allWaterbodiesAlpha);
   }, [
     allWaterbodiesAttribute,
     attributeName,
@@ -1106,15 +1106,13 @@ function useSharedLayers() {
       },
     });
 
-    const tribalLayer = new GroupLayer({
+    return new GroupLayer({
       id: 'tribalLayer',
       title: 'Tribal Areas',
       listMode: 'show',
       visible: false,
       layers: [alaskaNativeVillages, alaskaReservations, lower48Tribal],
     });
-
-    return tribalLayer;
   }
 
   function getCongressionalLayer() {
@@ -1128,7 +1126,8 @@ function useSharedLayers() {
       'PARTY',
       'SQMI',
     ];
-    const congressionalLayer = new FeatureLayer({
+
+    return new FeatureLayer({
       id: 'congressionalLayer',
       url: services.data.congressional,
       title: 'Congressional Districts',
@@ -1153,12 +1152,10 @@ function useSharedLayers() {
         outFields: congressionalLayerOutFields,
       },
     });
-
-    return congressionalLayer;
   }
 
   function getMappedWaterLayer() {
-    const mappedWaterLayer = new MapImageLayer({
+    return new MapImageLayer({
       id: 'mappedWaterLayer',
       url: services.data.mappedWater,
       title: 'Mapped Water (all)',
@@ -1166,12 +1163,10 @@ function useSharedLayers() {
       listMode: 'hide-children',
       visible: false,
     });
-
-    return mappedWaterLayer;
   }
 
   function getCountyLayer() {
-    const countyLayer = new FeatureLayer({
+    return new FeatureLayer({
       id: 'countyLayer',
       url: services.data.counties,
       title: 'County',
@@ -1195,12 +1190,10 @@ function useSharedLayers() {
         outFields: ['NAME', 'CNTY_FIPS', 'STATE_NAME'],
       },
     });
-
-    return countyLayer;
   }
 
   function getStateBoundariesLayer() {
-    const stateBoundariesLayer = new MapImageLayer({
+    return new MapImageLayer({
       id: 'stateBoundariesLayer',
       url: services.data.stateBoundaries,
       title: 'State',
@@ -1208,20 +1201,16 @@ function useSharedLayers() {
       listMode: 'hide',
       visible: false,
     });
-
-    return stateBoundariesLayer;
   }
 
   function getWatershedsLayer() {
-    const watershedsLayer = new FeatureLayer({
+    return new FeatureLayer({
       id: 'watershedsLayer',
       url: services.data.wbd,
       title: 'Watersheds',
       listMode: 'show',
       visible: false,
     });
-
-    return watershedsLayer;
   }
 
   function getEjscreen() {
@@ -1304,7 +1293,7 @@ function useSharedLayers() {
       popupTemplate: ejscreenPopupTemplate,
     });
 
-    const ejscreen = new GroupLayer({
+    return new GroupLayer({
       id: 'ejscreenLayer',
       title: 'Demographic Indicators',
       listMode: 'show',
@@ -1319,8 +1308,6 @@ function useSharedLayers() {
         ejDemographicIndex,
       ],
     });
-
-    return ejscreen;
   }
 
   function getAllWaterbodiesLayer() {
@@ -1341,9 +1328,9 @@ function useSharedLayers() {
         condition: 'unassessed',
         selected: false,
         geometryType: 'point',
-        alpha,
+        alpha: allWaterbodiesAlpha,
       }),
-      uniqueValueInfos: createUniqueValueInfos('point', alpha),
+      uniqueValueInfos: createUniqueValueInfos('point', allWaterbodiesAlpha),
     };
     const pointsLayer = new FeatureLayer({
       url: services.data.waterbodyService.points,
@@ -1361,9 +1348,9 @@ function useSharedLayers() {
         condition: 'unassessed',
         selected: false,
         geometryType: 'polyline',
-        alpha,
+        alpha: allWaterbodiesAlpha,
       }),
-      uniqueValueInfos: createUniqueValueInfos('polyline', alpha),
+      uniqueValueInfos: createUniqueValueInfos('polyline', allWaterbodiesAlpha),
     };
     const linesLayer = new FeatureLayer({
       url: services.data.waterbodyService.lines,
@@ -1381,9 +1368,9 @@ function useSharedLayers() {
         condition: 'unassessed',
         selected: false,
         geometryType: 'polygon',
-        alpha,
+        alpha: allWaterbodiesAlpha,
       }),
-      uniqueValueInfos: createUniqueValueInfos('polygon', alpha),
+      uniqueValueInfos: createUniqueValueInfos('polygon', allWaterbodiesAlpha),
     };
     const areasLayer = new FeatureLayer({
       url: services.data.waterbodyService.areas,

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -226,13 +226,8 @@ function useWaterbodyOnMap(
     setHighlightedGraphic,
     setSelectedGraphic, //
   } = useContext(MapHighlightContext);
-  const {
-    allWaterbodiesLayer,
-    pointsLayer,
-    linesLayer,
-    areasLayer,
-    mapView,
-  } = useContext(LocationSearchContext);
+  const { allWaterbodiesLayer, pointsLayer, linesLayer, areasLayer, mapView } =
+    useContext(LocationSearchContext);
 
   const setRenderer = useCallback(
     (layer, geometryType, attribute, alpha = null) => {
@@ -407,11 +402,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     else if (selectedGraphic) graphic = selectedGraphic;
 
     // save the state into separate variables for now
-    let {
-      currentHighlight,
-      currentSelection,
-      cachedHighlights,
-    } = highlightState;
+    let { currentHighlight, currentSelection, cachedHighlights } =
+      highlightState;
 
     // verify that we have a graphic before continuing
     if (!graphic || !graphic.attributes) {
@@ -840,8 +832,7 @@ function useSharedLayers() {
   const getDynamicPopup = useDynamicPopup();
   const { getTitle, getTemplate } = getDynamicPopup();
 
-  // Gets the settings for the WSIO Health Index layer.
-  return function getSharedLayers() {
+  function getWsioLayer() {
     // shared symbol settings
     const symbol = {
       type: 'simple-fill',
@@ -983,6 +974,10 @@ function useSharedLayers() {
       },
     );
 
+    return wsioHealthIndexLayer;
+  }
+
+  function getProtectedAreasLayer() {
     const protectedAreasLayer = new MapImageLayer({
       id: 'protectedAreasLayer',
       title: 'Protected Areas',
@@ -1001,6 +996,10 @@ function useSharedLayers() {
 
     setProtectedAreasLayer(protectedAreasLayer);
 
+    return protectedAreasLayer;
+  }
+
+  function getProtectedAreasHighlightLayer() {
     const protectedAreasHighlightLayer = new GraphicsLayer({
       id: 'protectedAreasHighlightLayer',
       title: 'Protected Areas Highlight Layer',
@@ -1009,6 +1008,10 @@ function useSharedLayers() {
 
     setProtectedAreasHighlightLayer(protectedAreasHighlightLayer);
 
+    return protectedAreasHighlightLayer;
+  }
+
+  function getWildScenicRiversLayer() {
     const wildScenicRiversRenderer = {
       type: 'simple',
       symbol: {
@@ -1035,7 +1038,10 @@ function useSharedLayers() {
 
     setWildScenicRiversLayer(wildScenicRiversLayer);
 
-    // START - Tribal layers
+    return wildScenicRiversLayer;
+  }
+
+  function getTribalLayer() {
     const renderer = {
       type: 'simple',
       symbol: {
@@ -1108,8 +1114,10 @@ function useSharedLayers() {
       layers: [alaskaNativeVillages, alaskaReservations, lower48Tribal],
     });
 
-    // END - Tribal layers
+    return tribalLayer;
+  }
 
+  function getCongressionalLayer() {
     const congressionalLayerOutFields = [
       'DISTRICTID',
       'STFIPS',
@@ -1146,6 +1154,10 @@ function useSharedLayers() {
       },
     });
 
+    return congressionalLayer;
+  }
+
+  function getMappedWaterLayer() {
     const mappedWaterLayer = new MapImageLayer({
       id: 'mappedWaterLayer',
       url: services.data.mappedWater,
@@ -1155,6 +1167,10 @@ function useSharedLayers() {
       visible: false,
     });
 
+    return mappedWaterLayer;
+  }
+
+  function getCountyLayer() {
     const countyLayer = new FeatureLayer({
       id: 'countyLayer',
       url: services.data.counties,
@@ -1180,6 +1196,10 @@ function useSharedLayers() {
       },
     });
 
+    return countyLayer;
+  }
+
+  function getStateBoundariesLayer() {
     const stateBoundariesLayer = new MapImageLayer({
       id: 'stateBoundariesLayer',
       url: services.data.stateBoundaries,
@@ -1189,6 +1209,10 @@ function useSharedLayers() {
       visible: false,
     });
 
+    return stateBoundariesLayer;
+  }
+
+  function getWatershedsLayer() {
     const watershedsLayer = new FeatureLayer({
       id: 'watershedsLayer',
       url: services.data.wbd,
@@ -1197,8 +1221,10 @@ function useSharedLayers() {
       visible: false,
     });
 
-    // BEGIN - EJSCREEN layers
+    return watershedsLayer;
+  }
 
+  function getEjscreen() {
     const ejOutFields = [
       'T_MINORPCT',
       'T_LWINCPCT',
@@ -1294,10 +1320,10 @@ function useSharedLayers() {
       ],
     });
 
-    // END - EJSCREEN layers
+    return ejscreen;
+  }
 
-    // START - All Waterbodies layers
-
+  function getAllWaterbodiesLayer() {
     const popupTemplate = {
       title: getTitle,
       content: getTemplate,
@@ -1384,7 +1410,34 @@ function useSharedLayers() {
     allWaterbodiesLayer.addMany([areasLayer, linesLayer, pointsLayer]);
     setAllWaterbodiesLayer(allWaterbodiesLayer);
 
-    // END - All Waterbodies layers
+    return allWaterbodiesLayer;
+  }
+
+  // Gets the settings for the WSIO Health Index layer.
+  return function getSharedLayers() {
+    const wsioHealthIndexLayer = getWsioLayer();
+
+    const protectedAreasLayer = getProtectedAreasLayer();
+
+    const protectedAreasHighlightLayer = getProtectedAreasHighlightLayer();
+
+    const wildScenicRiversLayer = getWildScenicRiversLayer();
+
+    const tribalLayer = getTribalLayer();
+
+    const congressionalLayer = getCongressionalLayer();
+
+    const mappedWaterLayer = getMappedWaterLayer();
+
+    const countyLayer = getCountyLayer();
+
+    const stateBoundariesLayer = getStateBoundariesLayer();
+
+    const watershedsLayer = getWatershedsLayer();
+
+    const ejscreen = getEjscreen();
+
+    const allWaterbodiesLayer = getAllWaterbodiesLayer();
 
     return [
       ejscreen,

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -31,6 +31,12 @@ import {
 
 let dynamicPopupFields = [];
 
+const alpha = {
+  base: 1,
+  poly: 0.4,
+  outline: 1,
+};
+
 // Closes the map popup and clears highlights whenever the user changes
 // tabs. This function is called from the useWaterbodyHighlight hook (handles
 // tab changes) and from the use useWaterbodyOnMap hook (handles sub tab changes
@@ -280,12 +286,6 @@ function useWaterbodyOnMap(
 
   useEffect(() => {
     if (!allWaterbodiesLayer || allWaterbodiesLayer === 'error') return;
-
-    const alpha = {
-      base: 0.2,
-      poly: 0.1,
-      outline: 0.05,
-    };
 
     const layers = allWaterbodiesLayer.layers;
     const attribute = allWaterbodiesAttribute
@@ -1330,12 +1330,6 @@ function useSharedLayers() {
       outFields: ['*'],
     };
 
-    const alpha = {
-      base: 0.2,
-      poly: 0.1,
-      outline: 0.05,
-    };
-
     const minScale = 577791;
 
     // Build the feature layers that will make up the waterbody layer
@@ -1406,6 +1400,7 @@ function useSharedLayers() {
       listMode: 'hide',
       visible: true,
       minScale,
+      opacity: 0.3,
     });
     allWaterbodiesLayer.addMany([areasLayer, linesLayer, pointsLayer]);
     setAllWaterbodiesLayer(allWaterbodiesLayer);


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-102

## Main Changes:
* Refactored the getSharedLayers function. Before there was a lot to scroll through to get to a particular layer. Now you can just collapse the functions for each layer.
* Fixed the issue with colors bleeding through on the surrounding bodies layer, which sometimes resulted in odd colors (i.e., olive waterbodies). 
  * I ended up not using MapImageLayers, because that broke the "Change to this location" popup. I ended up setting the transparency on the GroupLayer and on the Areas layer.

## Steps To Test:
1. Open up two tabs
2. On the first tab navigate to https://mywaterway.epa.gov/community/020600030902/protect
3. On the second tab navigate to http://localhost:3000/community/020600030902/overview
4. The first tab will have waterbodies with an olive color (i.e., blend of red and green) to the south west of the selected HUC
5. Verify the olive colored waterbodies, from the first tab, are a solid red on the second tab

