### PR TITLE
Feature/101 hide surrounding waterbodies popups inside huc

### DIFF
--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -226,13 +226,8 @@ function useWaterbodyOnMap(
     setHighlightedGraphic,
     setSelectedGraphic, //
   } = useContext(MapHighlightContext);
-  const {
-    allWaterbodiesLayer,
-    pointsLayer,
-    linesLayer,
-    areasLayer,
-    mapView,
-  } = useContext(LocationSearchContext);
+  const { allWaterbodiesLayer, pointsLayer, linesLayer, areasLayer, mapView } =
+    useContext(LocationSearchContext);
 
   const setRenderer = useCallback(
     (layer, geometryType, attribute, alpha = null) => {
@@ -407,11 +402,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     else if (selectedGraphic) graphic = selectedGraphic;
 
     // save the state into separate variables for now
-    let {
-      currentHighlight,
-      currentSelection,
-      cachedHighlights,
-    } = highlightState;
+    let { currentHighlight, currentSelection, cachedHighlights } =
+      highlightState;
 
     // verify that we have a graphic before continuing
     if (!graphic || !graphic.attributes) {
@@ -479,6 +471,7 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     }
 
     if (!layer) return;
+    if (graphic.layer?.parent?.id === 'allWaterbodiesLayer') return;
 
     // remove the highlights
     handles.remove(group);


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-101

## Main Changes:
* Added code to filter out surrounding waterbodies layer popups when the user clicks inside the HUC.
* Disabled highlighting of the surrounding waterbodies layer when the user clicks inside the HUC.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Click a waterbody inside the HUC
3. Verify the popup opens and the waterbody is highlighted
4. If there is more than 1 feature in the popup, cycle through them and verify that none of the assessment unit ids are duplicated 
5. Turn the waterbodies layer off
6. Click on a waterbody inside the HUC
7. Verify the popup does not open and nothing is highlighted
8. Click a waterbody outside the HUC
9. Verify the popup opens and the waterbody is highlighted
