### PR TITLE
Feature/185 legend infinite loading spinner

### DIFF
--- a/app/client/src/components/shared/MapLegend.js
+++ b/app/client/src/components/shared/MapLegend.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import { css } from 'styled-components/macro';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
@@ -604,8 +604,8 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
           {layerName}
         </GlossaryTerm>
 
-        {Object.entries(subLegends).map(([name, legend]) => (
-          <>
+        {Object.entries(subLegends).map(([name, legend], index) => (
+          <Fragment key={index}>
             <div css={subLayerLabelStyles}>{name}</div>
 
             <ul css={[nestedUl, { marginBottom: '0.5rem' }]}>
@@ -625,7 +625,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
                 );
               })}
             </ul>
-          </>
+          </Fragment>
         ))}
       </li>
     );

--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -46,6 +46,10 @@ const layersToAllowPopups = ['restore', 'protect'];
 // workaround for React state variables not being updated inside of
 // esri watch events
 let displayEsriLegendNonState = false;
+let additionalLegendInfoNonState = {
+  status: 'fetching',
+  data: {},
+};
 
 const basemapNames = [
   'Streets',
@@ -636,21 +640,23 @@ function MapWidgets({
 
     Promise.all(requests)
       .then((responses) => {
-        setAdditionalLegendInfo({
+        additionalLegendInfoNonState = {
           status: 'success',
           data: {
             protectedAreasLayer: responses[0],
             ejscreen: responses[1],
             mappedWaterLayer: responses[2],
           },
-        });
+        };
+        setAdditionalLegendInfo(additionalLegendInfoNonState);
       })
       .catch((err) => {
         console.error(err);
-        setAdditionalLegendInfo({
+        additionalLegendInfoNonState = {
           status: 'failure',
           data: {},
-        });
+        };
+        setAdditionalLegendInfo(additionalLegendInfoNonState);
       });
   }, [additioanlLegendInitialized, services]);
 
@@ -706,7 +712,7 @@ function MapWidgets({
             view,
             displayEsriLegendNonState,
             hmwLegendNode,
-            additionalLegendInfo,
+            additionalLegendInfoNonState,
           );
 
           item.watch('visible', function (event) {
@@ -714,7 +720,7 @@ function MapWidgets({
               view,
               displayEsriLegendNonState,
               hmwLegendNode,
-              additionalLegendInfo,
+              additionalLegendInfoNonState,
             );
             const dict = {
               layerId: item.layer.id,
@@ -770,7 +776,7 @@ function MapWidgets({
   // Sets up the zoom event handler that is used for determining if layers
   // should be visible at the current zoom level.
   useEffect(() => {
-    if (!view || !additionalLegendInfo || mapEventHandlersSet) return;
+    if (!view || mapEventHandlersSet) return;
 
     // setup map event handlers
     watchUtils.watch(view, 'zoom', (newVal, oldVal, propName, target) => {
@@ -780,7 +786,7 @@ function MapWidgets({
         view,
         displayEsriLegendNonState,
         hmwLegendNode,
-        additionalLegendInfo,
+        additionalLegendInfoNonState,
       );
     });
 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-185

## Main Changes:
* Fixed an issue with infinite loading spinners being displayed in the legend.
* Fixed an error that was showing up in the console related to a missing key prop. This happened when the "Mapped Water (all)" layer was turned on.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/protect
2. Open the legend
3. Open the developer tools
4. Clear the console
5. Turn on the "Mapped Water (all)" layer
6. Verify there is not a console error related to a missing key prop
7. Turn on the "Demographic Indicators" and "Protected Areas" layers
8. Zoom in on the map
9. Open the legend
10. Verify there are no loading spinners being displayed

