### PR TITLE
feature/200_remove-temp-clustering-switch

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import type { Node } from 'react';
+import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
 import StickyBox from 'react-sticky-box';
 import { useNavigate } from 'react-router-dom';
@@ -34,7 +35,10 @@ import {
 } from 'utils/mapFunctions';
 import MapErrorBoundary from 'components/shared/ErrorBoundary.MapErrorBoundary';
 // contexts
-import { useFetchedDataDispatch, useFetchedDataState } from 'contexts/FetchedData';
+import {
+  useFetchedDataDispatch,
+  useFetchedDataState,
+} from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import {
   useOrganizationsContext,
@@ -640,7 +644,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         symbol: {
           type: 'simple-marker',
           style: 'circle',
-          color: colors.lightPurple(0.3),
+          color: colors.lightPurple(0.5),
         },
         visualVariables: [
           {
@@ -1125,7 +1129,10 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   // updates the features on the monitoringStationsLayer
   useEffect(() => {
     if (!monitoringLocationsLayer) return;
-    if (!monitoringLocations.data.features || monitoringLocations.status !== 'success') {
+    if (
+      !monitoringLocations.data.features ||
+      monitoringLocations.status !== 'success'
+    ) {
       return;
     }
 
@@ -1182,6 +1189,58 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         },
       });
     });
+
+    if (stationsSorted.length > 20) {
+      monitoringLocationsLayer.featureReduction = {
+        type: 'cluster',
+        clusterRadius: '100px',
+        clusterMinSize: '24px',
+        clusterMaxSize: '60px',
+        popupEnabled: true,
+        popupTemplate: {
+          title: 'Cluster summary',
+          content: (feature) => {
+            const content = (
+              <div style={{ margin: '0.625em' }}>
+                This cluster represents{' '}
+                {feature.graphic.attributes.cluster_count} stations
+              </div>
+            );
+
+            const contentContainer = document.createElement('div');
+            render(content, contentContainer);
+
+            // return an esri popup item
+            return contentContainer;
+          },
+          fieldInfos: [
+            {
+              fieldName: 'cluster_count',
+              format: {
+                places: 0,
+                digitSeparator: true,
+              },
+            },
+          ],
+        },
+        labelingInfo: [
+          {
+            deconflictionStrategy: 'none',
+            labelExpressionInfo: {
+              expression: "Text($feature.cluster_count, '#,###')",
+            },
+            symbol: {
+              type: 'text',
+              color: '#000000',
+              font: { size: 10, weight: 'bold' },
+            },
+            labelPlacement: 'center-center',
+          },
+        ],
+      };
+    } else {
+      monitoringLocationsLayer.featureReduction = undefined;
+    }
 
     monitoringLocationsLayer.queryFeatures().then((featureSet) => {
       monitoringLocationsLayer.applyEdits({

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -7,9 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
-import Switch from 'components/shared/Switch';
 import { useNavigate } from 'react-router-dom';
 import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import Locator from '@arcgis/core/tasks/Locator';
@@ -161,24 +159,6 @@ const searchBoxStyles = css`
   }
 `;
 
-/**
- * TODO
- *   Delete the following styles once the
- *   testing clustering switch is removed.
- */
-const tempClusteringContainerStyles = css`
-  display: flex;
-  justify-content: space-between;
-`;
-const tempClusteringLabelContainerStyles = css`
-  display: flex;
-  align-items: center;
-`;
-const tempClusteringLabelStyles = css`
-  margin: 0;
-  margin-right: 10px;
-`;
-
 type Props = {
   route: string,
   label: Node,
@@ -198,14 +178,7 @@ function LocationSearch({ route, label }: Props) {
   const sourceEnterPress = useKeyPress('Enter', sourceList);
   const clearButton = useRef();
   const clearEnterPress = useKeyPress('Enter', clearButton);
-  const {
-    searchText,
-    watershed,
-    huc12,
-    monitoringLocations,
-    monitoringLocationsLayer,
-    visibleLayers,
-  } = useContext(LocationSearchContext);
+  const { searchText, watershed, huc12 } = useContext(LocationSearchContext);
 
   const placeholder = 'Search by address, zip code, or place...';
   const [allSources] = useState([
@@ -738,9 +711,6 @@ function LocationSearch({ route, label }: Props) {
     };
   }, [suggestionsRef]);
 
-  // TODO Delete this state when the TEMP clustering switch is removed
-  const [clusteringEnabled, setClusteringEnabled] = useState(false);
-
   return (
     <>
       {errorMessage && (
@@ -749,87 +719,9 @@ function LocationSearch({ route, label }: Props) {
         </div>
       )}
 
-      {visibleLayers.monitoringLocationsLayer &&
-      monitoringLocationsLayer &&
-      monitoringLocations.status === 'success' &&
-      monitoringLocations.data.features.length ? (
-        <div css={tempClusteringContainerStyles}>
-          <label css={labelStyles} htmlFor="hmw-search-input">
-            {label}
-          </label>
-          <div css={tempClusteringLabelContainerStyles}>
-            <label css={tempClusteringLabelStyles}>
-              TEMP Monitoring Clustering
-            </label>
-            <Switch
-              checked={clusteringEnabled}
-              onChange={(checked) => {
-                setClusteringEnabled(checked);
-
-                if (checked) {
-                  monitoringLocationsLayer.renderer.symbol.color =
-                    colors.lightPurple(0.8);
-                  monitoringLocationsLayer.featureReduction = {
-                    type: 'cluster',
-                    clusterRadius: '100px',
-                    clusterMinSize: '24px',
-                    clusterMaxSize: '60px',
-                    popupEnabled: true,
-                    popupTemplate: {
-                      title: 'Cluster summary',
-                      content: (feature) => {
-                        const content = (
-                          <div style={{ margin: '0.625em' }}>
-                            This cluster represents{' '}
-                            {feature.graphic.attributes.cluster_count} stations
-                          </div>
-                        );
-
-                        const contentContainer = document.createElement('div');
-                        render(content, contentContainer);
-
-                        // return an esri popup item
-                        return contentContainer;
-                      },
-                      fieldInfos: [
-                        {
-                          fieldName: 'cluster_count',
-                          format: {
-                            places: 0,
-                            digitSeparator: true,
-                          },
-                        },
-                      ],
-                    },
-                    labelingInfo: [
-                      {
-                        deconflictionStrategy: 'none',
-                        labelExpressionInfo: {
-                          expression: "Text($feature.cluster_count, '#,###')",
-                        },
-                        symbol: {
-                          type: 'text',
-                          color: '#000000',
-                          font: { size: 10, weight: 'bold' },
-                        },
-                        labelPlacement: 'center-center',
-                      },
-                    ],
-                  };
-                } else {
-                  monitoringLocationsLayer.renderer.symbol.color =
-                    colors.lightPurple(0.3);
-                  monitoringLocationsLayer.featureReduction = undefined;
-                }
-              }}
-            />
-          </div>
-        </div>
-      ) : (
-        <label css={labelStyles} htmlFor="hmw-search-input">
-          {label}
-        </label>
-      )}
+      <label css={labelStyles} htmlFor="hmw-search-input">
+        {label}
+      </label>
 
       <form
         css={formStyles}


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-200

## Main Changes:
* Removed the Temp Monitoring Clustering switch and updated the code so that clustering is automatically activated if there are more than 20 stations in the HUC.

## Steps To Test:
1. Navigate to http://localhost:3000/community/portland%20or/monitoring
2. Verify the Past Water Conditions layer is being clustered
3. Verify the `TEMP Monitoring Clustering` switch is no longer in the app
4. Navigate to http://localhost:3000/community/columbia%20sc/monitoring
5. Verify the Past Water Conditions layer is not being clustered
6. Verify the `TEMP Monitoring Clustering` switch is no longer in the app
