### PR TITLE
feature/135_recreation-to-swimming-boating

### DIFF
--- a/app/client/src/components/pages/LocationMap/index.js
+++ b/app/client/src/components/pages/LocationMap/index.js
@@ -376,7 +376,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               assessment.useAttainments,
             ),
             recreation_use: getUseStatus(
-              'Recreation',
+              'Recreation', // Recreation in Attains = Swimming and Boating in HMW
               stateCode,
               assessment.useAttainments,
             ),

--- a/app/client/src/config/attainsToHmwMapping.js
+++ b/app/client/src/config/attainsToHmwMapping.js
@@ -5,7 +5,7 @@ export const useFields = [
   { value: 'drinkingwater_use', label: 'Drinking Water' },
   { value: 'ecological_use', label: 'Aquatic Life' },
   { value: 'fishconsumption_use', label: 'Fish and Shellfish Consumption' },
-  { value: 'recreation_use', label: 'Recreation' },
+  { value: 'recreation_use', label: 'Swimming and Boating' },
   { value: 'other_use', label: 'Other' },
 ];
 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-135

## Main Changes:
* Updated "Recreation" to "Swimming and Boating" on the community page.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Expand waterbodies in the list to the right
3. Verify "Recreation" is now "Swimming and Boating"
    * Note: Some waterbodies will not have all of the evaluated uses
4. Click some waterbodies on the map
5. Verify "Recreation" is now "Swimming and Boating"
    * Note: Some waterbodies will not have all of the evaluated uses
