### PR TITLE
Feature/181 simplify popup code

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -190,7 +190,7 @@ const changeWatershedContainerStyles = css`
 
 type Props = {
   type: string,
-  feature: ?Object,
+  feature: Object,
   fieldName: ?string,
   extraContent: ?Object,
   services: ?Object,
@@ -1093,7 +1093,7 @@ function WaterbodyInfo({
 
 type MapPopupProps = {
   type: string,
-  feature: ?Object,
+  feature: Object,
   fieldName: ?string,
   extraContent: ?Object,
   getClickedHuc: ?Function,

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -193,8 +193,6 @@ type Props = {
   feature: ?Object,
   fieldName: ?string,
   extraContent: ?Object,
-  getClickedHuc: ?Function,
-  resetData: ?Function,
   services: ?Object,
   fields: ?Object,
 };
@@ -204,8 +202,6 @@ function WaterbodyInfo({
   feature,
   fieldName,
   extraContent,
-  getClickedHuc,
-  resetData,
   services,
   fields,
 }: Props) {
@@ -1095,6 +1091,17 @@ function WaterbodyInfo({
   return content;
 }
 
+type MapPopupProps = {
+  type: string,
+  feature: ?Object,
+  fieldName: ?string,
+  extraContent: ?Object,
+  getClickedHuc: ?Function,
+  resetData: ?Function,
+  services: ?Object,
+  fields: ?Object,
+};
+
 function MapPopup({
   type,
   feature,
@@ -1104,7 +1111,7 @@ function MapPopup({
   resetData,
   services,
   fields,
-}: Props) {
+}: MapPopupProps) {
   // Gets the response of what huc was clicked, if provided.
   const [clickedHuc, setClickedHuc] = useState<{
     status: 'none' | 'fetching' | 'success' | 'failure',

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -55,6 +55,21 @@ function renderLink(label, link) {
   );
 }
 
+function labelValue(label, value, icon = null) {
+  return (
+    <p>
+      <strong>{label}: </strong>
+      {icon ? (
+        <span css={popupIconStyles}>
+          {icon} {value}
+        </span>
+      ) : (
+        value
+      )}
+    </p>
+  );
+}
+
 const popupContainerStyles = css`
   margin: 0;
   overflow-y: auto;
@@ -177,7 +192,6 @@ type Props = {
   type: string,
   feature: ?Object,
   fieldName: ?string,
-  isPopup: boolean,
   extraContent: ?Object,
   getClickedHuc: ?Function,
   resetData: ?Function,
@@ -189,59 +203,15 @@ function WaterbodyInfo({
   type,
   feature,
   fieldName,
-  isPopup = false,
   extraContent,
   getClickedHuc,
   resetData,
   services,
   fields,
 }: Props) {
-  // Gets the response of what huc was clicked, if provided.
-  const [clickedHuc, setClickedHuc] = useState<{
-    status: 'none' | 'fetching' | 'success' | 'failure',
-    data: { huc12: any, watershed: any } | null,
-  }>({ status: 'none', data: null });
-
-  useEffect(() => {
-    if (!getClickedHuc || clickedHuc.status !== 'none') return;
-
-    setClickedHuc({ status: 'fetching', data: null });
-
-    getClickedHuc
-      .then((res) => setClickedHuc(res))
-      .catch((err) => {
-        console.error(err);
-        setClickedHuc({ status: 'failure', data: null });
-      });
-  }, [getClickedHuc, clickedHuc]);
-
   const { attributes } = feature;
   const onWaterbodyReportPage =
     window.location.pathname.indexOf('waterbody-report') !== -1;
-
-  function labelValue(label, value, icon = null) {
-    if (isPopup) {
-      return (
-        <p>
-          <strong>{label}: </strong>
-          {icon ? (
-            <span css={popupIconStyles}>
-              {icon} {value}
-            </span>
-          ) : (
-            value
-          )}
-        </p>
-      );
-    }
-
-    return (
-      <p css={paragraphStyles}>
-        <strong>{label}: </strong>
-        {value}
-      </p>
-    );
-  }
 
   const waterbodyPollutionCategories = (label: string) => {
     const pollutionCategories = impairmentFields
@@ -265,31 +235,6 @@ function WaterbodyInfo({
         <ul>{pollutionCategories}</ul>
       </>
     );
-  };
-
-  const getTypeTitle = () => {
-    const typesToSkip = [
-      'Action',
-      'Change Location',
-      'Waterbody State Overview',
-    ];
-    if (typesToSkip.includes(type)) return null;
-
-    let title = type;
-    if (type === 'Demographic Indicators') {
-      title = `${type} - ${feature.layer.title}`;
-    }
-    if (type === 'Restoration Plans') {
-      title = 'Restoration Plans for this Waterbody';
-    }
-    if (type === 'Protection Plans') {
-      title = 'Protection Plans for this Waterbody';
-    }
-    if (type === 'Upstream Watershed') {
-      title = <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>;
-    }
-
-    return <p css={popupTitleStyles}>{title}</p>;
   };
 
   const waterbodyReportLink =
@@ -353,7 +298,6 @@ function WaterbodyInfo({
       }) || [];
 
     const reportingCycle = attributes && attributes.reportingcycle;
-
     return (
       <>
         {reportingCycle && (
@@ -1148,75 +1092,141 @@ function WaterbodyInfo({
     content = congressionalDistrictContent();
   }
 
-  if (isPopup) {
-    const huc12 = clickedHuc?.data?.huc12;
-    const watershed = clickedHuc?.data?.watershed;
-
-    content = (
-      <div css={popupContainerStyles}>
-        {clickedHuc && (
-          <>
-            {clickedHuc.status === 'no-data' && null}
-            {clickedHuc.status === 'fetching' && <LoadingSpinner />}
-            {clickedHuc.status === 'failure' && <p>Web service error</p>}
-            {clickedHuc.status === 'success' && (
-              <>
-                {type !== 'Change Location' && (
-                  <p css={popupTitleStyles}>Change to this location?</p>
-                )}
-
-                <div css={changeWatershedContainerStyles}>
-                  <div>
-                    {labelValue('WATERSHED', `${watershed} (${huc12})`)}
-                  </div>
-
-                  <div css={buttonsContainer}>
-                    <button
-                      css={buttonStyles}
-                      title="Change to this location"
-                      className="btn"
-                      onClick={(ev) => {
-                        // Clear all data before navigating.
-                        // The main reason for this is better performance
-                        // when doing a huc search by clicking on the state map. The app
-                        // will attempt to use all of the loaded state data, then clear it
-                        // then load the huc. This could take a long time if the state
-                        // has a lot of waterbodies.
-                        if (resetData) resetData();
-
-                        let baseRoute = `/community/${huc12}`;
-
-                        // community will attempt to stay on the same tab
-                        // if available, stay on the same tab otherwise go to overview
-                        let urlParts = window.location.pathname.split('/');
-                        if (
-                          urlParts.includes('community') &&
-                          urlParts.length > 3
-                        ) {
-                          window.location.assign(`${baseRoute}/${urlParts[3]}`);
-                          return;
-                        }
-
-                        window.location.assign(`${baseRoute}/overview`);
-                      }}
-                    >
-                      Yes
-                    </button>
-                  </div>
-                </div>
-              </>
-            )}
-          </>
-        )}
-
-        {getTypeTitle()}
-
-        <div css={popupContentStyles}>{content}</div>
-      </div>
-    );
-  }
-
   return content;
+}
+
+function MapPopup({
+  type,
+  feature,
+  fieldName,
+  extraContent,
+  getClickedHuc,
+  resetData,
+  services,
+  fields,
+}: Props) {
+  // Gets the response of what huc was clicked, if provided.
+  const [clickedHuc, setClickedHuc] = useState<{
+    status: 'none' | 'fetching' | 'success' | 'failure',
+    data: { huc12: any, watershed: any } | null,
+  }>({ status: 'none', data: null });
+
+  useEffect(() => {
+    if (!getClickedHuc || clickedHuc.status !== 'none') return;
+
+    setClickedHuc({ status: 'fetching', data: null });
+
+    getClickedHuc
+      .then((res) => setClickedHuc(res))
+      .catch((err) => {
+        console.error(err);
+        setClickedHuc({ status: 'failure', data: null });
+      });
+  }, [getClickedHuc, clickedHuc]);
+
+  const { attributes } = feature;
+
+  const getTypeTitle = () => {
+    const typesToSkip = [
+      'Action',
+      'Change Location',
+      'Waterbody State Overview',
+    ];
+    if (typesToSkip.includes(type)) return null;
+
+    let title = type;
+    if (type === 'Demographic Indicators') {
+      title = `${type} - ${feature.layer.title}`;
+    }
+    if (type === 'Restoration Plans') {
+      title = 'Restoration Plans for this Waterbody';
+    }
+    if (type === 'Protection Plans') {
+      title = 'Protection Plans for this Waterbody';
+    }
+    if (type === 'Upstream Watershed') {
+      title = <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>;
+    }
+
+    return <p css={popupTitleStyles}>{title}</p>;
+  };
+
+  if (!attributes) return null;
+
+  const huc12 = clickedHuc?.data?.huc12;
+  const watershed = clickedHuc?.data?.watershed;
+
+  return (
+    <div css={popupContainerStyles}>
+      {clickedHuc && (
+        <>
+          {clickedHuc.status === 'no-data' && null}
+          {clickedHuc.status === 'fetching' && <LoadingSpinner />}
+          {clickedHuc.status === 'failure' && <p>Web service error</p>}
+          {clickedHuc.status === 'success' && (
+            <>
+              {type !== 'Change Location' && (
+                <p css={popupTitleStyles}>Change to this location?</p>
+              )}
+
+              <div css={changeWatershedContainerStyles}>
+                <div>{labelValue('WATERSHED', `${watershed} (${huc12})`)}</div>
+
+                <div css={buttonsContainer}>
+                  <button
+                    css={buttonStyles}
+                    title="Change to this location"
+                    className="btn"
+                    onClick={(ev) => {
+                      // Clear all data before navigating.
+                      // The main reason for this is better performance
+                      // when doing a huc search by clicking on the state map. The app
+                      // will attempt to use all of the loaded state data, then clear it
+                      // then load the huc. This could take a long time if the state
+                      // has a lot of waterbodies.
+                      if (resetData) resetData();
+
+                      let baseRoute = `/community/${huc12}`;
+
+                      // community will attempt to stay on the same tab
+                      // if available, stay on the same tab otherwise go to overview
+                      let urlParts = window.location.pathname.split('/');
+                      if (
+                        urlParts.includes('community') &&
+                        urlParts.length > 3
+                      ) {
+                        window.location.assign(`${baseRoute}/${urlParts[3]}`);
+                        return;
+                      }
+
+                      window.location.assign(`${baseRoute}/overview`);
+                    }}
+                  >
+                    Yes
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {getTypeTitle()}
+
+      <div css={popupContentStyles}>
+        <WaterbodyInfo
+          type={type}
+          feature={feature}
+          fieldName={fieldName}
+          extraContent={extraContent}
+          getClickedHuc={getClickedHuc}
+          resetData={resetData}
+          services={services}
+          fields={fields}
+        />
+      </div>
+    </div>
+  );
 }
 
 function UsgsStreamgagesContent({ feature }: { feature: Object }) {
@@ -1430,3 +1440,5 @@ function UsgsStreamgageParameter({ url, data }) {
 }
 
 export default WaterbodyInfo;
+
+export { MapPopup };

--- a/app/client/src/utils/mapFunctions.js
+++ b/app/client/src/utils/mapFunctions.js
@@ -6,8 +6,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { css } from 'styled-components/macro';
 import Graphic from '@arcgis/core/Graphic';
 // components
+import { MapPopup } from 'components/shared/WaterbodyInfo';
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
-import WaterbodyInfo from 'components/shared/WaterbodyInfo';
 // styles
 import { colors } from 'styles/index.js';
 // utilities
@@ -760,11 +760,10 @@ export function getPopupContent({
   }
 
   const content = (
-    <WaterbodyInfo
+    <MapPopup
       type={type}
       feature={feature}
       fieldName={fieldName}
-      isPopup={true}
       extraContent={extraContent}
       getClickedHuc={getClickedHuc}
       resetData={resetData}


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-181

## Main Changes:
* Created a separate `MapPopup` component that wraps the `WaterbodyInfo` component.
  * I ended up keeping these components in the same, since they share some styles and helper functions.
  * The only visual thing that removing the `isPopup` flag does that might be undesirable, is now the waterbodies in the list view will show the status icon twice, once in the accordion header and once in the content next to `Waterbody Condition`. 

![image](https://user-images.githubusercontent.com/46329268/167948898-0a4bf141-444c-4dd7-bb9c-5d71201ee8b4.png)


## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Verify the popup works on the map 
3. Verify the list to the right works

