### PR TITLE
Feature/112 filter out public comment assessments

### DIFF
--- a/app/client/src/components/pages/Community/components/tabs/Overview.js
+++ b/app/client/src/components/pages/Community/components/tabs/Overview.js
@@ -88,7 +88,6 @@ const toggleStyles = css`
 function Overview() {
   const {
     cipSummary,
-    assessmentUnitCount, // TODO: determine if this is needed...
     monitoringLocations,
     usgsStreamgages,
     permittedDischargers,
@@ -270,8 +269,8 @@ function Overview() {
           ) : (
             <>
               <span css={keyMetricNumberStyles}>
-                {Boolean(assessmentUnitCount) && cipSummary.status === 'success'
-                  ? assessmentUnitCount.toLocaleString()
+                {Boolean(waterbodies.length) && cipSummary.status === 'success'
+                  ? waterbodies.length.toLocaleString()
                   : 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Waterbodies</p>

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -209,44 +209,42 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         return [];
       }
 
-      return [];
-
       // The code below is commented out because, these assessments do not
       // have a reportingCycle. So there is no way to know if any of these
       // assessments will match up with the reportingCycle of the organization
-      // return idsWithNoAssessmentData.map((id) => {
-      //   const assessmentUnitName = matchAssessmentUnitName(
-      //     id,
-      //     allAssessmentUnits,
-      //   );
+      return idsWithNoAssessmentData.map((id) => {
+        const assessmentUnitName = matchAssessmentUnitName(
+          id,
+          allAssessmentUnits,
+        );
 
-      //   const matchingItem = assessmentUnitServiceData.items.find((item) => {
-      //     return item.assessmentUnits.find(
-      //       (assessmentUnit) => assessmentUnit.assessmentUnitIdentifier === id,
-      //     );
-      //   });
+        const matchingItem = assessmentUnitServiceData.items.find((item) => {
+          return item.assessmentUnits.find(
+            (assessmentUnit) => assessmentUnit.assessmentUnitIdentifier === id,
+          );
+        });
 
-      //   const orgID = matchingItem && matchingItem.organizationIdentifier;
-      //   const orgName = matchingItem && matchingItem.organizationName;
-      //   const orgType = matchingItem && matchingItem.organizationTypeText;
+        const orgID = matchingItem && matchingItem.organizationIdentifier;
+        const orgName = matchingItem && matchingItem.organizationName;
+        const orgType = matchingItem && matchingItem.organizationTypeText;
 
-      //   return {
-      //     limited: true,
-      //     attributes: {
-      //       assessmentunitidentifier: id,
-      //       assessmentunitname: assessmentUnitName || 'Unknown',
-      //       organizationid: orgID,
-      //       reportingcycle: null,
-      //       overallstatus: 'Condition Unknown',
-      //       orgtype: orgType,
-      //       organizationname: orgName,
-      //       drinkingwater_use: null,
-      //       fishconsumption_use: null,
-      //       ecological_use: null,
-      //       recreation_use: null,
-      //     },
-      //   };
-      // });
+        return {
+          limited: true,
+          attributes: {
+            assessmentunitidentifier: id,
+            assessmentunitname: assessmentUnitName || 'Unknown',
+            organizationid: orgID,
+            reportingcycle: null,
+            overallstatus: 'Condition Unknown',
+            orgtype: orgType,
+            organizationname: orgName,
+            drinkingwater_use: null,
+            fishconsumption_use: null,
+            ecological_use: null,
+            recreation_use: null,
+          },
+        };
+      });
     },
     [],
   );

--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -229,6 +229,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         const orgType = matchingItem && matchingItem.organizationTypeText;
 
         return {
+          includeInOutput: true,
           limited: true,
           attributes: {
             assessmentunitidentifier: id,
@@ -329,6 +330,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       const orgType = res[0].organizationTypeText;
       const organizationName = res[0].organizationName;
       const cycleYear = res[0].reportingCycleText;
+      let includeInOutput = true;
 
       // get organization
       const organization = organizations.data.features.find(
@@ -337,8 +339,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       if (!organization?.attributes?.reportingcycle) return [];
 
       // check if record cycle year matches the organization cycle year
+      // if they don't match exclude it from the output
       const orgCycleYear = organization.attributes.reportingcycle;
-      if (orgCycleYear.toString() !== cycleYear.toString()) return [];
+      if (orgCycleYear.toString() !== cycleYear.toString()) {
+        includeInOutput = false;
+      }
 
       return res[0].assessments.map((assessment) => {
         const assessmentUnitName = matchAssessmentUnitName(
@@ -366,6 +371,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         const parametersObject = createParametersObject(parameterList);
 
         return {
+          includeInOutput,
           limited: true,
           attributes: {
             organizationid: orgId,
@@ -505,7 +511,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               orphans = orphans.concat(simpleFeatures);
             }
           }
-          setOrphanFeatures({ features: orphans, status: 'success' });
+
+          // filter out the orphans that arn't marked for includeInOutput
+          setOrphanFeatures({
+            features: orphans.filter((orphan) => orphan.includeInOutput),
+            status: 'success',
+          });
         })
         .catch((err) => {
           console.error(err);

--- a/app/client/src/contexts/LookupFiles.js
+++ b/app/client/src/contexts/LookupFiles.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { Node } from 'react';
 // utilities
-import { lookupFetch } from 'utils/fetchUtils';
+import { fetchCheck, lookupFetch } from 'utils/fetchUtils';
 
 // Common function for setting the context/state of lookup files.
 function getLookupFile(filename: string, setVariable: Function) {
@@ -99,6 +99,10 @@ function LookupFilesProvider({ children }: Props) {
     status: 'fetching',
     data: {},
   });
+  const [organizations, setOrganizations] = React.useState({
+    status: 'fetching',
+    data: {},
+  });
 
   return (
     <LookupFilesContext.Provider
@@ -119,6 +123,8 @@ function LookupFilesProvider({ children }: Props) {
         setNotifications,
         services,
         setServices,
+        organizations,
+        setOrganizations,
       }}
     >
       {children}
@@ -129,9 +135,8 @@ function LookupFilesProvider({ children }: Props) {
 // Custom hook for the documentOrder.json lookup file.
 let documentOrderInitialized = false; // global var for ensuring fetch only happens once
 function useDocumentOrderContext() {
-  const { documentOrder, setDocumentOrder } = React.useContext(
-    LookupFilesContext,
-  );
+  const { documentOrder, setDocumentOrder } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!documentOrderInitialized) {
@@ -145,9 +150,8 @@ function useDocumentOrderContext() {
 // Custom hook for the reportStatusMapping.json lookup file.
 let reportStatusMappingInitialized = false; // global var for ensuring fetch only happens once
 function useReportStatusMappingContext() {
-  const { reportStatusMapping, setReportStatusMapping } = React.useContext(
-    LookupFilesContext,
-  );
+  const { reportStatusMapping, setReportStatusMapping } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!reportStatusMappingInitialized) {
@@ -161,9 +165,8 @@ function useReportStatusMappingContext() {
 // Custom hook for the stateNationalUses.json lookup file.
 let stateNationalUsesInitialized = false; // global var for ensuring fetch only happens once
 function useStateNationalUsesContext() {
-  const { stateNationalUses, setStateNationalUses } = React.useContext(
-    LookupFilesContext,
-  );
+  const { stateNationalUses, setStateNationalUses } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!stateNationalUsesInitialized) {
@@ -177,9 +180,8 @@ function useStateNationalUsesContext() {
 // Custom hook for the surveyMapping.json lookup file.
 let surveyMappingInitialized = false; // global var for ensuring fetch only happens once
 function useSurveyMappingContext() {
-  const { surveyMapping, setSurveyMapping } = React.useContext(
-    LookupFilesContext,
-  );
+  const { surveyMapping, setSurveyMapping } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!surveyMappingInitialized) {
@@ -193,9 +195,8 @@ function useSurveyMappingContext() {
 // Custom hook for the waterTypeOptions.json lookup file.
 let waterTypeOptionsInitialized = false; // global var for ensuring fetch only happens once
 function useWaterTypeOptionsContext() {
-  const { waterTypeOptions, setWaterTypeOptions } = React.useContext(
-    LookupFilesContext,
-  );
+  const { waterTypeOptions, setWaterTypeOptions } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!waterTypeOptionsInitialized) {
@@ -223,9 +224,8 @@ function useNarsContext() {
 // Custom hook for the messages.json file.
 let notificationsInitialized = false; // global var for ensuring fetch only happens once
 function useNotificationsContext() {
-  const { notifications, setNotifications } = React.useContext(
-    LookupFilesContext,
-  );
+  const { notifications, setNotifications } =
+    React.useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!notificationsInitialized) {
@@ -289,15 +289,45 @@ function useServicesContext() {
   return services;
 }
 
+// Custom hook for the services.json file.
+let organizationsInitialized = false; // global var for ensuring fetch only happens once
+function useOrganizationsContext() {
+  const { services, organizations, setOrganizations } =
+    React.useContext(LookupFilesContext);
+
+  // fetch the lookup file if necessary
+  if (!organizationsInitialized && services.status === 'success') {
+    organizationsInitialized = true;
+
+    // fetch the lookup file
+    const outFields = ['organizationid', 'orgtype', 'reportingcycle', 'state'];
+    fetchCheck(
+      `${
+        services.data.waterbodyService.controlTable
+      }/query?where=1%3D1&outFields=${outFields.join('%2C')}&f=json`,
+    )
+      .then((data) => {
+        setOrganizations({ status: 'success', data });
+      })
+      .catch((err) => {
+        console.error(err);
+        setOrganizations({ status: 'failure', data: err });
+      });
+  }
+
+  return organizations;
+}
+
 export {
+  LookupFilesContext,
   LookupFilesProvider,
   useDocumentOrderContext,
+  useNarsContext,
+  useNotificationsContext,
+  useOrganizationsContext,
   useReportStatusMappingContext,
+  useServicesContext,
   useStateNationalUsesContext,
   useSurveyMappingContext,
   useWaterTypeOptionsContext,
-  useNarsContext,
-  useNotificationsContext,
-  useServicesContext,
-  LookupFilesContext,
 };

--- a/app/client/src/contexts/LookupFiles.js
+++ b/app/client/src/contexts/LookupFiles.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import type { Node } from 'react';
 // utilities
 import { fetchCheck, lookupFetch } from 'utils/fetchUtils';
@@ -43,7 +43,7 @@ type LookupFiles = {
   setServices: Function,
 };
 
-const LookupFilesContext: Object = React.createContext<LookupFiles>({
+const LookupFilesContext: Object = createContext<LookupFiles>({
   documentOrder: { status: 'fetching', data: null },
   setDocumentOrder: () => {},
   reportStatusMapping: { status: 'fetching', data: null },
@@ -67,39 +67,39 @@ type Props = {
 };
 
 function LookupFilesProvider({ children }: Props) {
-  const [documentOrder, setDocumentOrder] = React.useState({
+  const [documentOrder, setDocumentOrder] = useState({
     status: 'fetching',
     data: {},
   });
-  const [reportStatusMapping, setReportStatusMapping] = React.useState({
+  const [reportStatusMapping, setReportStatusMapping] = useState({
     status: 'fetching',
     data: {},
   });
-  const [stateNationalUses, setStateNationalUses] = React.useState({
+  const [stateNationalUses, setStateNationalUses] = useState({
     status: 'fetching',
     data: [],
   });
-  const [surveyMapping, setSurveyMapping] = React.useState({
+  const [surveyMapping, setSurveyMapping] = useState({
     status: 'fetching',
     data: [],
   });
-  const [waterTypeOptions, setWaterTypeOptions] = React.useState({
+  const [waterTypeOptions, setWaterTypeOptions] = useState({
     status: 'fetching',
     data: {},
   });
-  const [nars, setNars] = React.useState({
+  const [nars, setNars] = useState({
     status: 'fetching',
     data: {},
   });
-  const [notifications, setNotifications] = React.useState({
+  const [notifications, setNotifications] = useState({
     status: 'fetching',
     data: [],
   });
-  const [services, setServices] = React.useState({
+  const [services, setServices] = useState({
     status: 'fetching',
     data: {},
   });
-  const [organizations, setOrganizations] = React.useState({
+  const [organizations, setOrganizations] = useState({
     status: 'fetching',
     data: {},
   });
@@ -135,8 +135,7 @@ function LookupFilesProvider({ children }: Props) {
 // Custom hook for the documentOrder.json lookup file.
 let documentOrderInitialized = false; // global var for ensuring fetch only happens once
 function useDocumentOrderContext() {
-  const { documentOrder, setDocumentOrder } =
-    React.useContext(LookupFilesContext);
+  const { documentOrder, setDocumentOrder } = useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!documentOrderInitialized) {
@@ -151,7 +150,7 @@ function useDocumentOrderContext() {
 let reportStatusMappingInitialized = false; // global var for ensuring fetch only happens once
 function useReportStatusMappingContext() {
   const { reportStatusMapping, setReportStatusMapping } =
-    React.useContext(LookupFilesContext);
+    useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!reportStatusMappingInitialized) {
@@ -166,7 +165,7 @@ function useReportStatusMappingContext() {
 let stateNationalUsesInitialized = false; // global var for ensuring fetch only happens once
 function useStateNationalUsesContext() {
   const { stateNationalUses, setStateNationalUses } =
-    React.useContext(LookupFilesContext);
+    useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!stateNationalUsesInitialized) {
@@ -180,8 +179,7 @@ function useStateNationalUsesContext() {
 // Custom hook for the surveyMapping.json lookup file.
 let surveyMappingInitialized = false; // global var for ensuring fetch only happens once
 function useSurveyMappingContext() {
-  const { surveyMapping, setSurveyMapping } =
-    React.useContext(LookupFilesContext);
+  const { surveyMapping, setSurveyMapping } = useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!surveyMappingInitialized) {
@@ -196,7 +194,7 @@ function useSurveyMappingContext() {
 let waterTypeOptionsInitialized = false; // global var for ensuring fetch only happens once
 function useWaterTypeOptionsContext() {
   const { waterTypeOptions, setWaterTypeOptions } =
-    React.useContext(LookupFilesContext);
+    useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!waterTypeOptionsInitialized) {
@@ -210,7 +208,7 @@ function useWaterTypeOptionsContext() {
 // Custom hook for the waterTypeOptions.json lookup file.
 let narsInitialized = false; // global var for ensuring fetch only happens once
 function useNarsContext() {
-  const { nars, setNars } = React.useContext(LookupFilesContext);
+  const { nars, setNars } = useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!narsInitialized) {
@@ -224,8 +222,7 @@ function useNarsContext() {
 // Custom hook for the messages.json file.
 let notificationsInitialized = false; // global var for ensuring fetch only happens once
 function useNotificationsContext() {
-  const { notifications, setNotifications } =
-    React.useContext(LookupFilesContext);
+  const { notifications, setNotifications } = useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!notificationsInitialized) {
@@ -239,7 +236,7 @@ function useNotificationsContext() {
 // Custom hook for the services.json file.
 let servicesInitialized = false; // global var for ensuring fetch only happens once
 function useServicesContext() {
-  const { services, setServices } = React.useContext(LookupFilesContext);
+  const { services, setServices } = useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!servicesInitialized) {
@@ -293,7 +290,7 @@ function useServicesContext() {
 let organizationsInitialized = false; // global var for ensuring fetch only happens once
 function useOrganizationsContext() {
   const { services, organizations, setOrganizations } =
-    React.useContext(LookupFilesContext);
+    useContext(LookupFilesContext);
 
   // fetch the lookup file if necessary
   if (!organizationsInitialized && services.status === 'success') {

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -233,7 +233,6 @@ type State = {
   searchText: string,
   lastSearchText: string,
   huc12: string,
-  assessmentUnitCount: ?number,
   assessmentUnitIDs: Array<string>,
   watershed: string,
   address: string,
@@ -313,7 +312,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     searchText: '',
     lastSearchText: '',
     huc12: '',
-    assessmentUnitCount: null,
     assessmentUnitIDs: [],
     watershed: '',
     address: '',
@@ -443,9 +441,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     },
     setHuc12: (huc12) => {
       this.setState({ huc12 });
-    },
-    setAssessmentUnitCount: (assessmentUnitCount) => {
-      this.setState({ assessmentUnitCount });
     },
     setAssessmentUnitIDs: (assessmentUnitIDs) => {
       this.setState({ assessmentUnitIDs });
@@ -798,7 +793,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
     resetData: () => {
       this.setState({
         huc12: '',
-        assessmentUnitCount: null,
         assessmentUnitIDs: null,
         watershed: '',
         pointsData: null,
@@ -839,7 +833,6 @@ export class LocationSearchProvider extends React.Component<Props, State> {
       this.setState(
         {
           huc12: '',
-          assessmentUnitCount: null,
           assessmentUnitIDs: null,
           watershed: '',
           pointsData: [],

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -138,8 +138,7 @@ function useWaterbodyFeatures() {
       waterbodyCountMismatch === null ||
       (waterbodyCountMismatch === true &&
         orphanFeatures &&
-        orphanFeatures.status !== 'error' &&
-        orphanFeatures.features.length === 0)
+        orphanFeatures.status === 'fetching')
     ) {
       if (features) setFeatures(null);
       return;

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -13,7 +13,8 @@
     "points": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/0",
     "lines": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/1",
     "areas": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/2",
-    "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4"
+    "summary": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/4",
+    "controlTable": "https://gispub.epa.gov/arcgis/rest/services/OW/ATTAINS_Assessment/MapServer/5"
   },
   "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/savedreport/terms/HMWGlossary",
   "waterQualityPortal": {


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-112

## Main Changes:
* Added code to filter out assessments that are in public comment status. While the assessments service does return a `reportStatusCode` value, we can't use that because there is some delay between the assessments service data being updated and the attains GIS data being updated.

## Steps To Test:
1. Navigate to http://localhost:3000/community/sawyer%20mn/overview
2. Verify the waterbodies count is 14, instead of 27 that is being displayed in production
3. Scroll through list and make sure there are 14 items in the list as well
4. Verify there are no items in the list that are marked as `[Waterbody not visible on map.]`
