### PR TITLE
HMW-127 Force popups to always be expanded.

### DIFF
--- a/app/client/src/components/shared/Map/index.js
+++ b/app/client/src/components/shared/Map/index.js
@@ -23,13 +23,8 @@ type Props = {
 };
 
 function Map({ layers = null, startingExtent = null, children }: Props) {
-  const {
-    initialExtent,
-    highlightOptions,
-    getBasemap,
-    mapView,
-    setMapView,
-  } = useContext(LocationSearchContext);
+  const { initialExtent, highlightOptions, getBasemap, mapView, setMapView } =
+    useContext(LocationSearchContext);
 
   const [map, setMap] = useState(null);
 
@@ -50,6 +45,9 @@ function Map({ layers = null, startingExtent = null, children }: Props) {
       map: esriMap,
       extent: startingExtent ?? initialExtent,
       highlightOptions,
+      popup: {
+        collapseEnabled: false,
+      },
     });
 
     setMapView(view);


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-127

## Main Changes:
* Updated code so that popups are always expanded.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the layer list
3. Turn on the "Tribal Areas" layer
4. Click on one of the circles over Alaska
5. Shrink the window until the popup docks on the bottom
6. Click on several items and verify the popup is always expanded (i.e., doesn't look like screenshot below)

![image](https://user-images.githubusercontent.com/46329268/153464952-30ac3d1c-3075-4234-891e-b053090ddcd9.png)
