### PR TITLE
Feature/187 waterbody report table overflow

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -188,7 +188,9 @@ const parameterStyles = css`
 `;
 
 const dateCellStyles = css`
-  white-space: nowrap;
+  @media (min-width: 480px) {
+    white-space: nowrap;
+  }
 `;
 
 const locationsStyles = css`

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -50,16 +50,14 @@ const containerStyles = css`
   table {
     margin-top: 0.75rem;
     margin-bottom: 0.75rem;
-  }
-
-  .table-container {
-    overflow: scroll;
+    table-layout: fixed;
   }
 
   th,
   td {
     font-size: 0.875rem;
     line-height: 1.25;
+    overflow-wrap: break-word;
 
     &:last-child {
       text-align: right;
@@ -1306,7 +1304,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                         </div>
                       )}
                       {waterbodyActions.status === 'success' && (
-                        <div className="table-container">
+                        <>
                           {waterbodyActions.data.length === 0 ? (
                             <p>No plans specified for this waterbody.</p>
                           ) : (
@@ -1363,7 +1361,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                               </table>
                             </>
                           )}
-                        </div>
+                        </>
                       )}
                     </div>
                   </div>

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -52,6 +52,10 @@ const containerStyles = css`
     margin-bottom: 0.75rem;
   }
 
+  .table-container {
+    overflow: scroll;
+  }
+
   th,
   td {
     font-size: 0.875rem;
@@ -1302,7 +1306,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                         </div>
                       )}
                       {waterbodyActions.status === 'success' && (
-                        <>
+                        <div className="table-container">
                           {waterbodyActions.data.length === 0 ? (
                             <p>No plans specified for this waterbody.</p>
                           ) : (
@@ -1359,7 +1363,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                               </table>
                             </>
                           )}
-                        </>
+                        </div>
                       )}
                     </div>
                   </div>

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -188,7 +188,7 @@ const parameterStyles = css`
 `;
 
 const dateCellStyles = css`
-  @media (min-width: 480px) {
+  @media (min-width: 25em) {
     white-space: nowrap;
   }
 `;


### PR DESCRIPTION
## Related Issues:
* [HMW-187](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-187&quickFilter=2479)

## Main Changes:
* Added CSS rules to condense the "Plans to Restore Water Quality" table on the waterbody report page, which was previously overflowing its container.

## Steps To Test:
1. Visit a waterbody report page, e.g. [http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022](http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022)
2. Resize the screen to a mobile view
3. Scroll to the "Plans to Restore Water Quality" section
4. Check that the table does not overflow its border

