### PR TITLE
HMW-171 Fixed ordering of survey stressors.

### DIFF
--- a/app/server/app/public/data/state/surveyMapping.json
+++ b/app/server/app/public/data/state/surveyMapping.json
@@ -3121,20 +3121,20 @@
       },
       {
         "stressor": "PHOSPHORUS, TOTAL",
-        "surveyCategoryCode": "Not Supporting",
-        "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
-        "categoryCode_color": "#cb223e"
-      },
-      {
-        "stressor": "PHOSPHORUS, TOTAL",
         "surveyCategoryCode": "Potentially Not Supporting",
         "categoryCode_label": "Potentially Not Supporting",
-        "categoryCode_order": "3",
+        "categoryCode_order": "2",
         "categoryCode_color": "#FFFF00"
       },
       {
         "stressor": "PHOSPHORUS, TOTAL",
+        "surveyCategoryCode": "Not Supporting",
+        "categoryCode_label": "Not Supporting",
+        "categoryCode_order": "3",
+        "categoryCode_color": "#cb223e"
+      },
+      {
+        "stressor": "PHOSPHORUS, TOTAL",
         "surveyCategoryCode": "Insufficient Information",
         "categoryCode_label": "Insufficient Information",
         "categoryCode_order": "4",
@@ -3151,7 +3151,7 @@
         "stressor": "PH",
         "surveyCategoryCode": "Not Supporting",
         "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
+        "categoryCode_order": "3",
         "categoryCode_color": "#cb223e"
       },
       {
@@ -3165,7 +3165,7 @@
         "stressor": "NON-NATIVE AQUATIC PLANTS",
         "surveyCategoryCode": "Not Supporting",
         "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
+        "categoryCode_order": "3",
         "categoryCode_color": "#cb223e"
       },
       {
@@ -3179,7 +3179,7 @@
         "stressor": "DISSOLVED OXYGEN SATURATION",
         "surveyCategoryCode": "Not Supporting",
         "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
+        "categoryCode_order": "3",
         "categoryCode_color": "#cb223e"
       },
       {
@@ -3200,7 +3200,7 @@
         "stressor": "DISSOLVED OXYGEN",
         "surveyCategoryCode": "Not Supporting",
         "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
+        "categoryCode_order": "3",
         "categoryCode_color": "#cb223e"
       },
       {
@@ -3221,7 +3221,7 @@
         "stressor": "CHLOROPHYLL-A",
         "surveyCategoryCode": "Not Supporting",
         "categoryCode_label": "Not Supporting",
-        "categoryCode_order": "2",
+        "categoryCode_order": "3",
         "categoryCode_color": "#cb223e"
       },
       {


### PR DESCRIPTION
## Related Issues:
* [HMW-171](https://jira.epa.gov/browse/HMW-171)

## Main Changes:
* Updated the `stateNationalUses.json` file.
* Updated the `surveyMapping.json` file.

## Steps To Test:
1. Navigate to http://localhost:3000/state/NH/water-quality-overview
2. Click on the `Aquatic Life` tab
3. Select `Lakes and Reservoirs` for the water type
4. Expand `Stressors surveyed for Aquatic Life Integrity`
5. Verify the legend/data is in the following order
    1. Fully Supporting
    2. Potentially Not Supporting
    3. Not Supporting
    4. Insufficient Information 
