### PR TITLE
Feature/190 station download styles

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -27,7 +27,6 @@ import { waterbodyReportError } from 'config/errorMessages';
 import {
   colors,
   disclaimerStyles,
-  downloadLinksStyles,
   iconStyles,
   modifiedTableStyles,
 } from 'styles/index.js';

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -195,12 +195,7 @@ const totalRowStyles = css`
 const tableFooterStyles = css`
   span {
     display: inline-block;
-    &.download-text {
-      margin-bottom: 5px;
-    }
-    &.download-links {
-      margin-left: 5px;
-    }
+    margin-bottom: 0.25em;
   }
 
   td {
@@ -849,8 +844,9 @@ function WaterbodyInfo({
                   </small>
                 </td>
                 <td colSpan="2">
-                  <span className="download-text">Download Station Data</span>
-                  <span className="download-links">
+                  <span>Download Station Data</span>
+                  <span>
+                    &nbsp;&nbsp;
                     <a href={`${downloadUrl}&mimeType=xlsx`}>
                       <i className="fas fa-file-excel" aria-hidden="true" />
                     </a>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -77,14 +77,9 @@ const popupTitleStyles = css`
   background-color: #f0f6f9;
 `;
 
-const measurementStyles = css`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-`;
-
 const measurementTableStyles = css`
   ${modifiedTableStyles};
+
   th:last-of-type,
   td:last-of-type {
     text-align: right;
@@ -93,6 +88,7 @@ const measurementTableStyles = css`
 
 const modifiedDisclaimerStyles = css`
   ${disclaimerStyles};
+
   padding-bottom: 0;
 `;
 
@@ -123,6 +119,12 @@ const moreLessRowStyles = css`
 const additionalTextStyles = css`
   font-style: italic;
   color: ${colors.gray6};
+`;
+
+const measurementStyles = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const popupIconStyles = css`
@@ -160,10 +162,6 @@ const imageContainerStyles = css`
 const imageStyles = css`
   width: 100%;
   height: auto;
-`;
-
-const infoLinkStyles = css`
-  padding-bottom: 1.5em;
 `;
 
 const dateStyles = css`
@@ -741,7 +739,7 @@ function WaterbodyInfo({
           </tbody>
         </table>
 
-        <p css={infoLinkStyles}>
+        <p>
           <a
             rel="noopener noreferrer"
             target="_blank"

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -80,11 +80,51 @@ const popupTitleStyles = css`
 
 const measurementTableStyles = css`
   ${modifiedTableStyles};
-
   th:last-of-type,
   td:last-of-type {
     text-align: right;
   }
+
+  tfoot {
+    .totals {
+      border-top: 2px solid #dee2e6;
+      th {
+        border: none;
+      }
+    }
+    .download-links {
+      th {
+        border-top: none;
+        div {
+          display: inline-block;
+          vertical-align: top;
+          width: 50%;
+          &:first-of-type {
+            text-align: left;
+            a {
+              margin-right: 5px;
+            }
+          }
+          &:last-of-type {
+            .download-text {
+              margin-bottom: 5px;
+            }
+            a {
+              margin-left: 5px;
+            }
+          }
+        }
+        span {
+          display: inline-block;
+        }
+      }
+    }
+  }
+`;
+
+const modifiedDisclaimerStyles = css`
+  ${disclaimerStyles};
+  padding-bottom: 0;
 `;
 
 const checkboxCellStyles = css`
@@ -158,6 +198,11 @@ const imageStyles = css`
   width: 100%;
   height: auto;
 `;
+
+const infoLinkStyles = css`
+  padding-bottom: 1.5em;
+`;
+
 
 const dateStyles = css`
   white-space: nowrap;
@@ -693,8 +738,21 @@ function WaterbodyInfo({
           </tbody>
         </table>
 
-        <p>
-          <strong>Download Monitoring Data:</strong>
+        <p css={infoLinkStyles}>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href={attributes.locationUrl}
+          >
+            <i
+              css={iconStyles}
+              className="fas fa-info-circle"
+              aria-hidden="true"
+            />
+            More Information
+          </a>
+          &nbsp;&nbsp;
+          <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>
         </p>
 
         {Object.keys(groups).length === 0 && (
@@ -755,53 +813,50 @@ function WaterbodyInfo({
                 );
               })}
             </tbody>
+            <tfoot>
+              <tr className="totals">
+                <th></th>
+                <th>Totals</th>
+                <th>
+                  {Number(attributes.stationTotalMeasurements).toLocaleString()}
+                </th>
+              </tr>
+              <tr className="download-links">
+                <th colSpan="4">
+                  <div>
+                    <a
+                      rel="noopener noreferrer"
+                      target="_blank"
+                      data-cy="portal"
+                      href={portalUrl}
+                    >
+                      <i
+                        css={iconStyles}
+                        className="fas fa-filter"
+                        aria-hidden="true"
+                      />
+                      Advanced Filtering
+                    </a>
+                    <small css={modifiedDisclaimerStyles}>
+                      (opens new browser tab)
+                    </small>
+                  </div>
+                  <div>
+                    <span className="download-text">Download Station Data</span>
+                    <span className="icon-set">
+                      <a href={`${downloadUrl}&mimeType=xlsx`}>
+                        <i className="fas fa-file-excel" aria-hidden="true" />
+                      </a>
+                      <a href={`${downloadUrl}&mimeType=csv`}>
+                        <i className="fas fa-file-csv" aria-hidden="true" />
+                      </a>
+                    </span>
+                  </div>
+                </th>
+              </tr>
+            </tfoot>
           </table>
         )}
-
-        <p css={downloadLinksStyles}>
-          <span>Data Download Format:</span>
-          &nbsp;
-          <a href={`${downloadUrl}&mimeType=xlsx`}>
-            <i
-              css={iconStyles}
-              className="fas fa-file-excel"
-              aria-hidden="true"
-            />
-            xls
-          </a>
-          <a href={`${downloadUrl}&mimeType=csv`}>
-            <i
-              css={iconStyles}
-              className="fas fa-file-csv"
-              aria-hidden="true"
-            />
-            csv
-          </a>
-        </p>
-
-        <p>
-          <a
-            rel="noopener noreferrer"
-            target="_blank"
-            href={attributes.locationUrl}
-          >
-            <i
-              css={iconStyles}
-              className="fas fa-info-circle"
-              aria-hidden="true"
-            />
-            More Information
-          </a>
-          &nbsp;&nbsp;
-          <small css={disclaimerStyles}>(opens new browser tab)</small>
-          <br />
-          <a rel="noopener noreferrer" target="_blank" href={portalUrl}>
-            <i css={iconStyles} className="fas fa-filter" aria-hidden="true" />
-            Filter this data using the <em>Water Quality Portal</em> form
-          </a>
-          &nbsp;&nbsp;
-          <small css={disclaimerStyles}>(opens new browser tab)</small>
-        </p>
       </>
     );
   }

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -203,7 +203,6 @@ const infoLinkStyles = css`
   padding-bottom: 1.5em;
 `;
 
-
 const dateStyles = css`
   white-space: nowrap;
 `;
@@ -562,6 +561,9 @@ function WaterbodyInfo({
   const [charGroupFilters, setCharGroupFilters] = useState('');
   const [selected, setSelected] = useState({});
   const [selectAll, setSelectAll] = useState(1);
+  const [totalMeasurements, setTotalMeasurements] = useState(
+    attributes.stationTotalMeasurements,
+  );
 
   function monitoringLocationsContent() {
     const stationGroups = JSON.parse(attributes.stationTotalsByCategory);
@@ -597,6 +599,14 @@ function WaterbodyInfo({
         }
       }
     });
+
+    if (!Object.keys(selected).length) {
+      let selectedGroups = {};
+      Object.keys(groups).forEach((key) => {
+        selectedGroups[key] = true;
+      });
+      setSelected(selectedGroups);
+    }
 
     function buildFilter(selectedNames, monitoringLocationData) {
       let filter = '';
@@ -636,15 +646,24 @@ function WaterbodyInfo({
       if (numberSelected === totalSelections) {
         setSelectAll(1);
         setCharGroupFilters('');
+        setTotalMeasurements(attributes.stationTotalMeasurements);
       }
       // if none selected
       else if (numberSelected === 0) {
         setSelectAll(0);
         setCharGroupFilters('');
+        setTotalMeasurements(0);
       }
       // if some selected
       else {
         setSelectAll(2);
+        let newTotalMeasurementCount = 0;
+        Object.keys(groups).forEach((group) => {
+          if (selectedGroups[group] === true) {
+            newTotalMeasurementCount += groups[group].resultCount;
+          }
+        });
+        setTotalMeasurements(newTotalMeasurementCount);
       }
     }
 
@@ -662,6 +681,9 @@ function WaterbodyInfo({
 
       setSelected(selectedGroups);
       setSelectAll(selectAll === 0 ? 1 : 0);
+      setTotalMeasurements(
+        selectAll === 0 ? attributes.stationTotalMeasurements : 0,
+      );
       setCharGroupFilters('');
     }
 
@@ -816,10 +838,8 @@ function WaterbodyInfo({
             <tfoot>
               <tr className="totals">
                 <th></th>
-                <th>Totals</th>
-                <th>
-                  {Number(attributes.stationTotalMeasurements).toLocaleString()}
-                </th>
+                <th>Total</th>
+                <th>{Number(totalMeasurements).toLocaleString()}</th>
               </tr>
               <tr className="download-links">
                 <th colSpan="4">

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -77,47 +77,17 @@ const popupTitleStyles = css`
   background-color: #f0f6f9;
 `;
 
+const measurementStyles = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
 const measurementTableStyles = css`
   ${modifiedTableStyles};
   th:last-of-type,
   td:last-of-type {
     text-align: right;
-  }
-
-  tfoot {
-    .totals {
-      border-top: 2px solid #dee2e6;
-      th {
-        border: none;
-      }
-    }
-    .download-links {
-      th {
-        border-top: none;
-        div {
-          display: inline-block;
-          vertical-align: top;
-          width: 50%;
-          &:first-of-type {
-            text-align: left;
-            a {
-              margin-right: 5px;
-            }
-          }
-          &:last-of-type {
-            .download-text {
-              margin-bottom: 5px;
-            }
-            a {
-              margin-left: 5px;
-            }
-          }
-        }
-        span {
-          display: inline-block;
-        }
-      }
-    }
   }
 `;
 
@@ -153,12 +123,6 @@ const moreLessRowStyles = css`
 const additionalTextStyles = css`
   font-style: italic;
   color: ${colors.gray6};
-`;
-
-const measurementStyles = css`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 `;
 
 const popupIconStyles = css`
@@ -220,6 +184,29 @@ const changeWatershedContainerStyles = css`
 
   p {
     padding-bottom: 0;
+  }
+`;
+
+const totalRowStyles = css`
+  border-top: 2px solid #dee2e6;
+  font-weight: bold;
+`;
+
+const tableFooterStyles = css`
+  span {
+    display: inline-block;
+    &.download-text {
+      margin-bottom: 5px;
+    }
+    &.download-links {
+      margin-left: 5px;
+    }
+  }
+
+  td {
+    border-top: none;
+    font-weight: bold;
+    width: 50%;
   }
 `;
 
@@ -833,45 +820,46 @@ function WaterbodyInfo({
                   </tr>
                 );
               })}
-            </tbody>
-            <tfoot>
-              <tr className="totals">
-                <th></th>
-                <th>Total</th>
-                <th>{Number(totalMeasurements).toLocaleString()}</th>
+              <tr css={totalRowStyles}>
+                <td></td>
+                <td>Total</td>
+                <td>{Number(totalMeasurements).toLocaleString()}</td>
               </tr>
-              <tr className="download-links">
-                <th colSpan="4">
-                  <div>
-                    <a
-                      rel="noopener noreferrer"
-                      target="_blank"
-                      data-cy="portal"
-                      href={portalUrl}
-                    >
-                      <i
-                        css={iconStyles}
-                        className="fas fa-filter"
-                        aria-hidden="true"
-                      />
-                      Advanced Filtering
+            </tbody>
+
+            <tfoot css={tableFooterStyles}>
+              <tr>
+                <td colSpan="2">
+                  <a
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    data-cy="portal"
+                    href={portalUrl}
+                  >
+                    <i
+                      css={iconStyles}
+                      className="fas fa-filter"
+                      aria-hidden="true"
+                    />
+                    Advanced Filtering
+                  </a>
+                  &nbsp;&nbsp;
+                  <small css={modifiedDisclaimerStyles}>
+                    (opens new browser tab)
+                  </small>
+                </td>
+                <td colSpan="2">
+                  <span className="download-text">Download Station Data</span>
+                  <span className="download-links">
+                    <a href={`${downloadUrl}&mimeType=xlsx`}>
+                      <i className="fas fa-file-excel" aria-hidden="true" />
                     </a>
-                    <small css={modifiedDisclaimerStyles}>
-                      (opens new browser tab)
-                    </small>
-                  </div>
-                  <div>
-                    <span className="download-text">Download Station Data</span>
-                    <span className="icon-set">
-                      <a href={`${downloadUrl}&mimeType=xlsx`}>
-                        <i className="fas fa-file-excel" aria-hidden="true" />
-                      </a>
-                      <a href={`${downloadUrl}&mimeType=csv`}>
-                        <i className="fas fa-file-csv" aria-hidden="true" />
-                      </a>
-                    </span>
-                  </div>
-                </th>
+                    &nbsp;&nbsp;
+                    <a href={`${downloadUrl}&mimeType=csv`}>
+                      <i className="fas fa-file-csv" aria-hidden="true" />
+                    </a>
+                  </span>
+                </td>
               </tr>
             </tfoot>
           </table>


### PR DESCRIPTION
## Related Issues:
* [HMW-190](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-190&quickFilter=2479)

## Main Changes:
* Condensed the monitoring location measurement download section. It matches the recent style changes in the `feature/76_download-data-entire-huc` branch.
* Added a *Total* row to the monitoring location characteristic groups table of checkboxes that tracks the total count of selected groups.
* Added initialization code for the selected checkboxes. Previously, clicking on a checkbox would do the opposite of the expected behavior.

## Steps To Test:
1. Go to the **Monitoring** tab of the **Community** page, e.g. [http://localhost:3000/community/dc/monitoring](http://localhost:3000/community/dc/monitoring)
2. Click the **Sample Locations** sub-tab
3. Scroll to the monitoring sample locations accordion, and expand one
4. Confirm that interaction with the checkboxes accurately updates the total count