### PR TITLE
Feature/206 associated document updates

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -215,6 +215,17 @@ const listStyles = css`
   padding-bottom: 0;
 `;
 
+const listItemStyles = css`
+  span {
+    &:first-of-type {
+      padding-right: 1em;
+    }
+    &:last-of-type {
+      padding-left: 1em;
+    }
+  }
+`;
+
 type Props = {
   fullscreen: Object,
 };
@@ -1256,7 +1267,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                       )}
                       {documents.status === 'success' && (
                         <>
-                          {documents.length > 0 && (
+                          {documents.data.length > 0 && (
                             <div css={[boxSectionStyles, { paddingBottom: 0 }]}>
                               <p css={introTextStyles}>
                                 <em>Links below open in a new browser tab.</em>
@@ -1271,17 +1282,29 @@ function WaterbodyReport({ fullscreen }: Props) {
 
                               {documents.data.length > 0 &&
                                 documents.data.map((document) => (
-                                  <li key={document.documentName}>
-                                    <a
-                                      href={document.documentURL}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                    >
-                                      {document.documentName}
-                                    </a>
-                                    <DynamicExitDisclaimer
-                                      url={document.documentURL}
-                                    />
+                                  <li css={listItemStyles} key={document.documentName}>
+                                    <span className='row-start'>
+                                      <a
+                                        href={document.documentURL}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                      >
+                                        {document.documentName}
+                                      </a>
+                                      <DynamicExitDisclaimer
+                                        url={document.documentURL}
+                                      />
+                                    </span>
+                                    {document.documentTypes.length && (
+                                      <>
+                                        <strong>&mdash;</strong>
+                                        <span className='row-end'>
+                                          <strong>
+                                            {document.documentTypes.map((type) => type.documentTypeCode).join(' / ')}
+                                          </strong>
+                                        </span>
+                                      </>
+                                    )}
                                   </li>
                                 ))}
                             </ul>

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -213,16 +213,29 @@ const introTextStyles = css`
 
 const listStyles = css`
   padding-bottom: 0;
+  &.document-list {
+    padding-left: 0;
+    width: 100%;
+  }
 `;
 
 const listItemStyles = css`
-  span {
-    &:first-of-type {
-      padding-right: 1em;
-    }
-    &:last-of-type {
-      padding-left: 1em;
-    }
+  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr 3em 1fr;
+  padding-bottom: 1em;
+  .row-center {
+    justify-self: center;
+  }
+  .row-end {
+    justify-self: start;
+  }
+  .row-start {
+    justify-self: end;
+    text-align: right;
+  }
+  &:last-of-type {
+    padding-bottom: 0;
   }
 `;
 
@@ -1275,7 +1288,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                             </div>
                           )}
                           <div css={boxSectionStyles}>
-                            <ul css={listStyles}>
+                            <ul css={listStyles} className="document-list">
                               {documents.data.length === 0 && (
                                 <li>No documents are available</li>
                               )}
@@ -1297,12 +1310,10 @@ function WaterbodyReport({ fullscreen }: Props) {
                                     </span>
                                     {document.documentTypes.length && (
                                       <>
-                                        <strong>&mdash;</strong>
-                                        <span className='row-end'>
-                                          <strong>
-                                            {document.documentTypes.map((type) => type.documentTypeCode).join(' / ')}
-                                          </strong>
-                                        </span>
+                                        <strong className='row-center'>&mdash;</strong>
+                                        <strong className='row-end'>
+                                          {document.documentTypes.map((type) => type.documentTypeCode).join(' / ')}
+                                        </strong>
                                       </>
                                     )}
                                   </li>

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -213,10 +213,8 @@ const introTextStyles = css`
 
 const listStyles = css`
   padding-bottom: 0;
-  &.document-list {
-    padding-left: 0;
-    width: 100%;
-  }
+  padding-left: 0;
+  width: 100%;
 `;
 
 const listItemStyles = css`
@@ -1288,7 +1286,7 @@ function WaterbodyReport({ fullscreen }: Props) {
                             </div>
                           )}
                           <div css={boxSectionStyles}>
-                            <ul css={listStyles} className="document-list">
+                            <ul css={listStyles}>
                               {documents.data.length === 0 && (
                                 <li>No documents are available</li>
                               )}


### PR DESCRIPTION
## Related Issues:
* [HMW-206](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-206&quickFilter=2479)

## Main Changes:
* Added the document type code next to the document link in the **Assessment Documents** section of the **Waterbody Report** page.
* Allows for a concatenation of document types, though the array of types in the example I found had only one item.
* Aligned the respective list item fields using CSS Grid.

## Steps To Test:
1. Go to a **Waterbody Report** page with assessment documents, i.e. [http://localhost:3000/waterbody-report/TDECWR/TN03150101012_0100](http://localhost:3000/waterbody-report/TDECWR/TN03150101012_0100)
2. Locate the **Assessment Documents** box in the second column, and observe the document type following the hyphen
3. Resize the page to ensure the layout remains appealing