### PR TITLE
Feature/204 remove gage height numbers

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -722,19 +722,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         //   },
         // ],
       },
-      labelingInfo: [
-        {
-          symbol: {
-            type: 'text',
-            yoffset: '-3px',
-            font: { size: 10, weight: 'bold' },
-          },
-          labelPlacement: 'above-center',
-          labelExpressionInfo: {
-            expression: '$feature.gageHeight',
-          },
-        },
-      ],
       popupTemplate: {
         outFields: ['*'],
         title: (feature) => getPopupTitle(feature.graphic.attributes),


### PR DESCRIPTION
## Related Issues:
* [HMW-204](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-204&quickFilter=2479)

## Main Changes:
* Removed the streamgage height measurement labels from the icons on the **Community** page `LocationMap`.
* In particular, removed the `labelingInfo` property from the `usgsStreamgagesLayer` constructor.

## Steps To Test:
1. Go to the **Community** page, and perform a valid location search.
2. In the visible **Overview** tab, toggle the switch labelled _Monitoring Locations_
3. On the map, the yellow squares representing streamgages should not have any labels above them