### PR TITLE
Feature/195 education page shading

### DIFF
--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { css } from 'styled-components/macro';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
@@ -10,6 +10,7 @@ import { useEducatorMaterialsContext } from 'contexts/LookupFiles';
 // config
 import { educatorContentError } from 'config/errorMessages';
 // styles
+import { infoBoxStyles } from 'components/shared/MessageBoxes';
 import { fonts } from 'styles/index.js';
 
 // NOTE: matching styles used in tabs in `AboutContent` component
@@ -37,7 +38,6 @@ const containerStyles = css`
   }
 
   h3 {
-    margin-top: 1rem;
     font-size: 1.2em;
     font-weight: bold;
   }
@@ -65,6 +65,14 @@ const containerStyles = css`
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles}
   margin-bottom: 1.25rem;
+`;
+
+const modifiedInfoBoxStyles = css`
+  ${infoBoxStyles}
+  margin-top: 1rem;
+  h3 {
+    margin-bottom: 0.5em;
+  }
 `;
 
 const disclaimerStyles = css`
@@ -127,21 +135,23 @@ function EducatorsContent() {
         </ul>
       )}
 
-      <h3>
-        If you’re an educator, we would like to know how you're using{' '}
-        <em>How’s My Waterway</em>.
-      </h3>
-      <p>
-        <a
-          href="https://www.epa.gov/waterdata/forms/contact-us-about-hows-my-waterway"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Contact us
-        </a>
-        &nbsp;&nbsp;
-        <small css={disclaimerStyles}>(opens new browser tab)</small>
-      </p>
+      <div css={modifiedInfoBoxStyles}>
+        <h3>
+          If you’re an educator, we would like to know how you're using{' '}
+          <em>How’s My Waterway</em>.
+        </h3>
+        <p>
+          <a
+            href="https://www.epa.gov/waterdata/forms/contact-us-about-hows-my-waterway"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Contact us
+          </a>
+          &nbsp;&nbsp;
+          <small css={disclaimerStyles}>(opens new browser tab)</small>
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -4,13 +4,12 @@ import React, { useEffect } from 'react';
 import { css } from 'styled-components/macro';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
 // contexts
 import { useEducatorMaterialsContext } from 'contexts/LookupFiles';
 // config
 import { educatorContentError } from 'config/errorMessages';
 // styles
-import { infoBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import { fonts } from 'styles/index.js';
 
 // NOTE: matching styles used in tabs in `AboutContent` component


### PR DESCRIPTION
## Related Issues:
* [HMW-195](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-195&quickFilter=2479)

## Main Changes:
* Moved the contact prompt and link for educators inside a container, shaded with the site's `infoBoxStyles`.

## Steps to Test:
* Navigate to the Educators page: [http://localhost:3000/educators](http://localhost:3000/educators)