### PR TITLE
Feature/186 locations loss

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -409,10 +409,8 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
           }
         }
       });
-
-      plotGages(gages, usgsStreamgagesLayer).then((_result) => {
-        setNormalizedUsgsStreamgages(gages);
-      });
+      setNormalizedUsgsStreamgages(gages);
+      plotGages(gages, usgsStreamgagesLayer);
     },
     [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
   );

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -35,13 +35,11 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { plotFacilities } from 'utils/mapFunctions';
-import { useWaterbodyOnMap } from 'utils/hooks';
+import { useStreamgageData, useWaterbodyOnMap } from 'utils/hooks';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
 // errors
 import { monitoringError } from 'config/errorMessages';
-// config
-import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
 import { toggleTableStyles } from 'styles/index.js';
 
@@ -101,79 +99,6 @@ type MonitoringLocationGroups = {
     toggled: boolean,
   },
 };
-
-function useStreamgageData(fetchedData, fetchStatus) {
-  const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
-    [],
-  );
-
-  // normalize USGS streamgages data with monitoring stations data
-  useEffect(() => {
-    if (fetchStatus !== 'success' || !fetchedData.value) return;
-
-    const gages = fetchedData.value.map((gage) => {
-      const streamgageMeasurements = { primary: [], secondary: [] };
-
-      [...gage.Datastreams]
-        .filter((item) => item.Observations.length > 0)
-        .forEach((item) => {
-          const observation = item.Observations[0];
-          const parameterCode = item.properties.ParameterCode;
-          const parameterDesc = item.description.split(' / USGS-')[0];
-          const parameterUnit = item.unitOfMeasurement;
-
-          let measurement = observation.result;
-          // convert measurements recorded in celsius to fahrenheit
-          if (['00010', '00020', '85583'].includes(parameterCode)) {
-            measurement = measurement * (9 / 5) + 32;
-          }
-
-          const matchedParam = usgsStaParameters.find((p) => {
-            return p.staParameterCode === parameterCode;
-          });
-
-          const data = {
-            parameterCategory: matchedParam?.hmwCategory || 'exclude',
-            parameterOrder: matchedParam?.hmwOrder || 0,
-            parameterName: matchedParam?.hmwName || parameterDesc,
-            parameterUsgsName: matchedParam?.staDescription || parameterDesc,
-            parameterCode,
-            measurement,
-            datetime: new Date(observation.phenomenonTime).toLocaleString(),
-            dailyAverages: [],
-            unitAbbr: matchedParam?.hmwUnits || parameterUnit.symbol,
-            unitName: parameterUnit.name,
-          };
-
-          if (data.parameterCategory === 'primary') {
-            streamgageMeasurements.primary.push(data);
-          }
-
-          if (data.parameterCategory === 'secondary') {
-            streamgageMeasurements.secondary.push(data);
-          }
-        });
-
-      return {
-        monitoringType: 'Current Water Conditions',
-        siteId: gage.properties.monitoringLocationNumber,
-        orgId: gage.properties.agencyCode,
-        orgName: gage.properties.agency,
-        locationLongitude: gage.Locations[0].location.coordinates[0],
-        locationLatitude: gage.Locations[0].location.coordinates[1],
-        locationName: gage.properties.monitoringLocationName,
-        locationType: gage.properties.monitoringLocationType,
-        locationUrl: gage.properties.monitoringLocationUrl,
-        // usgs streamgage specific properties:
-        streamgageMeasurements,
-      };
-    });
-
-    setNormalizedUsgsStreamgages(gages);
-  }, [fetchedData, fetchStatus]);
-
-  return normalizedUsgsStreamgages;
-}
 
 function Monitoring() {
   const { usgsStreamgages } = useFetchedDataState();
@@ -406,10 +331,7 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
 
   const { watershed } = useContext(LocationSearchContext);
 
-  const normalizedUsgsStreamgages = useStreamgageData(
-    usgsStreamgages.data,
-    usgsStreamgages.status,
-  );
+  const normalizedUsgsStreamgages = useStreamgageData(usgsStreamgages);
 
   // once streamgages have been normalized, add precipitation data and
   // daily average measurements data (both fetched from the usgs daily values

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -41,7 +41,7 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 import { MapHighlightContext } from 'contexts/MapHighlight';
 // utilities
-import { plotFacilities, plotGages, plotStations } from 'utils/mapFunctions';
+import { plotFacilities, plotGages } from 'utils/mapFunctions';
 import { useWaterbodyOnMap } from 'utils/hooks';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
@@ -652,7 +652,25 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
 
       setAllToggled(allOthersToggled);
 
-      plotStations(tempDisplayedMonitoringLocations, monitoringLocationsLayer);
+      // generate a list of location ids
+      const locationIds = [];
+      tempDisplayedMonitoringLocations.forEach((station) => {
+        locationIds.push(station.uniqueId);
+      });
+
+      // update the filters on the layer
+      if (
+        tempDisplayedMonitoringLocations.length ===
+        monitoringLocationTogglesParam.All.stations.length
+      ) {
+        monitoringLocationsLayer.definitionExpression = '';
+      } else if (locationIds.length === 0) {
+        monitoringLocationsLayer.definitionExpression = '1=0';
+      } else {
+        monitoringLocationsLayer.definitionExpression = `uniqueId IN ('${locationIds.join(
+          "','",
+        )}')`;
+      }
 
       if (tempDisplayedMonitoringLocations.length === 0) {
         setDisplayedMonitoringLocations([]);

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -39,6 +39,7 @@ import VirtualizedList from 'components/shared/VirtualizedList';
 import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
+import { MapHighlightContext } from 'contexts/MapHighlight';
 // utilities
 import { plotFacilities, plotGages, plotStations } from 'utils/mapFunctions';
 import { useWaterbodyOnMap } from 'utils/hooks';
@@ -124,6 +125,12 @@ function Monitoring() {
     setVisibleLayers,
     usgsStreamgagesLayer,
   } = useContext(LocationSearchContext);
+
+  // Clear features cached for highlighting on unmount
+  const { setCacheStale } = useContext(MapHighlightContext);
+  useEffect(() => {
+    return setCacheStale(true);
+  }, [setCacheStale]);
 
   const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
     useState(true);

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -410,7 +410,9 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
         }
       });
 
-      setNormalizedUsgsStreamgages(gages);
+      plotGages(gages, usgsStreamgagesLayer).then((_result) => {
+        setNormalizedUsgsStreamgages(gages);
+      });
     },
     [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
   );
@@ -480,18 +482,6 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
 
     addStreamgageData(gages);
   }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
-
-  // emulate componentdidupdate
-  const mounted = useRef();
-  useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-    } else {
-      if (normalizedUsgsStreamgages.length === 0) return;
-
-      plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
-    }
-  }, [normalizedUsgsStreamgages, usgsStreamgagesLayer]);
 
   const [sensorsSortedBy, setSensorsSortedBy] = useState('locationName');
 

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -353,7 +353,6 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
   // once streamgages have been plotted initially, add precipitation data and
   // daily average measurements data (both fetched from the usgs daily values
   // web service) to each streamgage if it exists for that particular location
-  // and replot the streamgages on the map
   const addStreamgageData = useCallback(
     (gages) => {
       if (!usgsPrecipitation.data.value) return;
@@ -416,14 +415,11 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
           }
         }
       });
-      setNormalizedUsgsStreamgages(gages);
-      plotGages(gages, usgsStreamgagesLayer);
     },
-    [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
+    [usgsPrecipitation, usgsDailyAverages],
   );
 
-  // normalize USGS streamgages data with monitoring stations data,
-  // and draw them on the map
+  // normalize USGS streamgages data with monitoring stations data
   useEffect(() => {
     if (!usgsStreamgages.data.value) return;
 
@@ -485,8 +481,22 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
       };
     });
 
+    setNormalizedUsgsStreamgages(gages);
     addStreamgageData(gages);
   }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
+
+  // draw the streamgages on the map,
+  // emulates componentdidupdate
+  const mounted = useRef();
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+    } else {
+      if (normalizedUsgsStreamgages.length === 0) return;
+
+      plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
+    }
+  }, [normalizedUsgsStreamgages, usgsStreamgagesLayer]);
 
   const [sensorsSortedBy, setSensorsSortedBy] = useState('locationName');
 

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1,12 +1,6 @@
 // @flow
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
 import { css } from 'styled-components/macro';
 // components
@@ -39,9 +33,8 @@ import VirtualizedList from 'components/shared/VirtualizedList';
 import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
-import { MapHighlightContext } from 'contexts/MapHighlight';
 // utilities
-import { plotFacilities, plotGages } from 'utils/mapFunctions';
+import { plotFacilities } from 'utils/mapFunctions';
 import { useWaterbodyOnMap } from 'utils/hooks';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
@@ -109,6 +102,79 @@ type MonitoringLocationGroups = {
   },
 };
 
+function useStreamgageData(fetchedData, fetchStatus) {
+  const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
+    [],
+  );
+
+  // normalize USGS streamgages data with monitoring stations data
+  useEffect(() => {
+    if (fetchStatus !== 'success' || !fetchedData.value) return;
+
+    const gages = fetchedData.value.map((gage) => {
+      const streamgageMeasurements = { primary: [], secondary: [] };
+
+      [...gage.Datastreams]
+        .filter((item) => item.Observations.length > 0)
+        .forEach((item) => {
+          const observation = item.Observations[0];
+          const parameterCode = item.properties.ParameterCode;
+          const parameterDesc = item.description.split(' / USGS-')[0];
+          const parameterUnit = item.unitOfMeasurement;
+
+          let measurement = observation.result;
+          // convert measurements recorded in celsius to fahrenheit
+          if (['00010', '00020', '85583'].includes(parameterCode)) {
+            measurement = measurement * (9 / 5) + 32;
+          }
+
+          const matchedParam = usgsStaParameters.find((p) => {
+            return p.staParameterCode === parameterCode;
+          });
+
+          const data = {
+            parameterCategory: matchedParam?.hmwCategory || 'exclude',
+            parameterOrder: matchedParam?.hmwOrder || 0,
+            parameterName: matchedParam?.hmwName || parameterDesc,
+            parameterUsgsName: matchedParam?.staDescription || parameterDesc,
+            parameterCode,
+            measurement,
+            datetime: new Date(observation.phenomenonTime).toLocaleString(),
+            dailyAverages: [],
+            unitAbbr: matchedParam?.hmwUnits || parameterUnit.symbol,
+            unitName: parameterUnit.name,
+          };
+
+          if (data.parameterCategory === 'primary') {
+            streamgageMeasurements.primary.push(data);
+          }
+
+          if (data.parameterCategory === 'secondary') {
+            streamgageMeasurements.secondary.push(data);
+          }
+        });
+
+      return {
+        monitoringType: 'Current Water Conditions',
+        siteId: gage.properties.monitoringLocationNumber,
+        orgId: gage.properties.agencyCode,
+        orgName: gage.properties.agency,
+        locationLongitude: gage.Locations[0].location.coordinates[0],
+        locationLatitude: gage.Locations[0].location.coordinates[1],
+        locationName: gage.properties.monitoringLocationName,
+        locationType: gage.properties.monitoringLocationType,
+        locationUrl: gage.properties.monitoringLocationUrl,
+        // usgs streamgage specific properties:
+        streamgageMeasurements,
+      };
+    });
+
+    setNormalizedUsgsStreamgages(gages);
+  }, [fetchedData, fetchStatus]);
+
+  return normalizedUsgsStreamgages;
+}
+
 function Monitoring() {
   const { usgsStreamgages } = useFetchedDataState();
 
@@ -125,12 +191,6 @@ function Monitoring() {
     setVisibleLayers,
     usgsStreamgagesLayer,
   } = useContext(LocationSearchContext);
-
-  // Clear features cached for highlighting on unmount
-  const { setCacheStale } = useContext(MapHighlightContext);
-  useEffect(() => {
-    return setCacheStale(true);
-  }, [setCacheStale]);
 
   const [usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed] =
     useState(true);
@@ -344,159 +404,74 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
 
   const services = useServicesContext();
 
-  const { usgsStreamgagesLayer, watershed } = useContext(LocationSearchContext);
+  const { watershed } = useContext(LocationSearchContext);
 
-  const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
-    [],
+  const normalizedUsgsStreamgages = useStreamgageData(
+    usgsStreamgages.data,
+    usgsStreamgages.status,
   );
 
-  // once streamgages have been plotted initially, add precipitation data and
+  // once streamgages have been normalized, add precipitation data and
   // daily average measurements data (both fetched from the usgs daily values
   // web service) to each streamgage if it exists for that particular location
-  const addStreamgageData = useCallback(
-    (gages) => {
-      if (!usgsPrecipitation.data.value) return;
-      if (!usgsDailyAverages.data.value) return;
-      if (gages.length === 0) return;
-
-      const streamgageSiteIds = gages.map((gage) => {
-        return gage.siteId;
-      });
-
-      usgsPrecipitation.data.value?.timeSeries.forEach((site) => {
-        const siteId = site.sourceInfo.siteCode[0].value;
-        const observation = site.values[0].value[0];
-
-        if (streamgageSiteIds.includes(siteId)) {
-          const streamgage = gages.find((gage) => {
-            return gage.siteId === siteId;
-          });
-
-          streamgage.streamgageMeasurements.primary.push({
-            parameterCategory: 'primary',
-            parameterOrder: 5,
-            parameterName: 'Total Daily Rainfall',
-            parameterUsgsName: 'Precipitation (USGS Daily Value)',
-            parameterCode: '00045',
-            measurement: observation.value,
-            datetime: new Date(observation.dateTime).toLocaleDateString(),
-            dailyAverages: [],
-            unitAbbr: 'in',
-            unitName: 'inches',
-          });
-        }
-      });
-
-      usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
-        const siteId = site.sourceInfo.siteCode[0].value;
-        const sitesHasObservations = site.values[0].value.length > 0;
-
-        if (streamgageSiteIds.includes(siteId) && sitesHasObservations) {
-          const streamgage = gages.find((gage) => {
-            return gage.siteId === siteId;
-          });
-
-          const paramCode = site.variable.variableCode[0].value;
-          const observations = site.values[0].value.map(
-            ({ value, dateTime }) => {
-              return { measurement: value, date: new Date(dateTime) };
-            },
-          );
-
-          // NOTE: 'category' is either 'primary' or 'secondary' – loop over both
-          for (const category in streamgage.streamgageMeasurements) {
-            streamgage.streamgageMeasurements[category].forEach(
-              (measurement) => {
-                if (measurement.parameterCode === paramCode.toString()) {
-                  measurement.dailyAverages = observations;
-                }
-              },
-            );
-          }
-        }
-      });
-    },
-    [usgsPrecipitation, usgsDailyAverages],
-  );
-
-  // normalize USGS streamgages data with monitoring stations data
   useEffect(() => {
-    if (!usgsStreamgages.data.value) return;
+    if (!usgsPrecipitation.data.value) return;
+    if (!usgsDailyAverages.data.value) return;
+    if (normalizedUsgsStreamgages.length === 0) return;
 
-    const gages = usgsStreamgages.data.value.map((gage) => {
-      const streamgageMeasurements = { primary: [], secondary: [] };
-
-      [...gage.Datastreams]
-        .filter((item) => item.Observations.length > 0)
-        .forEach((item) => {
-          const observation = item.Observations[0];
-          const parameterCode = item.properties.ParameterCode;
-          const parameterDesc = item.description.split(' / USGS-')[0];
-          const parameterUnit = item.unitOfMeasurement;
-
-          let measurement = observation.result;
-          // convert measurements recorded in celsius to fahrenheit
-          if (['00010', '00020', '85583'].includes(parameterCode)) {
-            measurement = measurement * (9 / 5) + 32;
-          }
-
-          const matchedParam = usgsStaParameters.find((p) => {
-            return p.staParameterCode === parameterCode;
-          });
-
-          const data = {
-            parameterCategory: matchedParam?.hmwCategory || 'exclude',
-            parameterOrder: matchedParam?.hmwOrder || 0,
-            parameterName: matchedParam?.hmwName || parameterDesc,
-            parameterUsgsName: matchedParam?.staDescription || parameterDesc,
-            parameterCode,
-            measurement,
-            datetime: new Date(observation.phenomenonTime).toLocaleString(),
-            dailyAverages: [],
-            unitAbbr: matchedParam?.hmwUnits || parameterUnit.symbol,
-            unitName: parameterUnit.name,
-          };
-
-          if (data.parameterCategory === 'primary') {
-            streamgageMeasurements.primary.push(data);
-          }
-
-          if (data.parameterCategory === 'secondary') {
-            streamgageMeasurements.secondary.push(data);
-          }
-        });
-
-      return {
-        monitoringType: 'Current Water Conditions',
-        siteId: gage.properties.monitoringLocationNumber,
-        orgId: gage.properties.agencyCode,
-        orgName: gage.properties.agency,
-        locationLongitude: gage.Locations[0].location.coordinates[0],
-        locationLatitude: gage.Locations[0].location.coordinates[1],
-        locationName: gage.properties.monitoringLocationName,
-        locationType: gage.properties.monitoringLocationType,
-        locationUrl: gage.properties.monitoringLocationUrl,
-        // usgs streamgage specific properties:
-        streamgageMeasurements,
-      };
+    const streamgageSiteIds = normalizedUsgsStreamgages.map((gage) => {
+      return gage.siteId;
     });
 
-    setNormalizedUsgsStreamgages(gages);
-    addStreamgageData(gages);
-  }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
+    usgsPrecipitation.data.value?.timeSeries.forEach((site) => {
+      const siteId = site.sourceInfo.siteCode[0].value;
+      const observation = site.values[0].value[0];
 
-  // draw the streamgages on the map,
-  // emulates componentdidupdate
-  const mounted = useRef();
-  useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-    } else {
-      if (normalizedUsgsStreamgages.length === 0) return;
+      if (streamgageSiteIds.includes(siteId)) {
+        const streamgage = normalizedUsgsStreamgages.find((gage) => {
+          return gage.siteId === siteId;
+        });
 
-      plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
-    }
-  }, [normalizedUsgsStreamgages, usgsStreamgagesLayer]);
+        streamgage?.streamgageMeasurements.primary.push({
+          parameterCategory: 'primary',
+          parameterOrder: 5,
+          parameterName: 'Total Daily Rainfall',
+          parameterUsgsName: 'Precipitation (USGS Daily Value)',
+          parameterCode: '00045',
+          measurement: observation.value,
+          datetime: new Date(observation.dateTime).toLocaleDateString(),
+          dailyAverages: [],
+          unitAbbr: 'in',
+          unitName: 'inches',
+        });
+      }
+    });
+
+    usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
+      const siteId = site.sourceInfo.siteCode[0].value;
+      const sitesHasObservations = site.values[0].value.length > 0;
+
+      if (streamgageSiteIds.includes(siteId) && sitesHasObservations) {
+        const streamgage = normalizedUsgsStreamgages.find((gage) => {
+          return gage.siteId === siteId;
+        });
+
+        const paramCode = site.variable.variableCode[0].value;
+        const observations = site.values[0].value.map(({ value, dateTime }) => {
+          return { measurement: value, date: new Date(dateTime) };
+        });
+
+        // NOTE: 'category' is either 'primary' or 'secondary' – loop over both
+        for (const category in streamgage?.streamgageMeasurements) {
+          streamgage.streamgageMeasurements[category].forEach((measurement) => {
+            if (measurement.parameterCode === paramCode.toString()) {
+              measurement.dailyAverages = observations;
+            }
+          });
+        }
+      }
+    });
+  }, [normalizedUsgsStreamgages, usgsPrecipitation, usgsDailyAverages]);
 
   const [sensorsSortedBy, setSensorsSortedBy] = useState('locationName');
 

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -38,7 +38,6 @@ import { MapHighlightContext } from 'contexts/MapHighlight';
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
 import {
   plotFacilities,
-  plotStations,
   plotGages,
   getUniqueWaterbodies,
 } from 'utils/mapFunctions';
@@ -695,7 +694,9 @@ function MonitoringAndSensorsTab({
     }));
 
     setNormalizedMonitoringLocations(stations);
-    plotStations(stations, monitoringLocationsLayer);
+
+    // remove any filters on the monitoring locations layer
+    monitoringLocationsLayer.definitionExpression = '';
   }, [monitoringLocations.data, monitoringLocationsLayer, services]);
 
   const allMonitoringAndSensors = [

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -1,12 +1,6 @@
 // @flow
 
-import React, {
-  useState,
-  useRef,
-  useEffect,
-  useContext,
-  useCallback,
-} from 'react';
+import React, { useState, useEffect, useContext, useCallback } from 'react';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
 import { css } from 'styled-components/macro';
 // components
@@ -35,11 +29,7 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
-import {
-  plotFacilities,
-  plotGages,
-  getUniqueWaterbodies,
-} from 'utils/mapFunctions';
+import { plotFacilities, getUniqueWaterbodies } from 'utils/mapFunctions';
 // errors
 import {
   echoError,

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -28,7 +28,11 @@ import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
-import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
+import {
+  useStreamgageData,
+  useWaterbodyFeatures,
+  useWaterbodyOnMap,
+} from 'utils/hooks';
 import { plotFacilities, getUniqueWaterbodies } from 'utils/mapFunctions';
 // errors
 import {
@@ -38,8 +42,6 @@ import {
   huc12SummaryError,
   zeroAssessedWaterbodies,
 } from 'config/errorMessages';
-// config
-import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
 import { toggleTableStyles } from 'styles/index.js';
 
@@ -81,79 +83,6 @@ const toggleStyles = css`
     margin-left: 0.5rem;
   }
 `;
-
-function useStreamgageData(fetchedData, fetchStatus) {
-  const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
-    [],
-  );
-
-  // normalize USGS streamgages data with monitoring stations data
-  useEffect(() => {
-    if (fetchStatus !== 'success' || !fetchedData.value) return;
-
-    const gages = fetchedData.value.map((gage) => {
-      const streamgageMeasurements = { primary: [], secondary: [] };
-
-      [...gage.Datastreams]
-        .filter((item) => item.Observations.length > 0)
-        .forEach((item) => {
-          const observation = item.Observations[0];
-          const parameterCode = item.properties.ParameterCode;
-          const parameterDesc = item.description.split(' / USGS-')[0];
-          const parameterUnit = item.unitOfMeasurement;
-
-          let measurement = observation.result;
-          // convert measurements recorded in celsius to fahrenheit
-          if (['00010', '00020', '85583'].includes(parameterCode)) {
-            measurement = measurement * (9 / 5) + 32;
-          }
-
-          const matchedParam = usgsStaParameters.find((p) => {
-            return p.staParameterCode === parameterCode;
-          });
-
-          const data = {
-            parameterCategory: matchedParam?.hmwCategory || 'exclude',
-            parameterOrder: matchedParam?.hmwOrder || 0,
-            parameterName: matchedParam?.hmwName || parameterDesc,
-            parameterUsgsName: matchedParam?.staDescription || parameterDesc,
-            parameterCode,
-            measurement,
-            datetime: new Date(observation.phenomenonTime).toLocaleString(),
-            dailyAverages: [],
-            unitAbbr: matchedParam?.hmwUnits || parameterUnit.symbol,
-            unitName: parameterUnit.name,
-          };
-
-          if (data.parameterCategory === 'primary') {
-            streamgageMeasurements.primary.push(data);
-          }
-
-          if (data.parameterCategory === 'secondary') {
-            streamgageMeasurements.secondary.push(data);
-          }
-        });
-
-      return {
-        monitoringType: 'Current Water Conditions',
-        siteId: gage.properties.monitoringLocationNumber,
-        orgId: gage.properties.agencyCode,
-        orgName: gage.properties.agency,
-        locationLongitude: gage.Locations[0].location.coordinates[0],
-        locationLatitude: gage.Locations[0].location.coordinates[1],
-        locationName: gage.properties.monitoringLocationName,
-        locationType: gage.properties.monitoringLocationType,
-        locationUrl: gage.properties.monitoringLocationUrl,
-        // usgs streamgage specific properties:
-        streamgageMeasurements,
-      };
-    });
-
-    setNormalizedUsgsStreamgages(gages);
-  }, [fetchedData, fetchStatus]);
-
-  return normalizedUsgsStreamgages;
-}
 
 function Overview() {
   const { usgsStreamgages } = useFetchedDataState();
@@ -561,10 +490,7 @@ function MonitoringAndSensorsTab({
     setMonitoringAndSensorsDisplayed,
   ]);
 
-  const normalizedUsgsStreamgages = useStreamgageData(
-    usgsStreamgages.data,
-    usgsStreamgages.status,
-  );
+  const normalizedUsgsStreamgages = useStreamgageData(usgsStreamgages);
 
   // once streamgages have been normalized, add precipitation data and
   // daily average measurements data (both fetched from the usgs daily values

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -510,19 +510,9 @@ function MonitoringAndSensorsTab({
     [],
   );
 
-  // emulate componentdidupdate
-  const mounted = useRef();
-  useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true;
-    }
-    return () => (mounted.current = false);
-  }, []);
-
   // once streamgages have been plotted initially, add precipitation data and
   // daily average measurements data (both fetched from the usgs daily values
   // web service) to each streamgage if it exists for that particular location
-  // and replot the streamgages on the map
   const addStreamgageData = useCallback(
     (gages) => {
       if (!usgsPrecipitation.data.value) return;
@@ -585,14 +575,11 @@ function MonitoringAndSensorsTab({
           }
         }
       });
-
-      plotGages(gages, usgsStreamgagesLayer);
     },
-    [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
+    [usgsPrecipitation, usgsDailyAverages],
   );
 
-  // normalize USGS streamgages data with monitoring stations data,
-  // and draw them on the map
+  // normalize USGS streamgages data with monitoring stations data
   useEffect(() => {
     if (!usgsStreamgages.data.value) return;
 
@@ -657,6 +644,19 @@ function MonitoringAndSensorsTab({
     setNormalizedUsgsStreamgages(gages);
     addStreamgageData(gages);
   }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
+
+  // draw the streamgages on the map,
+  // emulates componentdidupdate
+  const mounted = useRef();
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+    } else {
+      if (normalizedUsgsStreamgages.length === 0) return;
+
+      plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
+    }
+  }, [normalizedUsgsStreamgages, usgsStreamgagesLayer]);
 
   const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
     useState([]);

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -484,10 +484,80 @@ function MonitoringAndSensorsTab({
     setMonitoringAndSensorsDisplayed,
   ]);
 
-  const [usgsStreamgagesPlotted, setUsgsStreamgagesPlotted] = useState(false);
-
   const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
     [],
+  );
+
+  // once streamgages have been plotted initially, add precipitation data and
+  // daily average measurements data (both fetched from the usgs daily values
+  // web service) to each streamgage if it exists for that particular location
+  // and replot the streamgages on the map
+  const addStreamgageData = useCallback(
+    (gages) => {
+      if (!usgsPrecipitation.data.value) return;
+      if (!usgsDailyAverages.data.value) return;
+      if (gages.length === 0) return;
+
+      const streamgageSiteIds = gages.map((gage) => {
+        return gage.siteId;
+      });
+
+      usgsPrecipitation.data.value?.timeSeries.forEach((site) => {
+        const siteId = site.sourceInfo.siteCode[0].value;
+        const observation = site.values[0].value[0];
+
+        if (streamgageSiteIds.includes(siteId)) {
+          const streamgage = gages.find((gage) => {
+            return gage.siteId === siteId;
+          });
+
+          streamgage.streamgageMeasurements.primary.push({
+            parameterCategory: 'primary',
+            parameterOrder: 5,
+            parameterName: 'Total Daily Rainfall',
+            parameterUsgsName: 'Precipitation (USGS Daily Value)',
+            parameterCode: '00045',
+            measurement: observation.value,
+            datetime: new Date(observation.dateTime).toLocaleDateString(),
+            dailyAverages: [],
+            unitAbbr: 'in',
+            unitName: 'inches',
+          });
+        }
+      });
+
+      usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
+        const siteId = site.sourceInfo.siteCode[0].value;
+        const sitesHasObservations = site.values[0].value.length > 0;
+
+        if (streamgageSiteIds.includes(siteId) && sitesHasObservations) {
+          const streamgage = gages.find((gage) => {
+            return gage.siteId === siteId;
+          });
+
+          const paramCode = site.variable.variableCode[0].value;
+          const observations = site.values[0].value.map(
+            ({ value, dateTime }) => {
+              return { measurement: value, date: new Date(dateTime) };
+            },
+          );
+
+          // NOTE: 'category' is either 'primary' or 'secondary' – loop over both
+          for (const category in streamgage.streamgageMeasurements) {
+            streamgage.streamgageMeasurements[category].forEach(
+              (measurement) => {
+                if (measurement.parameterCode === paramCode.toString()) {
+                  measurement.dailyAverages = observations;
+                }
+              },
+            );
+          }
+        }
+      });
+
+      setNormalizedUsgsStreamgages(gages);
+    },
+    [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
   );
 
   // normalize USGS streamgages data with monitoring stations data,
@@ -553,84 +623,8 @@ function MonitoringAndSensorsTab({
       };
     });
 
-    setNormalizedUsgsStreamgages(gages);
-
-    plotGages(gages, usgsStreamgagesLayer).then((result) => {
-      if (result.addFeatureResults.length > 0) setUsgsStreamgagesPlotted(true);
-    });
-  }, [usgsStreamgages.data, usgsStreamgagesLayer]);
-
-  // once streamgages have been plotted initially, add precipitation data and
-  // daily average measurements data (both fetched from the usgs daily values
-  // web service) to each streamgage if it exists for that particular location
-  // and replot the streamgages on the map
-  useEffect(() => {
-    if (!usgsStreamgagesPlotted) return;
-    if (!usgsPrecipitation.data.value) return;
-    if (!usgsDailyAverages.data.value) return;
-    if (normalizedUsgsStreamgages.length === 0) return;
-
-    const streamgageSiteIds = normalizedUsgsStreamgages.map((gage) => {
-      return gage.siteId;
-    });
-
-    usgsPrecipitation.data.value?.timeSeries.forEach((site) => {
-      const siteId = site.sourceInfo.siteCode[0].value;
-      const observation = site.values[0].value[0];
-
-      if (streamgageSiteIds.includes(siteId)) {
-        const streamgage = normalizedUsgsStreamgages.find((gage) => {
-          return gage.siteId === siteId;
-        });
-
-        streamgage.streamgageMeasurements.primary.push({
-          parameterCategory: 'primary',
-          parameterOrder: 5,
-          parameterName: 'Total Daily Rainfall',
-          parameterUsgsName: 'Precipitation (USGS Daily Value)',
-          parameterCode: '00045',
-          measurement: observation.value,
-          datetime: new Date(observation.dateTime).toLocaleDateString(),
-          dailyAverages: [],
-          unitAbbr: 'in',
-          unitName: 'inches',
-        });
-      }
-    });
-
-    usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
-      const siteId = site.sourceInfo.siteCode[0].value;
-      const sitesHasObservations = site.values[0].value.length > 0;
-
-      if (streamgageSiteIds.includes(siteId) && sitesHasObservations) {
-        const streamgage = normalizedUsgsStreamgages.find((gage) => {
-          return gage.siteId === siteId;
-        });
-
-        const paramCode = site.variable.variableCode[0].value;
-        const observations = site.values[0].value.map(({ value, dateTime }) => {
-          return { measurement: value, date: new Date(dateTime) };
-        });
-
-        // NOTE: 'category' is either 'primary' or 'secondary' – loop over both
-        for (const category in streamgage.streamgageMeasurements) {
-          streamgage.streamgageMeasurements[category].forEach((measurement) => {
-            if (measurement.parameterCode === paramCode.toString()) {
-              measurement.dailyAverages = observations;
-            }
-          });
-        }
-      }
-    });
-
-    plotGages(normalizedUsgsStreamgages, usgsStreamgagesLayer);
-  }, [
-    usgsStreamgagesPlotted,
-    usgsPrecipitation,
-    usgsDailyAverages,
-    normalizedUsgsStreamgages,
-    usgsStreamgagesLayer,
-  ]);
+    addStreamgageData(gages);
+  }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
 
   const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
     useState([]);
@@ -666,6 +660,10 @@ function MonitoringAndSensorsTab({
       stationTotalsByCategory: JSON.stringify(
         station.properties.characteristicGroupResultCount,
       ),
+      uniqueId:
+        `${station.properties.MonitoringLocationIdentifier}-` +
+        `${station.properties.ProviderName}-` +
+        `${station.properties.OrganizationIdentifier}`,
     }));
 
     setNormalizedMonitoringLocations(stations);

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -33,6 +33,7 @@ import VirtualizedList from 'components/shared/VirtualizedList';
 import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
+import { MapHighlightContext } from 'contexts/MapHighlight';
 // utilities
 import { useWaterbodyFeatures, useWaterbodyOnMap } from 'utils/hooks';
 import {
@@ -468,6 +469,12 @@ function MonitoringAndSensorsTab({
     usgsStreamgagesLayer,
     watershed,
   } = useContext(LocationSearchContext);
+
+  // Clear features cached for highlighting on unmount
+  const { setCacheStale } = useContext(MapHighlightContext);
+  useEffect(() => {
+    return setCacheStale(true);
+  }, [setCacheStale]);
 
   const services = useServicesContext();
 

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -473,6 +473,10 @@ function MonitoringAndSensorsTab({
 
   const [expandedRows, setExpandedRows] = useState([]);
 
+  const [listTypes, setListTypes] = useState({
+    usgsStreamgages: usgsStreamgagesDisplayed,
+    monitoringLocations: monitoringLocationsDisplayed,
+  });
   // if either of the "Current Water Conditions" or "Sample Locations" switches
   // are turned on, or if both switches are turned off, keep the "Monitoring
   // Stations" switch in sync
@@ -484,6 +488,11 @@ function MonitoringAndSensorsTab({
     if (!usgsStreamgagesDisplayed && !monitoringLocationsDisplayed) {
       setMonitoringAndSensorsDisplayed(false);
     }
+
+    setListTypes({
+      usgsStreamgages: usgsStreamgagesDisplayed,
+      monitoringLocations: monitoringLocationsDisplayed,
+    });
   }, [
     usgsStreamgagesDisplayed,
     monitoringLocationsDisplayed,
@@ -570,9 +579,7 @@ function MonitoringAndSensorsTab({
         }
       });
 
-      plotGages(gages, usgsStreamgagesLayer).then(() => {
-        mounted.current && setNormalizedUsgsStreamgages(gages);
-      });
+      plotGages(gages, usgsStreamgagesLayer);
     },
     [usgsPrecipitation, usgsDailyAverages, usgsStreamgagesLayer],
   );
@@ -640,6 +647,7 @@ function MonitoringAndSensorsTab({
       };
     });
 
+    setNormalizedUsgsStreamgages(gages);
     addStreamgageData(gages);
   }, [addStreamgageData, usgsStreamgages.data, usgsStreamgagesLayer]);
 
@@ -679,9 +687,8 @@ function MonitoringAndSensorsTab({
       ),
     }));
 
-    plotStations(stations, monitoringLocationsLayer).then((_result) => {
-      mounted.current && setNormalizedMonitoringLocations(stations);
-    });
+    setNormalizedMonitoringLocations(stations);
+    plotStations(stations, monitoringLocationsLayer);
   }, [monitoringLocations.data, monitoringLocationsLayer, services]);
 
   const allMonitoringAndSensors = [
@@ -869,6 +876,7 @@ function MonitoringAndSensorsTab({
               <VirtualizedList
                 items={filteredMonitoringAndSensors}
                 expandedRowsSetter={setExpandedRows}
+                displayedTypes={listTypes}
                 renderer={({ index, resizeCell, allExpanded }) => {
                   const item = filteredMonitoringAndSensors[index];
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -32,8 +32,6 @@ import {
   getUniqueWaterbodies,
 } from 'utils/mapFunctions';
 import MapErrorBoundary from 'components/shared/ErrorBoundary.MapErrorBoundary';
-// config
-import { usgsStaParameters } from 'config/usgsStaParameters';
 // contexts
 import { useFetchedDataDispatch, useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
@@ -57,6 +55,7 @@ import {
   useDynamicPopup,
   useGeometryUtils,
   useSharedLayers,
+  useStreamgageData,
   useWaterbodyHighlight,
   useWaterbodyFeatures,
 } from 'utils/hooks';
@@ -79,79 +78,6 @@ import { colors } from 'styles/index.js';
 // turns an array into a string for the service queries
 function createQueryString(array) {
   return `'${array.join("', '")}'`;
-}
-
-function useStreamgageData(fetchedData, fetchStatus) {
-  const [normalizedUsgsStreamgages, setNormalizedUsgsStreamgages] = useState(
-    [],
-  );
-
-  // normalize USGS streamgages data with monitoring stations data
-  useEffect(() => {
-    if (fetchStatus !== 'success' || !fetchedData.value) return;
-
-    const gages = fetchedData.value.map((gage) => {
-      const streamgageMeasurements = { primary: [], secondary: [] };
-
-      [...gage.Datastreams]
-        .filter((item) => item.Observations.length > 0)
-        .forEach((item) => {
-          const observation = item.Observations[0];
-          const parameterCode = item.properties.ParameterCode;
-          const parameterDesc = item.description.split(' / USGS-')[0];
-          const parameterUnit = item.unitOfMeasurement;
-
-          let measurement = observation.result;
-          // convert measurements recorded in celsius to fahrenheit
-          if (['00010', '00020', '85583'].includes(parameterCode)) {
-            measurement = measurement * (9 / 5) + 32;
-          }
-
-          const matchedParam = usgsStaParameters.find((p) => {
-            return p.staParameterCode === parameterCode;
-          });
-
-          const data = {
-            parameterCategory: matchedParam?.hmwCategory || 'exclude',
-            parameterOrder: matchedParam?.hmwOrder || 0,
-            parameterName: matchedParam?.hmwName || parameterDesc,
-            parameterUsgsName: matchedParam?.staDescription || parameterDesc,
-            parameterCode,
-            measurement,
-            datetime: new Date(observation.phenomenonTime).toLocaleString(),
-            dailyAverages: [],
-            unitAbbr: matchedParam?.hmwUnits || parameterUnit.symbol,
-            unitName: parameterUnit.name,
-          };
-
-          if (data.parameterCategory === 'primary') {
-            streamgageMeasurements.primary.push(data);
-          }
-
-          if (data.parameterCategory === 'secondary') {
-            streamgageMeasurements.secondary.push(data);
-          }
-        });
-
-      return {
-        monitoringType: 'Current Water Conditions',
-        siteId: gage.properties.monitoringLocationNumber,
-        orgId: gage.properties.agencyCode,
-        orgName: gage.properties.agency,
-        locationLongitude: gage.Locations[0].location.coordinates[0],
-        locationLatitude: gage.Locations[0].location.coordinates[1],
-        locationName: gage.properties.monitoringLocationName,
-        locationType: gage.properties.monitoringLocationType,
-        locationUrl: gage.properties.monitoringLocationUrl,
-        // usgs streamgage specific properties:
-        streamgageMeasurements,
-      };
-    });
-
-    setNormalizedUsgsStreamgages(gages);
-  }, [fetchedData, fetchStatus]);
-
-  return normalizedUsgsStreamgages;
 }
 
 const mapPadding = 20;
@@ -1308,7 +1234,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     [services, fetchedDataDispatch],
   );
 
-  const normalizedUsgsStreamgages = useStreamgageData(usgsStreamgages.data, usgsStreamgages.status);
+  const normalizedUsgsStreamgages = useStreamgageData(usgsStreamgages);
 
   useEffect(() => {
     if (!usgsStreamgagesLayer || !normalizedUsgsStreamgages.length) return;

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -15,7 +15,7 @@ type Props = {
   items: Array<Object>,
   renderer: Function,
   allExpanded?: boolean,
-  displayedTypes?: Array<String>,
+  displayedTypes?: Object,
   expandedRowsSetter?: Function,
 };
 

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -15,6 +15,7 @@ type Props = {
   items: Array<Object>,
   renderer: Function,
   allExpanded?: boolean,
+  displayedTypes?: Array<String>,
   expandedRowsSetter?: Function,
 };
 
@@ -22,6 +23,7 @@ function VirtualizedListInner({
   items,
   renderer,
   allExpanded,
+  displayedTypes,
   expandedRowsSetter,
 }: Props) {
   const [cache] = useState(
@@ -37,9 +39,9 @@ function VirtualizedListInner({
   // This is done anytime an accordion item is expanded/collapsed
   useEffect(() => {
     cache.clearAll();
-    listRef.current.recomputeRowHeights();
+    listRef.current?.recomputeRowHeights();
     if (expandedRowsSetter) expandedRowsSetter([]);
-  }, [allExpanded, cache, expandedRowsSetter]);
+  }, [allExpanded, cache, expandedRowsSetter, displayedTypes]);
 
   function rowRenderer({ index, isScrolling, key, parent, style }) {
     function resizeCell() {
@@ -102,6 +104,7 @@ function VirtualizedList({
   items,
   renderer,
   allExpanded,
+  displayedTypes,
   expandedRowsSetter,
 }: Props) {
   const ref = useRef();
@@ -115,6 +118,7 @@ function VirtualizedList({
           renderer={renderer}
           allExpanded={allExpanded}
           expandedRowsSetter={expandedRowsSetter}
+          displayedTypes={displayedTypes}
         />
       )}
     </div>

--- a/app/client/src/contexts/MapHighlight.js
+++ b/app/client/src/contexts/MapHighlight.js
@@ -6,22 +6,26 @@ import type { Node } from 'react';
 export const MapHighlightContext: Object = createContext({
   highlightedGraphic: '',
   selectedGraphic: '',
+  cacheStale: false,
 });
 
 type Props = { children: Node };
 type State = {
   highlightedGraphic: Object,
   selectedGraphic: Object,
+  cacheStale: boolean,
   getHighlightedGraphic: Function,
   getSelectedGraphic: Function,
   setHighlightedGraphic: Function,
   setSelectedGraphic: Function,
+  setCacheStale: Function,
 };
 
 export class MapHighlightProvider extends Component<Props, State> {
   state: State = {
     highlightedGraphic: '',
     selectedGraphic: '',
+    cacheStale: false,
     getHighlightedGraphic: () => {
       return this.state.highlightedGraphic;
     },
@@ -33,6 +37,9 @@ export class MapHighlightProvider extends Component<Props, State> {
     },
     setSelectedGraphic: (selectedGraphic: Object) => {
       this.setState({ selectedGraphic });
+    },
+    setCacheStale: (cacheStale: boolean) => {
+      this.setState({ cacheStale });
     },
   };
 

--- a/app/client/src/contexts/MapHighlight.js
+++ b/app/client/src/contexts/MapHighlight.js
@@ -6,26 +6,22 @@ import type { Node } from 'react';
 export const MapHighlightContext: Object = createContext({
   highlightedGraphic: '',
   selectedGraphic: '',
-  cacheStale: false,
 });
 
 type Props = { children: Node };
 type State = {
   highlightedGraphic: Object,
   selectedGraphic: Object,
-  cacheStale: boolean,
   getHighlightedGraphic: Function,
   getSelectedGraphic: Function,
   setHighlightedGraphic: Function,
   setSelectedGraphic: Function,
-  setCacheStale: Function,
 };
 
 export class MapHighlightProvider extends Component<Props, State> {
   state: State = {
     highlightedGraphic: '',
     selectedGraphic: '',
-    cacheStale: false,
     getHighlightedGraphic: () => {
       return this.state.highlightedGraphic;
     },
@@ -37,9 +33,6 @@ export class MapHighlightProvider extends Component<Props, State> {
     },
     setSelectedGraphic: (selectedGraphic: Object) => {
       this.setState({ selectedGraphic });
-    },
-    setCacheStale: (cacheStale: boolean) => {
-      this.setState({ cacheStale });
     },
   };
 

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -309,8 +309,6 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
   const {
     highlightedGraphic,
     selectedGraphic, //
-    cacheStale,
-    setCacheStale,
   } = useContext(MapHighlightContext);
   const {
     mapView,
@@ -392,8 +390,7 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
       currentSelection: null,
       cachedHighlights: {},
     });
-    setCacheStale(false);
-  }, [cacheStale, huc12, setCacheStale]);
+  }, [huc12]);
 
   // do the highlighting
   useEffect(() => {

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -309,6 +309,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
   const {
     highlightedGraphic,
     selectedGraphic, //
+    cacheStale,
+    setCacheStale,
   } = useContext(MapHighlightContext);
   const {
     mapView,
@@ -390,7 +392,8 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
       currentSelection: null,
       cachedHighlights: {},
     });
-  }, [huc12]);
+    setCacheStale(false);
+  }, [cacheStale, huc12, setCacheStale]);
 
   // do the highlighting
   useEffect(() => {

--- a/app/client/src/utils/mapFunctions.js
+++ b/app/client/src/utils/mapFunctions.js
@@ -339,38 +339,6 @@ export function createWaterbodySymbol({
   }
 }
 
-// plot monitoring stations on map
-export function plotStations(stations: Array<Object>, layer: any) {
-  if (!stations || !layer) return;
-
-  // sort descending order so that smaller graphics show up on top
-  const stationsSorted = [...stations];
-  stationsSorted.sort((a, b) => {
-    return (
-      parseInt(b.stationTotalMeasurements) -
-      parseInt(a.stationTotalMeasurements)
-    );
-  });
-
-  const graphics = stationsSorted.map((station) => {
-    return new Graphic({
-      geometry: {
-        type: 'point',
-        longitude: station.locationLongitude,
-        latitude: station.locationLatitude,
-      },
-      attributes: station,
-    });
-  });
-
-  return layer.queryFeatures().then((featureSet) => {
-    return layer.applyEdits({
-      deleteFeatures: featureSet.features,
-      addFeatures: graphics,
-    });
-  });
-}
-
 // plot usgs streamgages on map
 export function plotGages(gages: Object[], layer: any) {
   if (!gages || !layer) return;

--- a/app/client/src/utils/mapFunctions.js
+++ b/app/client/src/utils/mapFunctions.js
@@ -363,7 +363,7 @@ export function plotStations(stations: Array<Object>, layer: any) {
     });
   });
 
-  layer.queryFeatures().then((featureSet) => {
+  return layer.queryFeatures().then((featureSet) => {
     return layer.applyEdits({
       deleteFeatures: featureSet.features,
       addFeatures: graphics,

--- a/app/client/src/utils/mapFunctions.js
+++ b/app/client/src/utils/mapFunctions.js
@@ -339,38 +339,6 @@ export function createWaterbodySymbol({
   }
 }
 
-// plot usgs streamgages on map
-export function plotGages(gages: Object[], layer: any) {
-  if (!gages || !layer) return;
-
-  const graphics = gages.map((gage) => {
-    const gageHeightMeasurements = gage.streamgageMeasurements.primary.filter(
-      (d) => d.parameterCode === '00065',
-    );
-
-    const gageHeight =
-      gageHeightMeasurements.length === 1
-        ? gageHeightMeasurements[0]?.measurement
-        : null;
-
-    return new Graphic({
-      geometry: {
-        type: 'point',
-        longitude: gage.locationLongitude,
-        latitude: gage.locationLatitude,
-      },
-      attributes: { gageHeight, ...gage },
-    });
-  });
-
-  return layer.queryFeatures().then((featureSet) => {
-    return layer.applyEdits({
-      deleteFeatures: featureSet.features,
-      addFeatures: graphics,
-    });
-  });
-}
-
 // plot issues on map
 export function plotIssues(features: Array<Object>, layer: any) {
   if (!features || !layer) return;


### PR DESCRIPTION
## Related Issues:
* [HMW-186](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-186&quickFilter=2479)

## Main Changes:
* Moved a `useEffect` hook that plotted streamgages into a `useCallback` function, which is then called from a closely related effect. Altering the streamgage data after plotting or too many calls to `plotGages` was causing features on the map to drop off when switching tabs.
* Added a flag to the `MapHighlightContext` to signal when the feature cache employed by `useWaterbodyHighlight` goes stale. Re-using the cache between the **Overview** and **Monitoring** tabs resulted in features not being highlighted.
* Added an optional prop to the `VirtualizedList` component that lists which type of data is displayed in the list. This was done to fix a problem in the **Monitoring & Sensors** list in the **Overview** tab: if only *Current Water Conditions* was initially toggled on, then *Sample Locations*, the list would not resize to the larger row height of the monitoring locations accordion items, so the prop is used to signal a resize.

## Steps To Test:
1. Navigate to the **Overview** tab of the **Community** page
2. Click the *Monitoring & Sensors* sub-tab
3. Toggle on the *Current Water Condition*, and highlight a few of the features
4. Go to the **Monitoring** tab
5. Confirm that all features are still visible, and that highlighting works properly