### PR TITLE
Feature/196 text changes overview monitoring

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -49,6 +49,7 @@ import { monitoringError } from 'config/errorMessages';
 // config
 import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
+import { subTitleStyles } from 'components/shared/Accordion';
 import { toggleTableStyles } from 'styles/index.js';
 
 const containerStyles = css`
@@ -560,7 +561,13 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
           return (
             <AccordionItem
               key={index}
-              title={<strong>{item.locationName || 'Unknown'}</strong>}
+              title={
+                <>
+                  <em css={subTitleStyles}>Location Name:</em>
+                  &nbsp;&nbsp;
+                  <strong>{item.locationName || 'Unknown'}</strong>
+                </>
+              }
               subTitle={
                 <>
                   <em>Organization Name:</em>&nbsp;&nbsp;
@@ -1192,10 +1199,9 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       index={index}
                       title={
                         <>
-                          <em>Location Name:</em>&nbsp;&nbsp;
-                          <strong className="location-name">
-                            {item.locationName || 'Unknown'}
-                          </strong>
+                          <em css={subTitleStyles}>Location Name:</em>
+                          &nbsp;&nbsp;
+                          <strong>{item.locationName || 'Unknown'}</strong>
                         </>
                       }
                       subTitle={

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -49,7 +49,7 @@ import { monitoringError } from 'config/errorMessages';
 // config
 import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
-import { subTitleStyles } from 'components/shared/Accordion';
+import { subtitleStyles } from 'components/shared/Accordion';
 import { toggleTableStyles } from 'styles/index.js';
 
 const containerStyles = css`
@@ -563,7 +563,7 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
               key={index}
               title={
                 <>
-                  <em css={subTitleStyles}>Location Name:</em>
+                  <em css={subtitleStyles}>Location Name:</em>
                   &nbsp;&nbsp;
                   <strong>{item.locationName || 'Unknown'}</strong>
                 </>
@@ -1199,7 +1199,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       index={index}
                       title={
                         <>
-                          <em css={subTitleStyles}>Location Name:</em>
+                          <em css={subtitleStyles}>Location Name:</em>
                           &nbsp;&nbsp;
                           <strong>{item.locationName || 'Unknown'}</strong>
                         </>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -267,7 +267,7 @@ function Monitoring() {
                   ? 'N/A'
                   : `${monitoringLocations.data.features.length}`}
               </span>
-              <p css={keyMetricLabelStyles}>Sample Locations</p>
+              <p css={keyMetricLabelStyles}>Past Water Conditions</p>
               <div css={switchContainerStyles}>
                 <Switch
                   checked={
@@ -299,7 +299,7 @@ function Monitoring() {
         <Tabs>
           <TabList>
             <Tab>Current Water Conditions</Tab>
-            <Tab>Sample Locations</Tab>
+            <Tab>Past Water Conditions</Tab>
           </TabList>
 
           <TabPanels>
@@ -1190,7 +1190,14 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                     <AccordionItem
                       key={index}
                       index={index}
-                      title={<strong>{item.locationName || 'Unknown'}</strong>}
+                      title={
+                        <>
+                          <em>Location Name:</em>&nbsp;&nbsp;
+                          <strong className="location-name">
+                            {item.locationName || 'Unknown'}
+                          </strong>
+                        </>
+                      }
                       subTitle={
                         <>
                           <em>Organization Name:</em>&nbsp;&nbsp;

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -312,7 +312,7 @@ function Overview() {
                   ? totalMonitoringAndSensors
                   : 'N/A'}
               </span>
-              <p css={keyMetricLabelStyles}>Monitoring &amp; Sensors</p>
+              <p css={keyMetricLabelStyles}>Monitoring Locations</p>
               <div css={switchContainerStyles}>
                 <Switch
                   checked={
@@ -386,7 +386,7 @@ function Overview() {
         <Tabs>
           <TabList>
             <Tab>Waterbodies</Tab>
-            <Tab>Monitoring &amp; Sensors</Tab>
+            <Tab>Monitoring Locations</Tab>
             <Tab>Permitted Dischargers</Tab>
           </TabList>
 
@@ -812,7 +812,7 @@ function MonitoringAndSensorsTab({
                         disabled={normalizedMonitoringLocations.length === 0}
                         ariaLabel="Sample Locations"
                       />
-                      <span>Sample Locations</span>
+                      <span>Past Water Conditions</span>
                     </div>
                   </td>
                   <td>{normalizedMonitoringLocations.length}</td>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -46,6 +46,7 @@ import {
 // config
 import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
+import { subTitleStyles } from 'components/shared/Accordion';
 import { toggleTableStyles } from 'styles/index.js';
 
 const containerStyles = css`
@@ -874,7 +875,13 @@ function MonitoringAndSensorsTab({
                     <AccordionItem
                       key={index}
                       index={index}
-                      title={<strong>{item.locationName || 'Unknown'}</strong>}
+                      title={
+                        <>
+                          <em css={subTitleStyles}>Location Name:</em>
+                          &nbsp;&nbsp;
+                          <strong>{item.locationName || 'Unknown'}</strong>
+                        </>
+                      }
                       subTitle={
                         <>
                           <em>Monitoring Type:</em>&nbsp;&nbsp;

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -46,7 +46,7 @@ import {
 // config
 import { usgsStaParameters } from 'config/usgsStaParameters';
 // styles
-import { subTitleStyles } from 'components/shared/Accordion';
+import { subtitleStyles } from 'components/shared/Accordion';
 import { toggleTableStyles } from 'styles/index.js';
 
 const containerStyles = css`
@@ -877,7 +877,7 @@ function MonitoringAndSensorsTab({
                       index={index}
                       title={
                         <>
-                          <em css={subTitleStyles}>Location Name:</em>
+                          <em css={subtitleStyles}>Location Name:</em>
                           &nbsp;&nbsp;
                           <strong>{item.locationName || 'Unknown'}</strong>
                         </>

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -185,7 +185,7 @@ const textStyles = css`
   overflow-wrap: anywhere;
 `;
 
-const subTitleStyles = css`
+const subtitleStyles = css`
   font-size: 0.8125em;
 `;
 
@@ -284,7 +284,7 @@ function AccordionItem({
           {subTitle && (
             <>
               <br />
-              <span css={subTitleStyles}>{subTitle}</span>
+              <span css={subtitleStyles}>{subTitle}</span>
             </>
           )}
         </p>
@@ -309,4 +309,4 @@ function AccordionItem({
   );
 }
 
-export { AccordionList, AccordionItem, subTitleStyles };
+export { AccordionList, AccordionItem, subtitleStyles };

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -185,8 +185,11 @@ const textStyles = css`
   overflow-wrap: anywhere;
 `;
 
-const subtitleStyles = css`
+const accordionItemTitleStyles = css`
   font-size: 0.8125em;
+  .location-name {
+    font-size: initial;
+  }
 `;
 
 const arrowStyles = css`
@@ -280,11 +283,11 @@ function AccordionItem({
         {icon && <div css={iconStyles}>{icon}</div>}
 
         <p css={textStyles}>
-          {title}
+          <span css={accordionItemTitleStyles}>{title}</span>
           {subTitle && (
             <>
               <br />
-              <span css={subtitleStyles}>{subTitle}</span>
+              <span css={accordionItemTitleStyles}>{subTitle}</span>
             </>
           )}
         </p>

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -185,11 +185,8 @@ const textStyles = css`
   overflow-wrap: anywhere;
 `;
 
-const accordionItemTitleStyles = css`
+const subTitleStyles = css`
   font-size: 0.8125em;
-  .location-name {
-    font-size: initial;
-  }
 `;
 
 const arrowStyles = css`
@@ -283,11 +280,11 @@ function AccordionItem({
         {icon && <div css={iconStyles}>{icon}</div>}
 
         <p css={textStyles}>
-          <span css={accordionItemTitleStyles}>{title}</span>
+          {title}
           {subTitle && (
             <>
               <br />
-              <span css={accordionItemTitleStyles}>{subTitle}</span>
+              <span css={subTitleStyles}>{subTitle}</span>
             </>
           )}
         </p>
@@ -312,4 +309,4 @@ function AccordionItem({
   );
 }
 
-export { AccordionList, AccordionItem };
+export { AccordionList, AccordionItem, subTitleStyles };


### PR DESCRIPTION
## Related Issues:
* [HMW-196](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-196)

## Main Changes:
* Changed instances of *Monitoring & Sensors* on the **Overview** tab to *Monitoring Locations*.
* Changed instances of *Sample Locations* on the **Overview** and **Monitoring** tabs to *Past Water Conditions*.
* Put *Location Name:* in front of the monitoring location names in the accordions of the Overview and Monitoring tabs.

## Steps To Test:
1. Go to the **Community** page
2. In the **Overview** tab, make sure the toggle and center sub-tab read *Monitoring Locations*
3. In the center *Monitoring Locations* sub-tab, check that the second toggle reads *Past Sample Locations*, and that all accordion items start with *Location Name:*
4. Similarly check the **Monitoring** tab