### PR TITLE
Feature/108 address ga exceptions

### DIFF
--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -473,7 +473,7 @@ function LocationSearch({ route, label }: Props) {
     setSuggestionsVisible(false);
     setCursor(-1);
 
-    newSearchTerm = newSearchTerm.replace(/[\n\r\t\/]/g, ' ');
+    newSearchTerm = newSearchTerm.replace(/[\n\r\t/]/g, ' ');
 
     if (containsScriptTag(newSearchTerm)) {
       setErrorMessage(invalidSearchError);
@@ -502,7 +502,6 @@ function LocationSearch({ route, label }: Props) {
 
   // Splits the provided text by the searchString in a case insensitive way.
   function getHighlightParts(text, searchString) {
-    const searchLength = searchString.length;
     const indices = indicesOf(text, searchString);
 
     // build an array of the string split up by the searchString that includes
@@ -518,7 +517,7 @@ function LocationSearch({ route, label }: Props) {
       }
 
       // add in the search part of the text
-      endIndex = startIndex + searchLength;
+      endIndex = startIndex + searchString.length;
       parts.push(text.substring(startIndex, endIndex));
 
       // keep track of leftover text

--- a/app/client/src/components/shared/LocationSearch/index.js
+++ b/app/client/src/components/shared/LocationSearch/index.js
@@ -473,7 +473,7 @@ function LocationSearch({ route, label }: Props) {
     setSuggestionsVisible(false);
     setCursor(-1);
 
-    newSearchTerm = newSearchTerm.replace(/[\n\r\t]/g, ' ');
+    newSearchTerm = newSearchTerm.replace(/[\n\r\t\/]/g, ' ');
 
     if (containsScriptTag(newSearchTerm)) {
       setErrorMessage(invalidSearchError);

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -349,6 +349,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
     // get the parameters for the zoom call
     const geometry =
       selectedGraphic.originalGeometry ?? selectedGraphic.geometry;
+    if (!geometry) return;
+
     let params = geometry;
     if (!geometry.extent && geometry.longitude && geometry.latitude) {
       params = {

--- a/app/client/src/utils/utils.js
+++ b/app/client/src/utils/utils.js
@@ -334,6 +334,28 @@ function summarizeAssessments(waterbodies: Array<Object>, fieldName: string) {
   return summary;
 }
 
+// Finds all occurrences of the provided searchstring within the provided text.
+function indicesOf(text, searchString) {
+  const searchLength = searchString.length;
+  if (searchLength === 0) return [];
+
+  let startIndex = 0;
+  let index = 0;
+  const indices = [];
+
+  // make inputs lower case for doing case insensitive search
+  text = text.toLowerCase();
+  searchString = searchString.toLowerCase();
+
+  // search for all occurrences of the searchString
+  while ((index = text.indexOf(searchString, startIndex)) > -1) {
+    indices.push(index);
+    startIndex = index + searchLength;
+  }
+
+  return indices;
+}
+
 export {
   chunkArray,
   containsScriptTag,
@@ -357,4 +379,5 @@ export {
   getSelectedCommunityTab,
   normalizeString,
   summarizeAssessments,
+  indicesOf,
 };


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-108

## Main Changes:
* Reviewed exceptions flagged by Google Analytics. The following document is my review: [2022-01-24 HMW Exception Report_Review.xlsx](https://github.com/Eastern-Research-Group/mywaterway/files/8004252/2022-01-24.HMW.Exception.Report_Review.xlsx)
  * I skipped a lot of these based on Esri not supporting the browser version. Here is the URL that outlines minimum requirements for ArcGIS JS API: https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later
  * A lot of these the stack trace pointed to Esri code. None of the stack trace pointed to HMW code.
* Fixed a couple of GA exceptions that did point back to HMW.
  1. Typing `/(jaa[)/` into the location search causes the app to crash. I fixed this by moving away from Regex. We already have some code that attempts to escape the Regex, but it missed this issue. There probably is a way to change the escape Regex logic that would fix this issue, but I figured it would be easier and less prone to these issues that show up months later, to just rewrite the logic without Regex.
  2. Fixed the following issue: `Cannot read properties of null (reading 'extent')TypeError: Cannot Read properties of null (reading 'extent')`. I was able to find a place in the stack trace that pointed to our code. I just added an additional check to make sure the `geometry` variable is not null.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Type in `/(jaa[)/`
3. Verify you can type this in without the app crashing
4. Click "Go"
5. Verify the `Data is not available for this location. Please try a new search.` message is displayed.
