### PR TITLE
HMW-64 Added a try/catch around the server side proxy request logic.

### DIFF
--- a/app/server/app/server/routes/proxy.js
+++ b/app/server/app/server/routes/proxy.js
@@ -47,87 +47,98 @@ module.exports = function (app) {
       return;
     }
 
-    let request_headers = {};
-    if (parsedUrl.toLowerCase().includes('etss.epa.gov')) {
-      request_headers.authorization = 'basic ' + process.env.GLOSSARY_AUTH;
-    } else {
-      if (
-        !app.enabled('isLocal') &&
-        parsedUrl.toLowerCase().includes('://' + req.hostname.toLowerCase()) &&
-        parsedUrl.toLowerCase().includes('/data/')
-      ) {
-        //change out the URL for the internal s3 bucket that support this instance of the application in Cloud.gov
-        var jsonFileName = parsedUrl.split('/data/').pop();
-        parsedUrl = app.get('s3_bucket_url') + '/data/' + jsonFileName;
+    try {
+      let request_headers = {};
+      if (parsedUrl.toLowerCase().includes('etss.epa.gov')) {
+        request_headers.authorization = 'basic ' + process.env.GLOSSARY_AUTH;
+      } else {
+        if (
+          !app.enabled('isLocal') &&
+          parsedUrl
+            .toLowerCase()
+            .includes('://' + req.hostname.toLowerCase()) &&
+          parsedUrl.toLowerCase().includes('/data/')
+        ) {
+          //change out the URL for the internal s3 bucket that support this instance of the application in Cloud.gov
+          var jsonFileName = parsedUrl.split('/data/').pop();
+          parsedUrl = app.get('s3_bucket_url') + '/data/' + jsonFileName;
+        }
       }
-    }
 
-    function deleteTSHeaders(response) {
-      /* The EPA Terminology Services (TS) exposes sensitive 
-        information about its underlying technology. While we 
-        notified the TS Team about this, they have not had time 
-        to address it with the product vendor. Based on this,
-        we're going to programmatically remove them. */
-      delete response.headers['x-powered-by'];
-      delete response.headers['server'];
-      delete response.headers['x-aspnet-version'];
-      // end of EPA TS work around.
+      function deleteTSHeaders(response) {
+        /* The EPA Terminology Services (TS) exposes sensitive 
+          information about its underlying technology. While we 
+          notified the TS Team about this, they have not had time 
+          to address it with the product vendor. Based on this,
+          we're going to programmatically remove them. */
+        delete response.headers['x-powered-by'];
+        delete response.headers['server'];
+        delete response.headers['x-aspnet-version'];
+        // end of EPA TS work around.
 
-      // Disable cache for all proxy requests
-      response.headers['cache-control'] = 'no-cache';
-    }
+        // Disable cache for all proxy requests
+        response.headers['cache-control'] = 'no-cache';
+      }
 
-    axios({
-      method: req.query.method,
-      url: parsedUrl,
-      headers: request_headers,
-      timeout: 10000,
-    })
-      .then((response) => {
-        if (response.status !== 200) {
-          log.error(
-            logger.formatLogMsg(
-              metadataObj,
-              `Non-200 returned from web service. parsedUrl = ${parsedUrl}.`,
-            ),
-          );
-        } else {
-          log.info(
-            logger.formatLogMsg(
-              metadataObj,
-              `Successful request: ${parsedUrl}`,
-            ),
-          );
-        }
-
-        deleteTSHeaders(response);
-        res
-          .status(response.status)
-          .header(response.headers)
-          .send(response.data);
+      axios({
+        method: req.query.method,
+        url: parsedUrl,
+        headers: request_headers,
+        timeout: 10000,
       })
-      .catch((err) => {
-        log.error(
-          logger.formatLogMsg(
-            metadataObj,
-            `Unsuccessful request. parsedUrl = ${parsedUrl}. Detailed error: ${err}`,
-          ),
-        );
-        if (res.headersSent) {
+        .then((response) => {
+          if (response.status !== 200) {
+            log.error(
+              logger.formatLogMsg(
+                metadataObj,
+                `Non-200 returned from web service. parsedUrl = ${parsedUrl}.`,
+              ),
+            );
+          } else {
+            log.info(
+              logger.formatLogMsg(
+                metadataObj,
+                `Successful request: ${parsedUrl}`,
+              ),
+            );
+          }
+
+          deleteTSHeaders(response);
+          res
+            .status(response.status)
+            .header(response.headers)
+            .send(response.data);
+        })
+        .catch((err) => {
           log.error(
             logger.formatLogMsg(
               metadataObj,
-              `Odd header already sent check = ${parsedUrl}. Detailed error: ${err}`,
+              `Unsuccessful request. parsedUrl = ${parsedUrl}. Detailed error: ${err}`,
             ),
           );
-        }
+          if (res.headersSent) {
+            log.error(
+              logger.formatLogMsg(
+                metadataObj,
+                `Odd header already sent check = ${parsedUrl}. Detailed error: ${err}`,
+              ),
+            );
+          }
 
-        deleteTSHeaders(err.response);
-        res
-          .status(err.response.status)
-          .header(err.response.headers)
-          .send(err.response.data);
-      });
+          deleteTSHeaders(err.response);
+          res
+            .status(err.response.status)
+            .header(err.response.headers)
+            .send(err.response.data);
+        });
+    } catch (err) {
+      let msg = 'URL Request Error';
+      log.error(
+        logger.formatLogMsg(metadataObj, `${msg}. parsedUrl = ${parsedUrl}`),
+      );
+      res.status(403).json({ message: msg });
+      return;
+    }
   });
 
   app.use('/proxy', router);


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-126

## Main Changes:
* Wrapped the server side request logic in a try/catch. This was done because a 304 error from the glossary services caused the HMW server side code to crash.

## Steps To Test:
This change shouldn't have any affect, but here is a basic test.
1. Navigate to http://localhost:3000/community/dc/overview
2. Verify the app loads
3. Open the glossary
4. Verify the glossary loads and works

