### PR TITLE
Bugfix/107 legend issues

### DIFF
--- a/app/client/src/components/shared/MapWidgets/index.js
+++ b/app/client/src/components/shared/MapWidgets/index.js
@@ -695,7 +695,7 @@ function MapWidgets({
           uniqueParentItems.push(item.title);
           updateVisibleLayers(
             view,
-            displayEsriLegend,
+            displayEsriLegendNonState,
             hmwLegendNode,
             additionalLegendInfo,
           );


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-107
* Continuation of PR #576 - I kept playing around with that branch after I merged it in and ran into this edge case

## Main Changes:
* Fixed edge case with legend when zooming.

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the Add Data Widget
3. Add the "USA Flood Hazard Areas" layer
4. Zoom in 1 tick at a time until the "USA Flood Hazard Areas" layer is displayed
5. Open the legend
6. Verify the legend only displays info for the "USA Flood Hazard Areas" layer
7. Zoom in 1 tick further
8. Verify the legend only displays info for the "USA Flood Hazard Areas" layer
    * NOTE: On the dev site this will display "There are currently no items to display" and "USA Flood Hazard Areas" layer info.
  
Note: This same issue also occurs (on dev) if after step 4, you just zoom in really far (i.e., town level) and then open the legend. 
