### PR TITLE
Feature/160 update clustering popup

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -635,14 +635,14 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         symbol: {
           type: 'simple-marker',
           style: 'circle',
-          color: colors.lightPurple(0.3),
+          color: colors.lightPurple(0.5),
         },
         visualVariables: [
           {
             type: 'size',
             field: 'stationTotalMeasurementsPercentile',
             legendOptions: {
-              title: 'Monitoring Measurment Percentiles for HUC12',
+              title: 'Monitoring Measurment Percentiles for Watershed',
             },
             stops: [
               { value: 0.25, size: 8, label: '<25th percentile ' },

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -635,7 +635,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         symbol: {
           type: 'simple-marker',
           style: 'circle',
-          color: colors.lightPurple(0.5),
+          color: colors.lightPurple(0.3),
         },
         visualVariables: [
           {

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -774,7 +774,7 @@ function LocationSearch({ route, label }: Props) {
                       title: 'Cluster summary',
                       content: (feature) => {
                         const content = (
-                          <div css={{ margin: '0.625em' }}>
+                          <div style={{ margin: '0.625em' }}>
                             This cluster represents{' '}
                             {feature.graphic.attributes.cluster_count} stations
                           </div>

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -794,7 +794,8 @@ function LocationSearch({ route, label }: Props) {
                         },
                         symbol: {
                           type: 'text',
-                          color: '#ffffff',
+                          color: '#000',
+                          font: { size: 10, weight: 'bold' },
                         },
                         labelPlacement: 'center-center',
                       },

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -768,7 +768,7 @@ function LocationSearch({ route, label }: Props) {
 
                 if (checked) {
                   monitoringLocationsLayer.renderer.symbol.color =
-                    colors.lightPurple();
+                    colors.lightPurple(0.8);
                   monitoringLocationsLayer.featureReduction = {
                     type: 'cluster',
                     clusterRadius: '100px',

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -7,6 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
 import Switch from 'components/shared/Switch';
 import { useNavigate } from 'react-router-dom';
@@ -771,8 +772,20 @@ function LocationSearch({ route, label }: Props) {
                     clusterRadius: '100px',
                     popupTemplate: {
                       title: 'Cluster summary',
-                      content:
-                        'This cluster represents {cluster_count} stations',
+                      content: (feature) => {
+                        const content = (
+                          <div css={{ margin: '0.625em' }}>
+                            This cluster represents{' '}
+                            {feature.graphic.attributes.cluster_count} stations
+                          </div>
+                        );
+
+                        const contentContainer = document.createElement('div');
+                        render(content, contentContainer);
+
+                        // return an esri popup item
+                        return contentContainer;
+                      },
                       fieldInfos: [
                         {
                           fieldName: 'cluster_count',

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -767,9 +767,14 @@ function LocationSearch({ route, label }: Props) {
                 setClusteringEnabled(checked);
 
                 if (checked) {
+                  monitoringLocationsLayer.renderer.symbol.color =
+                    colors.lightPurple();
                   monitoringLocationsLayer.featureReduction = {
                     type: 'cluster',
                     clusterRadius: '100px',
+                    clusterMinSize: '24px',
+                    clusterMaxSize: '60px',
+                    popupEnabled: true,
                     popupTemplate: {
                       title: 'Cluster summary',
                       content: (feature) => {
@@ -796,9 +801,6 @@ function LocationSearch({ route, label }: Props) {
                         },
                       ],
                     },
-                    popupEnabled: true,
-                    clusterMinSize: '24px',
-                    clusterMaxSize: '60px',
                     labelingInfo: [
                       {
                         deconflictionStrategy: 'none',
@@ -815,6 +817,8 @@ function LocationSearch({ route, label }: Props) {
                     ],
                   };
                 } else {
+                  monitoringLocationsLayer.renderer.symbol.color =
+                    colors.lightPurple(0.3);
                   monitoringLocationsLayer.featureReduction = undefined;
                 }
               }}

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -809,7 +809,7 @@ function LocationSearch({ route, label }: Props) {
                         },
                         symbol: {
                           type: 'text',
-                          color: '#000',
+                          color: '#000000',
                           font: { size: 10, weight: 'bold' },
                         },
                         labelPlacement: 'center-center',


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-160

## Main Changes:
* Adjusted the font styles of the sample location cluster labels (changed color to black and updated font size/weight to match stream gages).
* Added some code to change the opacity of the sample locations layer when toggling clustering on/off. Having high transparency on the sample locations layer isn't as necessary when clustering is on and it was difficult to get good contrast when the layer has high transparency. 
* Added some margin around the popup content for the sample location clusters. This margin matches that of other popups.

## Steps To Test:
1. Navigate to http://localhost:3000/community/portland%20or/overview
2. Turn on the Sample Locations layer
3. Turn on the "Temp Monitoring Clustering" switch
4. Verify the cluster labels are legible with different backgrounds by turning on/off other layers in the layer list
5. Click on one of the clusters
6. Verify the popup content now has some margin
