### PR TITLE
Bugfix/64 community auto scroll issue

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -61,8 +61,6 @@
       padding-right: 0;
     }
   </style>
-  <!-- Prevent scroll restoration. This is used to avoid issues with browsers scrolling to odd positions after the page finishes loading -->
-  <script>history.scrollRestoration = "manual"</script>
   <!-- Set page title dynamically -->
   <script>
     // map pathnames to a formatted title for SEO purposes
@@ -126,6 +124,10 @@
   <!-- End Google Tag Manager -->
   <!-- Google Analytics -->
   <script>
+    // Prevent scroll restoration. This is used to avoid issues with browsers 
+    // scrolling to odd positions after the page finishes loading
+    history.scrollRestoration = "manual";
+
     function addGoogleAnalyticsObject() {
       (function (i, s, o, g, r, a, m) {
         i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -61,6 +61,8 @@
       padding-right: 0;
     }
   </style>
+  <!-- Prevent scroll restoration. This is used to avoid issues with browsers scrolling to odd positions after the page finishes loading -->
+  <script>history.scrollRestoration = "manual"</script>
   <!-- Set page title dynamically -->
   <script>
     // map pathnames to a formatted title for SEO purposes


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-64

## Main Changes:
* Fixed a bug that caused the screen to jump after the page loads. This issue was really noticeable when navigating to HMW from the HMW widget. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Scroll up a little bit so that part of the HMW header image is visible (see 1st screenshot below). Basically, just trying to set chromes scroll history so that it is set to something other than the default HMW scroll position (see 2nd screenshot below).
3. Refresh the page. 
4. Wait for the page to fully load
5. Verify the page loads to the default HMW scroll position (see 2nd screenshot below). 

Example of where to scroll to for testing
![image](https://user-images.githubusercontent.com/46329268/152587931-0413b75d-d842-40b9-9ed8-4d21528c8ea3.png)


Example of where HMW should scroll to by default
![image](https://user-images.githubusercontent.com/46329268/152588044-c306bc3a-a3a1-4562-9cf0-c202f68e09bb.png)

