### PR TITLE
Added a placeholder prop to the ReactTable component, changed column …

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -1204,6 +1204,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                           ) : (
                             <ReactTable
                               data={waterbodySources.data}
+                              placeholder="Filter..."
                               striped={false}
                               getColumns={(tableWidth) => {
                                 const columnWidth = 2 * (tableWidth / 5) - 1;

--- a/app/client/src/components/shared/ReactTable.js
+++ b/app/client/src/components/shared/ReactTable.js
@@ -22,22 +22,22 @@ const inputStyles = css`
   outline-width: 0;
 `;
 
-function generateFilterInput({
-  column: { filterValue, preFilteredRows, setFilter },
-}) {
-  return (
-    <input
-      css={inputStyles}
-      type="text"
-      placeholder="Filter column..."
-      value={filterValue ? filterValue : ''}
-      onClick={(event) => event.stopPropagation()}
-      onChange={
-        (event) => setFilter(event.target.value || undefined) // Set undefined to remove the filter entirely
-      }
-      aria-label="Filter column..."
-    />
-  );
+function generateFilterInput(placeholder = 'Filter column...') {
+  return ({ column: { filterValue, preFilteredRows, setFilter } }) => {
+    return (
+      <input
+        css={inputStyles}
+        type="text"
+        placeholder={placeholder}
+        value={filterValue ? filterValue : ''}
+        onClick={(event) => event.stopPropagation()}
+        onChange={
+          (event) => setFilter(event.target.value || undefined) // Set undefined to remove the filter entirely
+        }
+        aria-label="Filter column..."
+      />
+    );
+  };
 }
 
 const containerStyles = css`
@@ -130,10 +130,11 @@ const containerStyles = css`
 type Props = {
   data: Array<Object>,
   getColumns: Function,
+  placeholder: ?string,
   striped: ?boolean,
 };
 
-function ReactTable({ data, getColumns, striped = false }: Props) {
+function ReactTable({ data, getColumns, placeholder, striped = false }: Props) {
   // Initializes the column widths based on the table width
   const [tableWidth, setTableWidth] = useState(0);
   const columns = useMemo(() => {
@@ -147,9 +148,9 @@ function ReactTable({ data, getColumns, striped = false }: Props) {
       minWidth: 50, // minWidth is only used as a limit for resizing
       width: 150, // width is used for both the flex-basis and flex-grow
       maxWidth: 1000, // maxWidth is only used as a limit for resizing
-      Filter: generateFilterInput,
+      Filter: generateFilterInput(placeholder),
     }),
-    [],
+    [placeholder],
   );
 
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =


### PR DESCRIPTION
## Related Issues:
* [HMW-188](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-188&quickFilter=2479)

## Main Changes:
* Added an optional `placeholder` prop to the `ReactTable` component, which allows for customization of the column filter placeholder text.
* Updated the `ReactTable` on the **Waterbody Report** page to use the placeholder "Filter...", since "Filter columns..." was being cut short.

## Steps To Test:
1. Visit a **Waterbody Report** page, e.g. [http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022](http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022)
2. Find the table under the heading *Probable sources contributing to impairment from 2022:*
3. Check that the text input boxes in the table column headers have the placeholder value "Filter...", and that all is visible
