### PR TITLE
Feature/194 tribal name drinking water

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -702,7 +702,7 @@ function DrinkingWater() {
                                       <Switch
                                         disabled={!tribalProviderCount}
                                         checked={tribalProvidersOnly}
-                                        onChange={(ev) =>
+                                        onChange={(_ev) =>
                                           setTribalProvidersOnly(
                                             !tribalProvidersOnly,
                                           )
@@ -854,7 +854,7 @@ function DrinkingWater() {
                                         surfaceWaterDisplayed &&
                                         surfaceWaterCount > 0
                                       }
-                                      onChange={(ev) =>
+                                      onChange={(_ev) =>
                                         setSurfaceWaterDisplayed(
                                           !surfaceWaterDisplayed,
                                         )
@@ -875,7 +875,7 @@ function DrinkingWater() {
                                         groundWaterDisplayed &&
                                         groundWaterCount > 0
                                       }
-                                      onChange={(ev) =>
+                                      onChange={(_ev) =>
                                         setGroundWaterDisplayed(
                                           !groundWaterDisplayed,
                                         )
@@ -895,7 +895,7 @@ function DrinkingWater() {
                                       <Switch
                                         disabled={!bothCount}
                                         checked={bothDisplayed && bothCount > 0}
-                                        onChange={(ev) =>
+                                        onChange={(_ev) =>
                                           setBothDisplayed(!bothDisplayed)
                                         }
                                         ariaLabel="Ground Water and Surface Water"
@@ -923,7 +923,7 @@ function DrinkingWater() {
                                       <Switch
                                         disabled={!tribalWithdrawerCount}
                                         checked={tribalWithdrawersOnly}
-                                        onChange={(ev) =>
+                                        onChange={(_ev) =>
                                           setTribalWithdrawersOnly(
                                             !tribalWithdrawersOnly,
                                           )

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -711,7 +711,7 @@ function DrinkingWater() {
                                     <span>Tribal Only</span>
                                   </div>
                                 </td>
-                                <td></td>
+                                <td>{tribalProviderCount}</td>
                               </tr>
                             </tbody>
                           </table>
@@ -930,7 +930,7 @@ function DrinkingWater() {
                                     <span>Tribal Only</span>
                                   </div>
                                 </td>
-                                <td></td>
+                                <td>{tribalWithdrawerCount}</td>
                               </tr>
                             </tfoot>
                           </table>

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -682,41 +682,39 @@ function DrinkingWater() {
 
                       {providers.length > 0 && (
                         <>
-                          {tribalProviderCount > 0 && (
-                            <table
-                              css={modifiedToggleTableStyles}
-                              className="table"
-                            >
-                              <thead>
-                                <tr>
-                                  <th>
-                                    <span>Tribal Status</span>
-                                  </th>
-                                  <th></th>
-                                </tr>
-                              </thead>
-                              <tbody>
-                                <tr>
-                                  <td>
-                                    <div css={toggleStyles}>
-                                      <Switch
-                                        disabled={!tribalProviderCount}
-                                        checked={tribalProvidersOnly}
-                                        onChange={(_ev) =>
-                                          setTribalProvidersOnly(
-                                            !tribalProvidersOnly,
-                                          )
-                                        }
-                                        ariaLabel="Tribal Only"
-                                      />
-                                      <span>Tribal Only</span>
-                                    </div>
-                                  </td>
-                                  <td></td>
-                                </tr>
-                              </tbody>
-                            </table>
-                          )}
+                          <table
+                            css={modifiedToggleTableStyles}
+                            className="table"
+                          >
+                            <thead>
+                              <tr>
+                                <th>
+                                  <span>Tribal Status</span>
+                                </th>
+                                <th></th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr>
+                                <td>
+                                  <div css={toggleStyles}>
+                                    <Switch
+                                      disabled={!tribalProviderCount}
+                                      checked={tribalProvidersOnly}
+                                      onChange={(_ev) =>
+                                        setTribalProvidersOnly(
+                                          !tribalProvidersOnly,
+                                        )
+                                      }
+                                      ariaLabel="Tribal Only"
+                                    />
+                                    <span>Tribal Only</span>
+                                  </div>
+                                </td>
+                                <td></td>
+                              </tr>
+                            </tbody>
+                          </table>
                           <AccordionList
                             title={
                               <>
@@ -909,34 +907,32 @@ function DrinkingWater() {
                                 </tr>
                               )}
                             </tbody>
-                            {tribalWithdrawerCount > 0 && (
-                              <tfoot>
-                                <tr>
-                                  <th>
-                                    <span>Tribal Status</span>
-                                  </th>
-                                  <th></th>
-                                </tr>
-                                <tr>
-                                  <td>
-                                    <div css={toggleStyles}>
-                                      <Switch
-                                        disabled={!tribalWithdrawerCount}
-                                        checked={tribalWithdrawersOnly}
-                                        onChange={(_ev) =>
-                                          setTribalWithdrawersOnly(
-                                            !tribalWithdrawersOnly,
-                                          )
-                                        }
-                                        ariaLabel="Tribal Only"
-                                      />
-                                      <span>Tribal Only</span>
-                                    </div>
-                                  </td>
-                                  <td></td>
-                                </tr>
-                              </tfoot>
-                            )}
+                            <tfoot>
+                              <tr>
+                                <th>
+                                  <span>Tribal Status</span>
+                                </th>
+                                <th></th>
+                              </tr>
+                              <tr>
+                                <td>
+                                  <div css={toggleStyles}>
+                                    <Switch
+                                      disabled={!tribalWithdrawerCount}
+                                      checked={tribalWithdrawersOnly}
+                                      onChange={(_ev) =>
+                                        setTribalWithdrawersOnly(
+                                          !tribalWithdrawersOnly,
+                                        )
+                                      }
+                                      ariaLabel="Tribal Only"
+                                    />
+                                    <span>Tribal Only</span>
+                                  </div>
+                                </td>
+                                <td></td>
+                              </tr>
+                            </tfoot>
                           </table>
 
                           <AccordionList

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -397,8 +397,8 @@ function DrinkingWater() {
   const [tribalWithdrawersOnly, setTribalWithdrawersOnly] = useState(false);
 
   // sort drinking water data into providers and withdrawers via presence of 'huc12' property
-  const providers = [];
-  const displayedWithdrawers = [];
+  let providers = [];
+  let displayedWithdrawers = [];
   let surfaceWaterCount = 0; // total surface water withdrawers
   let groundWaterCount = 0; // total groundwater withdrawers
   let tribalProviderCount = 0;
@@ -412,6 +412,9 @@ function DrinkingWater() {
       if (provider.tribal_name) tribalProviderCount++;
       providers.push(provider);
     });
+    if (tribalProvidersOnly) {
+      providers = providers.filter((item) => item.tribal_name != null);
+    }
 
     // find all withdrawers
     const allWithdrawers = drinkingWater.data.filter((system) => system.huc12);
@@ -481,6 +484,11 @@ function DrinkingWater() {
         if (groundWaterDisplayed) displayedWithdrawers.push(item);
       }
     });
+    if (tribalWithdrawersOnly) {
+      displayedWithdrawers = displayedWithdrawers.filter(
+        (item) => item.tribal_name != null,
+      );
+    }
   }
 
   let county = '';
@@ -723,15 +731,13 @@ function DrinkingWater() {
                             }
                             sortOptions={providerSorts}
                           >
-                            {sortWaterSystems(providers, providersSortBy, false)
-                              .filter((item) => {
-                                if (tribalProvidersOnly)
-                                  return item.tribal_name != null;
-                                return true;
-                              })
-                              .map((item) =>
-                                createAccordionItem(services, item),
-                              )}
+                            {sortWaterSystems(
+                              providers,
+                              providersSortBy,
+                              false,
+                            ).map((item) =>
+                              createAccordionItem(services, item),
+                            )}
                           </AccordionList>
                         </>
                       )}
@@ -951,15 +957,9 @@ function DrinkingWater() {
                               displayedWithdrawers,
                               withdrawersSortBy,
                               true,
-                            )
-                              .filter((item) => {
-                                if (tribalWithdrawersOnly)
-                                  return item.tribal_name != null;
-                                return true;
-                              })
-                              .map((item) =>
-                                createAccordionItem(services, item, true),
-                              )}
+                            ).map((item) =>
+                              createAccordionItem(services, item, true),
+                            )}
                           </AccordionList>
                         </>
                       )}


### PR DESCRIPTION
## Related Issues:
* [HMW-194](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-194&quickFilter=2479)

## Main Changes:
* Added the `tribal_name` and `tribal_code` properties from the drinking water data to the accordions on the Drinking Water tab, as the fields *Tribal Name* and *Tribal ID*, respectively. The fields are visible only if there are values for the properties.
* Added a **Tribal Only** filter switch on both the providers and the withdrawers sub-tabs. It is visible in each only if there exists tribal data.

## Steps To Test:
1. Go to the **Drinking Water** tab of the **Community** page, and find a watershed with tribal data, for example  [http://localhost:3000/community/130202010611/drinking-water](http://localhost:3000/community/130202010611/drinking-water)
2. In the case of the example, there is only one tribal withdrawer, so click "Who withdraws water for drinking here?"
3. Toggle the **Tribal Only** switch, and open the accordion of the displayed system
4. The accordion item should have the fields *Tribal Name* and *Tribal ID*