### PR TITLE
Feature/134 unsupported browser message updates

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -565,11 +565,11 @@
             >
             <br />
             How's My Waterway utilizes Esri's ArcGIS JavaScript API for advanced
-            mapping features, which are not supported by Internet Explorer. For
+            mapping features, which are not supported by this browser. For
             more information visit the following links:
             <a
               href="https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later"
-              >ArcGIS System Requirements</a
+              >ArcGIS API for JavaScript System Requirements</a
             >
             and
             <a


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-134

## Main Changes:
* Updated the unsupported browser message text.

## Steps To Test:
1. Open a browser that ArcGIS does not support
2. Navigate to http://localhost:3000/community/dc/overview
3. Verify the message text now says:
> You are using a browser that is not supported. How's My Waterway works best on the latest verions of Chrome, Safari, Edge, or Firfox. 
> How's My Waterway utilizes Esri's ArcGIS JavaScript API for advanced mapping features, which are not supported by this browser. For more information visit the following links: [ArcGIS API for JavaScript System Requirements](https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later) and [So Long Internet Explorer](https://www.esri.com/arcgis-blog/products/arcgis/announcements/so-long-internet-explorer-11/).


