### PR TITLE
Bugfix/107 legend issues

### DIFF
--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Graphic from '@arcgis/core/Graphic';
 import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
@@ -49,21 +49,22 @@ type Props = {
 };
 
 function ActionsMap({ layout, unitIds, onLoad }: Props) {
-  const { actionsLayer, homeWidget, mapView, setActionsLayer } =
-    React.useContext(LocationSearchContext);
+  const { actionsLayer, homeWidget, mapView, setActionsLayer } = useContext(
+    LocationSearchContext,
+  );
 
-  const [layers, setLayers] = React.useState(null);
+  const [layers, setLayers] = useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [actionsMapLoadError, setActionsMapLoadError] = React.useState(false);
+  const [actionsMapLoadError, setActionsMapLoadError] = useState(false);
 
   const services = useServicesContext();
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
   // Initially sets up the layers
-  const [layersInitialized, setLayersInitialized] = React.useState(false);
-  React.useEffect(() => {
+  const [layersInitialized, setLayersInitialized] = useState(false);
+  useEffect(() => {
     if (!getSharedLayers || layersInitialized) return;
 
     let localActionsLayer = actionsLayer;
@@ -83,13 +84,13 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
     setLayersInitialized(true);
   }, [actionsLayer, setActionsLayer, getSharedLayers, layersInitialized]);
 
-  const [fetchStatus, setFetchStatus] = React.useState('');
+  const [fetchStatus, setFetchStatus] = useState('');
 
   // Queries the Gis service and plots the waterbodies on the map
-  const [noMapData, setNoMapData] = React.useState(null);
+  const [noMapData, setNoMapData] = useState(null);
 
   // Plots the assessments. Also re-plots if the layout changes
-  React.useEffect(() => {
+  useEffect(() => {
     if (!unitIds || !actionsLayer) return;
     if (fetchStatus) return; // only do a fetch if there is no status
 
@@ -265,7 +266,7 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
   }, [unitIds, actionsLayer, fetchStatus, onLoad, services]);
 
   // Scrolls to the map when switching layouts
-  React.useEffect(() => {
+  useEffect(() => {
     // scroll container or actions map content into view
     // get container or actions map content DOM node to scroll page
     // the layout changes
@@ -279,8 +280,8 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
   }, [layout]);
 
   // Zooms to the waterbodies after they are drawn on the map
-  const [mapLoading, setMapLoading] = React.useState(true);
-  React.useEffect(() => {
+  const [mapLoading, setMapLoading] = useState(true);
+  useEffect(() => {
     if (
       !fetchStatus ||
       !mapView ||

--- a/app/client/src/components/pages/Actions/ActionsMap.js
+++ b/app/client/src/components/pages/Actions/ActionsMap.js
@@ -49,12 +49,8 @@ type Props = {
 };
 
 function ActionsMap({ layout, unitIds, onLoad }: Props) {
-  const {
-    actionsLayer,
-    homeWidget,
-    mapView,
-    setActionsLayer,
-  } = React.useContext(LocationSearchContext);
+  const { actionsLayer, homeWidget, mapView, setActionsLayer } =
+    React.useContext(LocationSearchContext);
 
   const [layers, setLayers] = React.useState(null);
 
@@ -77,6 +73,7 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
         title: 'Waterbodies',
         listMode: 'hide',
         visible: true,
+        legendEnabled: false,
       });
       setActionsLayer(localActionsLayer);
     }
@@ -186,8 +183,9 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
             }
 
             // handle Waterbody Report page
-            const condition = getWaterbodyCondition(feature.attributes)
-              .condition;
+            const condition = getWaterbodyCondition(
+              feature.attributes,
+            ).condition;
 
             return createWaterbodySymbol({
               condition: condition,

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -928,7 +928,7 @@ export function getHighlightSymbol(geometry, color) {
 
 // helper method used in handleMapZoomChange() for determining a map layer’s listMode
 export function isInScale(layer: any, scale: number) {
-  let isInScale = true;
+  let inScale = true;
   let minScale = 0;
   let maxScale = 0;
 
@@ -970,13 +970,13 @@ export function isInScale(layer: any, scale: number) {
   // check if the map zoom is within scale
   if (minScale > 0 || maxScale > 0) {
     if (maxScale > 0 && minScale > 0) {
-      isInScale = maxScale <= scale && scale <= minScale;
+      inScale = maxScale <= scale && scale <= minScale;
     } else if (maxScale > 0) {
-      isInScale = maxScale <= scale;
+      inScale = maxScale <= scale;
     } else if (minScale > 0) {
-      isInScale = scale <= minScale;
+      inScale = scale <= minScale;
     }
   }
 
-  return isInScale;
+  return inScale;
 }

--- a/app/client/src/components/pages/LocationMap/MapFunctions.js
+++ b/app/client/src/components/pages/LocationMap/MapFunctions.js
@@ -925,3 +925,58 @@ export function getHighlightSymbol(geometry, color) {
 
   return symbol;
 }
+
+// helper method used in handleMapZoomChange() for determining a map layer’s listMode
+export function isInScale(layer: any, scale: number) {
+  let isInScale = true;
+  let minScale = 0;
+  let maxScale = 0;
+
+  // get the extreme min and max scales of the layer
+  if (layer.sublayers && layer.sourceJSON) {
+    // get sublayers included in the parentlayer
+    // note: the sublayer has maxScale and minScale, but these are always 0
+    //       even if the sublayer does actually have a min/max scale.
+    const sublayerIds = [];
+    layer.sublayers.forEach((sublayer) => {
+      sublayerIds.push(sublayer.id);
+    });
+
+    // get the min/max scale from the sourceJSON
+    layer.sourceJSON.layers.forEach((sourceLayer) => {
+      if (!sublayerIds.includes(sourceLayer.id)) return;
+
+      if (sourceLayer.minScale === 0 || sourceLayer.minScale > minScale) {
+        minScale = sourceLayer.minScale;
+      }
+      if (sourceLayer.maxScale === 0 || sourceLayer.maxScale < maxScale) {
+        maxScale = sourceLayer.maxScale;
+      }
+    });
+  } else if (layer.layers) {
+    // get the min/max scale from the sourceJSON
+    layer.layers.forEach((subLayer) => {
+      if (subLayer.minScale === 0 || subLayer.minScale > minScale) {
+        minScale = subLayer.minScale;
+      }
+      if (subLayer.maxScale === 0 || subLayer.maxScale < maxScale) {
+        maxScale = subLayer.maxScale;
+      }
+    });
+  } else {
+    ({ maxScale, minScale } = layer);
+  }
+
+  // check if the map zoom is within scale
+  if (minScale > 0 || maxScale > 0) {
+    if (maxScale > 0 && minScale > 0) {
+      isInScale = maxScale <= scale && scale <= minScale;
+    } else if (maxScale > 0) {
+      isInScale = maxScale <= scale;
+    } else if (minScale > 0) {
+      isInScale = scale <= minScale;
+    }
+  }
+
+  return isInScale;
+}

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -669,6 +669,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       id: 'usgsStreamgagesLayer',
       title: 'USGS Streamgages',
       listMode: 'hide',
+      legendEnabled: false,
       fields: [
         { name: 'ObjectID', type: 'oid' },
         { name: 'gageHeight', type: 'string' },
@@ -1037,6 +1038,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       title: 'Waterbodies',
       listMode: 'hide',
       visible: false,
+      legendEnabled: false,
     });
     newWaterbodyLayer.addMany([areasLayer, linesLayer, pointsLayer]);
     setWaterbodyLayer(newWaterbodyLayer);

--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -175,6 +175,10 @@
   display: none;
 }
 
+.esri-legend__message {
+  display: none;
+}
+
 .hidden {
   display: none !important;
 }

--- a/app/client/src/components/pages/LocationMap/mapStyles.css
+++ b/app/client/src/components/pages/LocationMap/mapStyles.css
@@ -168,6 +168,7 @@
 }
 
 .esri-legend {
+  min-height: auto !important;
   max-height: none !important;
 }
 

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -7,11 +7,13 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import PinIcon from 'components/shared/Icons/PinIcon';
 import { StyledErrorBox } from 'components/shared/MessageBoxes';
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
-import { GradientIcon } from 'components/pages/LocationMap/MapFunctions';
+import {
+  GradientIcon,
+  isInScale,
+} from 'components/pages/LocationMap/MapFunctions';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // utils
 import { getSelectedCommunityTab } from 'utils/utils';
-import { isInScale } from 'components/pages/LocationMap/MapFunctions';
 // errors
 import { legendUnavailableError } from 'config/errorMessages';
 // styles
@@ -76,7 +78,7 @@ const ignoreLayers = ['mappedWaterLayer', 'watershedsLayer', 'searchIconLayer'];
 // --- components ---
 type Props = {
   view: Object,
-  displayEsriLegend: Boolean,
+  displayEsriLegend: boolean,
   visibleLayers: Object,
   additionalLegendInfo: Object,
 };

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -103,7 +103,7 @@ function MapLegend({
     });
 
     setWatcher(newWatcher);
-  }, [esriLegendCount, watcher]);
+  }, [esriLegendCount, legendWidget, view, watcher]);
 
   // no legend data
   if (filteredVisibleLayers.length === 0 && esriLegendCount === 0) {

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -11,6 +11,7 @@ import { GradientIcon } from 'components/pages/LocationMap/MapFunctions';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // utils
 import { getSelectedCommunityTab } from 'utils/utils';
+import { isInScale } from 'components/pages/LocationMap/MapFunctions';
 // errors
 import { legendUnavailableError } from 'config/errorMessages';
 // styles
@@ -87,7 +88,7 @@ function MapLegend({
   additionalLegendInfo,
 }: Props) {
   const filteredVisibleLayers = visibleLayers.filter(
-    (layer) => !ignoreLayers.includes(layer.id),
+    (layer) => !ignoreLayers.includes(layer.id) && isInScale(layer, view.scale),
   );
 
   // no legend data

--- a/app/client/src/components/shared/MapLegend/index.js
+++ b/app/client/src/components/shared/MapLegend/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { css } from 'styled-components/macro';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
@@ -9,7 +9,6 @@ import { StyledErrorBox } from 'components/shared/MessageBoxes';
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
 import { GradientIcon } from 'components/pages/LocationMap/MapFunctions';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
-import * as watchUtils from '@arcgis/core/core/watchUtils';
 // utils
 import { getSelectedCommunityTab } from 'utils/utils';
 // errors
@@ -76,14 +75,14 @@ const ignoreLayers = ['mappedWaterLayer', 'watershedsLayer', 'searchIconLayer'];
 // --- components ---
 type Props = {
   view: Object,
-  legendWidget: Object,
+  displayEsriLegend: Boolean,
   visibleLayers: Object,
   additionalLegendInfo: Object,
 };
 
 function MapLegend({
   view,
-  legendWidget,
+  displayEsriLegend,
   visibleLayers,
   additionalLegendInfo,
 }: Props) {
@@ -91,22 +90,8 @@ function MapLegend({
     (layer) => !ignoreLayers.includes(layer.id),
   );
 
-  // Keep track of how many layers are visible in the Esri portion of
-  // the legend.
-  const [watcher, setWatcher] = useState(null);
-  const [esriLegendCount, setEsriLegendCount] = useState(0);
-  useEffect(() => {
-    if (watcher) return;
-
-    const newWatcher = watchUtils.watch(view, 'zoom', () => {
-      setEsriLegendCount(legendWidget.activeLayerInfos.length);
-    });
-
-    setWatcher(newWatcher);
-  }, [esriLegendCount, legendWidget, view, watcher]);
-
   // no legend data
-  if (filteredVisibleLayers.length === 0 && esriLegendCount === 0) {
+  if (filteredVisibleLayers.length === 0 && !displayEsriLegend) {
     return (
       <div css={containerStyles}>
         <ul css={listStyles}>There are currently no items to display</ul>

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -136,7 +136,7 @@ function handleMapZoomChange(newVal: number, target: any) {
 
 function updateVisibleLayers(
   view: any,
-  displayEsriLegend: Boolean,
+  displayEsriLegend: boolean,
   hmwLegendNode: Node,
   additionalLegendInfo: Object,
 ) {
@@ -505,7 +505,7 @@ function MapWidgets({
     });
 
     // Create an observer instance linked to the callback function
-    const observer = new MutationObserver((mutationsList, observer) => {
+    const observer = new MutationObserver((mutationsList, observerParam) => {
       const esriMessages = esriLegendNode
         ? esriLegendNode.querySelectorAll('.esri-legend__message')
         : [];
@@ -917,23 +917,6 @@ function MapWidgets({
     }
   }, [upstreamWidget, upstreamWidgetDisabled]);
 
-  // watch for changes to upstream layer visibility and update visible layers accordingly
-  useEffect(() => {
-    updateVisibleLayers(
-      view,
-      displayEsriLegend,
-      hmwLegendNode,
-      additionalLegendInfo,
-    );
-  }, [
-    additionalLegendInfo,
-    displayEsriLegend,
-    hmwLegendNode,
-    upstreamLayerVisible,
-    view,
-    visibleLayers,
-  ]);
-
   // create upstream widget
   const [
     upstreamWidgetCreated,
@@ -1282,6 +1265,7 @@ function MapWidgets({
     allWaterbodiesLayerVisible,
     displayEsriLegend,
     hmwLegendNode,
+    upstreamLayerVisible,
     view,
     visibleLayers,
   ]);

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -136,10 +136,17 @@ function isInScale(layer: any, scale: number) {
 
 function updateVisibleLayers(
   view: any,
+  legendWidget: any,
   hmwLegendNode: Node,
   additionalLegendInfo: Object,
 ) {
-  if (!view || !view.map || !view.map.layers || !view.map.layers.items) {
+  if (
+    !view ||
+    !view.map ||
+    !view.map.layers ||
+    !view.map.layers.items ||
+    !legendWidget
+  ) {
     return;
   }
 
@@ -190,6 +197,7 @@ function updateVisibleLayers(
   ReactDOM.render(
     <MapLegend
       view={view}
+      legendWidget={legendWidget}
       visibleLayers={visibleLayers}
       additionalLegendInfo={additionalLegendInfo}
     />,
@@ -626,6 +634,7 @@ function MapWidgets({
   React.useEffect(() => {
     if (
       !view ||
+      !esriLegend ||
       additionalLegendInfo.status === 'fetching' ||
       layerListWidget
     ) {
@@ -669,10 +678,20 @@ function MapWidgets({
         //only add the item if it has not been added before
         if (!uniqueParentItems.includes(item.title)) {
           uniqueParentItems.push(item.title);
-          updateVisibleLayers(view, hmwLegendNode, additionalLegendInfo);
+          updateVisibleLayers(
+            view,
+            esriLegend,
+            hmwLegendNode,
+            additionalLegendInfo,
+          );
 
           item.watch('visible', function (event) {
-            updateVisibleLayers(view, hmwLegendNode, additionalLegendInfo);
+            updateVisibleLayers(
+              view,
+              esriLegend,
+              hmwLegendNode,
+              additionalLegendInfo,
+            );
             const dict = {
               layerId: item.layer.id,
               visible: item.layer.visible,
@@ -716,7 +735,7 @@ function MapWidgets({
 
     view.ui.add(expandWidget, { position: 'top-right', index: 0 });
     setLayerListWidget(layerlist);
-  }, [hmwLegendNode, view, layerListWidget, additionalLegendInfo]);
+  }, [additionalLegendInfo, esriLegend, hmwLegendNode, layerListWidget, view]);
 
   // Sets up the zoom event handler that is used for determining if layers
   // should be visible at the current zoom level.
@@ -864,12 +883,13 @@ function MapWidgets({
 
   // watch for changes to upstream layer visibility and update visible layers accordingly
   React.useEffect(() => {
-    updateVisibleLayers(view, hmwLegendNode, additionalLegendInfo);
+    updateVisibleLayers(view, esriLegend, hmwLegendNode, additionalLegendInfo);
   }, [
-    view,
+    additionalLegendInfo,
+    esriLegend,
     hmwLegendNode,
     upstreamLayerVisible,
-    additionalLegendInfo,
+    view,
     visibleLayers,
   ]);
 
@@ -1210,12 +1230,13 @@ function MapWidgets({
   // watch for changes to all waterbodies layer visibility and update visible
   // layers accordingly
   React.useEffect(() => {
-    updateVisibleLayers(view, hmwLegendNode, additionalLegendInfo);
+    updateVisibleLayers(view, esriLegend, hmwLegendNode, additionalLegendInfo);
   }, [
-    view,
-    hmwLegendNode,
-    allWaterbodiesLayerVisible,
     additionalLegendInfo,
+    allWaterbodiesLayerVisible,
+    esriLegend,
+    hmwLegendNode,
+    view,
     visibleLayers,
   ]);
 

--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -1,6 +1,12 @@
 // @flow
 
-import React from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import ReactDOM from 'react-dom';
 import { Rnd } from 'react-rnd';
 import styled from 'styled-components';
@@ -239,7 +245,7 @@ function MapWidgets({
   onHomeWidgetRendered = () => {},
 }: Props) {
   const { addDataWidgetVisible, setAddDataWidgetVisible, widgetLayers } =
-    React.useContext(AddDataWidgetContext);
+    useContext(AddDataWidgetContext);
 
   const {
     homeWidget,
@@ -270,7 +276,7 @@ function MapWidgets({
     setAllWaterbodiesWidgetDisabled,
     getAllWaterbodiesWidgetDisabled,
     setMapView,
-  } = React.useContext(LocationSearchContext);
+  } = useContext(LocationSearchContext);
 
   const services = useServicesContext();
 
@@ -280,12 +286,12 @@ function MapWidgets({
   const {
     getFullscreenActive,
     setFullscreenActive, //
-  } = React.useContext(FullscreenContext);
+  } = useContext(FullscreenContext);
 
-  const [mapEventHandlersSet, setMapEventHandlersSet] = React.useState(false);
+  const [mapEventHandlersSet, setMapEventHandlersSet] = useState(false);
 
-  const [popupWatcher, setPopupWatcher] = React.useState(null);
-  React.useEffect(() => {
+  const [popupWatcher, setPopupWatcher] = useState(null);
+  useEffect(() => {
     if (!view || popupWatcher) return;
 
     const watcher = watchUtils.watch(
@@ -321,7 +327,7 @@ function MapWidgets({
   }, [popupWatcher, view]);
 
   // add the layers to the map
-  React.useEffect(() => {
+  useEffect(() => {
     if (!layers || !map) return;
 
     map.removeAll();
@@ -380,7 +386,7 @@ function MapWidgets({
   }, [layers, map, widgetLayers]);
 
   // put the home widget back on the ui after the window is resized
-  React.useEffect(() => {
+  useEffect(() => {
     if (homeWidget) {
       const newHomeWidget = new Home({ view, viewpoint: homeWidget.viewpoint });
       view.ui.add(newHomeWidget, { position: 'top-left', index: 1 });
@@ -390,9 +396,9 @@ function MapWidgets({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Keeps the layer visiblity in sync with the layer list widget visibilities
-  const [toggledLayer, setToggledLayer] = React.useState({});
-  const [lastToggledLayer, setLastToggledLayer] = React.useState({});
-  React.useEffect(() => {
+  const [toggledLayer, setToggledLayer] = useState({});
+  const [lastToggledLayer, setLastToggledLayer] = useState({});
+  useEffect(() => {
     // if the toggled layer didn't change exit early
     if (shallowCompare(toggledLayer, lastToggledLayer)) return;
 
@@ -415,7 +421,7 @@ function MapWidgets({
   }, [toggledLayer, lastToggledLayer, visibleLayers, setVisibleLayers]);
 
   // Creates and adds the home widget to the map
-  React.useEffect(() => {
+  useEffect(() => {
     if (!view || homeWidget) return;
 
     // create the home widget
@@ -429,8 +435,8 @@ function MapWidgets({
   }, [onHomeWidgetRendered, setHomeWidget, view, homeWidget]);
 
   // Creates and adds the scale bar widget to the map
-  const [scaleBar, setScaleBar] = React.useState(null);
-  React.useEffect(() => {
+  const [scaleBar, setScaleBar] = useState(null);
+  useEffect(() => {
     if (!view || scaleBar) return;
 
     const newScaleBar = new ScaleBar({
@@ -450,13 +456,13 @@ function MapWidgets({
   esriLegendTemp.className = 'esri-legend-hidden';
   legendTemp.appendChild(hmwLegendTemp);
   legendTemp.appendChild(esriLegendTemp);
-  const [hmwLegendNode] = React.useState(hmwLegendTemp);
-  const [esriLegendNode] = React.useState(esriLegendTemp);
-  const [legendNode] = React.useState(legendTemp);
+  const [hmwLegendNode] = useState(hmwLegendTemp);
+  const [esriLegendNode] = useState(esriLegendTemp);
+  const [legendNode] = useState(legendTemp);
 
   // Creates and adds the legend widget to the map
-  const [legend, setLegend] = React.useState(null);
-  React.useEffect(() => {
+  const [legend, setLegend] = useState(null);
+  useEffect(() => {
     if (!view || legend) return;
 
     const newLegend = new Expand({
@@ -473,8 +479,8 @@ function MapWidgets({
   }, [view, legend, legendNode]);
 
   // Create the layer list toolbar widget
-  const [esriLegend, setEsriLegend] = React.useState(null);
-  React.useEffect(() => {
+  const [esriLegend, setEsriLegend] = useState(null);
+  useEffect(() => {
     if (!view || esriLegend) return;
 
     // create the layer list using the same styles and structure as the
@@ -489,7 +495,7 @@ function MapWidgets({
   }, [view, esriLegend, esriLegendNode]);
 
   // Update the list of layers in the esri portion of the legend widget
-  React.useEffect(() => {
+  useEffect(() => {
     if (!esriLegend) return;
 
     // build the list of layers for the widget and update
@@ -509,9 +515,9 @@ function MapWidgets({
   }, [widgetLayers, esriLegend, visibleLayers]);
 
   // Creates and adds the legend widget to the map
-  const rnd = React.useRef();
-  const [addDataWidget, setAddDataWidget] = React.useState(null);
-  React.useEffect(() => {
+  const rnd = useRef();
+  const [addDataWidget, setAddDataWidget] = useState(null);
+  useEffect(() => {
     if (!view?.ui || addDataWidget) return;
 
     const node = document.createElement('div');
@@ -562,7 +568,7 @@ function MapWidgets({
     addDataWidgetVisibleParam,
     setAddDataWidgetVisibleParam,
   }) {
-    const [hover, setHover] = React.useState(false);
+    const [hover, setHover] = useState(false);
 
     return (
       <div
@@ -594,12 +600,12 @@ function MapWidgets({
   // Fetch additional legend information. Data is stored in a dictionary
   // where the key is the layer id.
   const [additioanlLegendInitialized, setAdditionalLegendInitialized] =
-    React.useState(false);
-  const [additionalLegendInfo, setAdditionalLegendInfo] = React.useState({
+    useState(false);
+  const [additionalLegendInfo, setAdditionalLegendInfo] = useState({
     status: 'fetching',
     data: {},
   });
-  React.useState(() => {
+  useState(() => {
     if (additioanlLegendInitialized) return;
 
     setAdditionalLegendInitialized(true);
@@ -630,8 +636,8 @@ function MapWidgets({
   }, [additioanlLegendInitialized, services]);
 
   // Creates and adds the basemap/layer list widget to the map
-  const [layerListWidget, setLayerListWidget] = React.useState(null);
-  React.useEffect(() => {
+  const [layerListWidget, setLayerListWidget] = useState(null);
+  useEffect(() => {
     if (
       !view ||
       !esriLegend ||
@@ -739,7 +745,7 @@ function MapWidgets({
 
   // Sets up the zoom event handler that is used for determining if layers
   // should be visible at the current zoom level.
-  React.useEffect(() => {
+  useEffect(() => {
     if (!view || mapEventHandlersSet) return;
 
     // setup map event handlers
@@ -758,7 +764,7 @@ function MapWidgets({
     setMapEventHandlersSet(true);
   }, [view, mapEventHandlersSet, basemap, setBasemap, map]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!layers || layers.length === 0) return;
 
     //build a list of layers that we care about
@@ -804,7 +810,7 @@ function MapWidgets({
   // however ESRI always leaves one layer behind that has a listMode equal
   // to hide. The other part of this bug, is if you build a new collection
   // of operationalItems then the layer loading indicators no longer work.
-  React.useEffect(() => {
+  useEffect(() => {
     if (!layerListWidget) return;
 
     const numOperationalItems = layerListWidget.operationalItems.items.length;
@@ -820,8 +826,8 @@ function MapWidgets({
   const [
     fullScreenWidgetCreated,
     setFullScreenWidgetCreated, //
-  ] = React.useState(false);
-  React.useEffect(() => {
+  ] = useState(false);
+  useEffect(() => {
     if (fullScreenWidgetCreated) return;
 
     // create the basemap/layers widget
@@ -848,7 +854,7 @@ function MapWidgets({
 
   // watch for location changes and disable/enable the upstream widget accordingly
   // widget should only be displayed on valid Community page location
-  React.useEffect(() => {
+  useEffect(() => {
     if (!upstreamWidget) return;
 
     if (!window.location.pathname.includes('/community')) {
@@ -867,7 +873,7 @@ function MapWidgets({
     setUpstreamWidgetDisabled(false);
   }, [huc12, upstreamWidget, setUpstreamWidgetDisabled]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!upstreamWidget || !window.location.pathname.includes('/community')) {
       return;
     }
@@ -882,7 +888,7 @@ function MapWidgets({
   }, [upstreamWidget, upstreamWidgetDisabled]);
 
   // watch for changes to upstream layer visibility and update visible layers accordingly
-  React.useEffect(() => {
+  useEffect(() => {
     updateVisibleLayers(view, esriLegend, hmwLegendNode, additionalLegendInfo);
   }, [
     additionalLegendInfo,
@@ -897,8 +903,8 @@ function MapWidgets({
   const [
     upstreamWidgetCreated,
     setUpstreamWidgetCreated, //
-  ] = React.useState(false);
-  React.useEffect(() => {
+  ] = useState(false);
+  useEffect(() => {
     if (upstreamWidgetCreated || !view || !view.ui) return;
 
     const node = document.createElement('div');
@@ -965,11 +971,11 @@ function MapWidgets({
     setUpstreamWidgetDisabled,
     setUpstreamLayerVisible,
   }: upstreamProps) {
-    const [hover, setHover] = React.useState(false);
-    const [lastHuc12, setLastHuc12] = React.useState('');
+    const [hover, setHover] = useState(false);
+    const [lastHuc12, setLastHuc12] = useState('');
 
     // store loading state to Upstream Watershed map widget icon
-    const [upstreamLoading, setUpstreamLoading] = React.useState(false);
+    const [upstreamLoading, setUpstreamLoading] = useState(false);
 
     const currentHuc12 = getHuc12();
 
@@ -1022,7 +1028,7 @@ function MapWidgets({
     );
   }
 
-  const retrieveUpstreamWatershed = React.useCallback(
+  const retrieveUpstreamWatershed = useCallback(
     (
       getWatershedName,
       currentHuc12,
@@ -1175,13 +1181,13 @@ function MapWidgets({
     [view, services.data.upstreamWatershed],
   );
 
-  const [allWaterbodiesWidget, setAllWaterbodiesWidget] = React.useState(null);
+  const [allWaterbodiesWidget, setAllWaterbodiesWidget] = useState(null);
   const [allWaterbodiesLayerVisible, setAllWaterbodiesLayerVisible] =
-    React.useState(true);
+    useState(true);
 
   // watch for location changes and disable/enable the all waterbodies widget
   // accordingly widget should only be displayed on valid Community page location
-  React.useEffect(() => {
+  useEffect(() => {
     if (!allWaterbodiesWidget) return;
 
     if (!window.location.pathname.includes('/community')) {
@@ -1210,7 +1216,7 @@ function MapWidgets({
   ]);
 
   // disable the all waterbodies widget if on the community home page
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       !allWaterbodiesWidget ||
       !window.location.pathname.includes('/community')
@@ -1229,7 +1235,7 @@ function MapWidgets({
 
   // watch for changes to all waterbodies layer visibility and update visible
   // layers accordingly
-  React.useEffect(() => {
+  useEffect(() => {
     updateVisibleLayers(view, esriLegend, hmwLegendNode, additionalLegendInfo);
   }, [
     additionalLegendInfo,
@@ -1244,8 +1250,8 @@ function MapWidgets({
   const [
     allWaterbodiesWidgetCreated,
     setAllWaterbodiesWidgetCreated, //
-  ] = React.useState(false);
-  React.useEffect(() => {
+  ] = useState(false);
+  useEffect(() => {
     if (allWaterbodiesWidgetCreated || !view || !view.ui) return;
 
     const node = document.createElement('div');
@@ -1280,12 +1286,11 @@ function MapWidgets({
     getDisabled,
     mapView,
   }: allWaterbodiesProps) {
-    const [firstLoad, setFirstLoad] = React.useState(true);
-    const [hover, setHover] = React.useState(false);
+    const [firstLoad, setFirstLoad] = useState(true);
+    const [hover, setHover] = useState(false);
 
     // store loading state to Upstream Watershed map widget icon
-    const [allWaterbodiesLoading, setAllWaterbodiesLoading] =
-      React.useState(false);
+    const [allWaterbodiesLoading, setAllWaterbodiesLoading] = useState(false);
 
     // create a watcher to control the loading spinner for the widget
     if (firstLoad) {
@@ -1451,7 +1456,7 @@ function ExpandCollapse({
   setFullscreenActive,
   mapViewSetter,
 }: ExpandeCollapseProps) {
-  const [hover, setHover] = React.useState(false);
+  const [hover, setHover] = useState(false);
 
   return (
     <div

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import type { Node } from 'react';
 import styled from 'styled-components';
 import StickyBox from 'react-sticky-box';
@@ -63,7 +63,7 @@ function StateMap({
 }: Props) {
   const services = useServicesContext();
 
-  const { selectedGraphic } = React.useContext(MapHighlightContext);
+  const { selectedGraphic } = useContext(MapHighlightContext);
 
   const {
     mapView,
@@ -80,19 +80,19 @@ function StateMap({
 
     homeWidget,
     resetData,
-  } = React.useContext(LocationSearchContext);
+  } = useContext(LocationSearchContext);
 
-  const [layers, setLayers] = React.useState(null);
+  const [layers, setLayers] = useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [stateMapLoadError, setStateMapLoadError] = React.useState(false);
+  const [stateMapLoadError, setStateMapLoadError] = useState(false);
 
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight(false);
 
   // Initializes the layers
-  const [layersInitialized, setLayersInitialized] = React.useState(false);
-  React.useEffect(() => {
+  const [layersInitialized, setLayersInitialized] = useState(false);
+  useEffect(() => {
     if (!getSharedLayers || layersInitialized) return;
 
     const popupTemplate = {
@@ -190,19 +190,19 @@ function StateMap({
   ]);
 
   // Function for resetting the LocationSearch context when the map is removed
-  React.useEffect(() => {
+  useEffect(() => {
     return function cleanup() {
       resetData();
     };
   }, [resetData]);
 
-  const [lastFilter, setLastFilter] = React.useState('');
+  const [lastFilter, setLastFilter] = useState('');
 
   // cDU
   // detect when user changes their search
-  const [homeWidgetSet, setHomeWidgetSet] = React.useState(false);
-  const [mapLoading, setMapLoading] = React.useState(true);
-  React.useEffect(() => {
+  const [homeWidgetSet, setHomeWidgetSet] = useState(false);
+  const [mapLoading, setMapLoading] = useState(true);
+  useEffect(() => {
     // query geocode server for every new search
     if (
       filter !== lastFilter &&
@@ -298,11 +298,11 @@ function StateMap({
 
   // Used to tell if the homewidget has been set to the selected state.
   // This will reset the value when the user selects a different state.
-  React.useEffect(() => {
+  useEffect(() => {
     setHomeWidgetSet(false);
   }, [activeState]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // scroll community content into view
     // get community content DOM node to scroll page when form is submitted
 
@@ -327,8 +327,8 @@ function StateMap({
   }, [layout, windowHeight, windowWidth]);
 
   // calculate height of div holding the footer content
-  const [footerHeight, setFooterHeight] = React.useState(0);
-  const measuredRef = React.useCallback((node) => {
+  const [footerHeight, setFooterHeight] = useState(0);
+  const measuredRef = useCallback((node) => {
     if (!node) return;
     setFooterHeight(node.getBoundingClientRect().height);
   }, []);

--- a/app/client/src/components/shared/StateMap/index.js
+++ b/app/client/src/components/shared/StateMap/index.js
@@ -168,6 +168,7 @@ function StateMap({
       title: 'Waterbodies',
       listMode: 'hide',
       visible: false,
+      legendEnabled: false,
     });
     waterbodyLayer.addMany([areasLayer, linesLayer, pointsLayer]);
     setWaterbodyLayer(waterbodyLayer);

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -943,6 +943,7 @@ function useSharedLayers() {
       renderer: wsioHealthIndexRenderer,
       listMode: 'show',
       visible: false,
+      legendEnabled: false,
       popupTemplate: {
         title: getTitle,
         content: getTemplate,
@@ -988,6 +989,7 @@ function useSharedLayers() {
       id: 'protectedAreasLayer',
       title: 'Protected Areas',
       url: services.data.protectedAreasDatabase,
+      legendEnabled: false,
       sublayers: [
         {
           id: 0,
@@ -1010,6 +1012,7 @@ function useSharedLayers() {
       id: 'protectedAreasHighlightLayer',
       title: 'Protected Areas Highlight Layer',
       listMode: 'hide',
+      legendEnabled: false,
     });
 
     setProtectedAreasHighlightLayer(protectedAreasHighlightLayer);
@@ -1035,6 +1038,7 @@ function useSharedLayers() {
       renderer: wildScenicRiversRenderer,
       listMode: 'hide',
       visible: false,
+      legendEnabled: false,
       popupTemplate: {
         title: getTitle,
         content: getTemplate,
@@ -1165,6 +1169,7 @@ function useSharedLayers() {
       title: 'Tribal Areas',
       listMode: 'show',
       visible: false,
+      legendEnabled: false,
       layers: [
         alaskaNativeVillages,
         otherTribes,
@@ -1193,6 +1198,7 @@ function useSharedLayers() {
       title: 'Congressional Districts',
       listMode: 'hide-children',
       visible: false,
+      legendEnabled: false,
       renderer: {
         type: 'simple',
         symbol: {
@@ -1232,6 +1238,7 @@ function useSharedLayers() {
       title: 'County',
       listMode: 'show',
       visible: false,
+      legendEnabled: false,
       renderer: {
         type: 'simple',
         symbol: {
@@ -1260,6 +1267,7 @@ function useSharedLayers() {
       sublayers: [{ id: 0 }],
       listMode: 'hide',
       visible: false,
+      legendEnabled: false,
     });
   }
 
@@ -1358,6 +1366,7 @@ function useSharedLayers() {
       title: 'Demographic Indicators',
       listMode: 'show',
       visible: false,
+      legendEnabled: false,
       layers: [
         ejLessThanHS,
         ejMinority,
@@ -1446,6 +1455,7 @@ function useSharedLayers() {
       title: 'All Waterbodies',
       listMode: 'hide',
       visible: true,
+      legendEnabled: false,
       minScale,
       opacity: 0.3,
     });


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-107
* https://jira.epa.gov/browse/HMW-117 (duplicate to be deleted)

## Main Changes:
* Fixed various issues with the legend
  1. Esri "No legend" text being displayed when there are custom HMW layers being shown in the legend.
  2. HMW "There are currently no items to display" text being displayed when there are layers being shown from the Add Data Widget.
  3. HMW layers being shown in the legend, even though the map zoom level is outside of the layer's zoom threshold. 
  4. Sometimes layers are duplicated in the legend. Basically, we were displaying our custom legend for the layer and esri was displaying the out of the box version.

Implementation Note: I couldn't find a good ESRI event to hook into to see if the Esri portion of the widget had anything to display. I ended up using MutationObserver to detect when Esri adds/removes the "No legend" text to/from the DOM and used this information to know whether the Esri portion of the legend was actually displaying anything. 

## Steps To Test:
* Issue 1 and 4
  1. Navigate to http://localhost:3000/community
  2. Open the Add Data Widget
  3. Add the "USA Flood Hazard Areas" layer
  4. Open the legend
  5. Verify the legend only says "There are currently no items to display"
      * NOTE: In production this currently says "There are currently no items to display" and "No legend" (simulates issue 1)
  6. Open the layer list 
  7. Turn on the "County" layer
  8. Verify the legend only displays "County" once
      * NOTE: In production this will display "County" twice (simulates issue 4)
  9. Zoom in until the "USA Flood Hazard Areas" layer is displayed
  10. Remove the "USA Flood Hazard Areas" layer
  11. Re-add the "USA Flood Hazard Areas" layer
  12. Zoom out until the "USA Flood Hazard Areas" layer is no longer visible
  13. Open the legend
  14. Verify the legend only says "County" once
      * NOTE: In production this will display "County" and "No legend" (simulates issue 1)

## Steps To Test:
* Issue 2
  1. Navigate to http://localhost:3000/community or refresh the page
  2. Open the Add Data Widget
  3. Add the "USA Flood Hazard Areas" layer
  4. Zoom in until the "USA Flood Hazard Areas" layer is displayed
  5. Open the legend
  6. Verify the legend only displays info for the "USA Flood Hazard Areas" layer
      * NOTE: In production this will display "There are currently no items to display" and "USA Flood Hazard Areas" layer info.
  
## Steps To Test:
* Issue 3
  1. Navigate to http://localhost:3000/community/dc/overview
  2. Turn off the "Waterbodies" layer and leave the "Surrounding Waterbodies" layer on
  3. Zoom out until the "Surrounding Waterbodies" layer is no longer visible
  4. Open the legend 
  5. Verify the legend only displays "Searched Location" and "HUC12 Boundaries"

