### PR TITLE
Feature/197 floating legend default open

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -2176,7 +2176,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               : windowHeight - searchTextHeight - 3 * mapPadding,
         }}
       >
-        <Map layers={layers} />
+        <Map layers={layers} legendExpanded={true} />
         {mapView && mapLoading && <MapLoadingSpinner />}
       </div>
     </>

--- a/app/client/src/components/shared/Map.js
+++ b/app/client/src/components/shared/Map.js
@@ -18,11 +18,17 @@ const mapContainerStyles = css`
 
 type Props = {
   layers: Object,
+  legendExpanded?: boolean,
   startingExtent?: Object,
   children?: Node,
 };
 
-function Map({ layers = null, startingExtent = null, children }: Props) {
+function Map({
+  layers = null,
+  legendExpanded = false,
+  startingExtent = null,
+  children,
+}: Props) {
   const { initialExtent, highlightOptions, getBasemap, mapView, setMapView } =
     useContext(LocationSearchContext);
 
@@ -66,7 +72,12 @@ function Map({ layers = null, startingExtent = null, children }: Props) {
     <div id="hmw-map-container" css={mapContainerStyles}>
       {map && mapView && (
         <>
-          <MapWidgets map={map} view={mapView} layers={layers} />
+          <MapWidgets
+            map={map}
+            legendExpanded={legendExpanded}
+            view={mapView}
+            layers={layers}
+          />
           <MapMouseEvents map={map} view={mapView} />
         </>
       )}

--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -223,6 +223,7 @@ type Props = {
   map: any,
   view: any,
   layers: Array<any>,
+  legendExpanded?: boolean,
   scrollToComponent: string,
   onHomeWidgetRendered: (homeWidget: any) => void,
 };
@@ -231,6 +232,7 @@ function MapWidgets({
   map,
   view,
   layers,
+  legendExpanded = false,
   scrollToComponent,
   onHomeWidgetRendered = () => {},
 }: Props) {
@@ -490,15 +492,15 @@ function MapWidgets({
     const newLegend = new Expand({
       content: legendNode,
       view,
-      expanded: false,
+      expanded: legendExpanded,
       expandIconClass: 'esri-icon-layer-list',
       expandTooltip: 'Toggle Legend',
-      autoCollapse: true,
+      autoCollapse: !legendExpanded,
       mode: 'floating',
     });
     view.ui.add(newLegend, { position: 'bottom-left', index: 0 });
     setLegend(newLegend);
-  }, [view, legend, legendNode]);
+  }, [view, legend, legendExpanded, legendNode]);
 
   // Create the layer list toolbar widget
   const [esriLegend, setEsriLegend] = useState(null);


### PR DESCRIPTION
## Related Issues:
* [HMW-197](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-197)

## Main Changes:
* Added a new optional prop, `legendExpanded`, that expands the legend by default. It is passed through the `Map` component to the `MapWidget` component.
* Enabled the functionality in the map on the **Community** page.
* Also set `autoCollapse` to false when the functionality is enabled, since map updates would close the legend before any content was rendered. `autoCollapse` is still true otherwise.

## Steps To Test:
1. Visit the **Community** page, and perform a valid search
2. The legend should be open, and it should remain open when zooming in or out
3. Visit a waterbody report page, i.e. [http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022
](http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022
)
4. The legend should not be open, and once opened, it should disappear on zoom change
