### PR TITLE
Feature/189 apply sparkline updates

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -339,7 +339,8 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
   // web service) to each streamgage if it exists for that particular location
   useEffect(() => {
     if (!usgsPrecipitation.data.value) return;
-    if (!usgsDailyAverages.data.value) return;
+    if (!usgsDailyAverages.data?.allParamsMean?.value) return;
+    if (!usgsDailyAverages.data?.precipitationSum?.value) return;
     if (normalizedUsgsStreamgages.length === 0) return;
 
     const streamgageSiteIds = normalizedUsgsStreamgages.map((gage) => {
@@ -370,7 +371,7 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
       }
     });
 
-    usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
+    usgsDailyAverages.data.allParamsMean.value?.timeSeries.forEach((site) => {
       const siteId = site.sourceInfo.siteCode[0].value;
       const sitesHasObservations = site.values[0].value.length > 0;
 

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -387,7 +387,12 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
 
         const paramCode = site.variable.variableCode[0].value;
         const observations = site.values[0].value.map(({ value, dateTime }) => {
-          return { measurement: value, date: new Date(dateTime) };
+          let measurement = value;
+          // convert measurements recorded in celsius to fahrenheit
+          if (['00010', '00020', '85583'].includes(paramCode)) {
+            measurement = measurement * (9 / 5) + 32;
+          }
+          return { measurement, date: new Date(dateTime) };
         });
 
         // NOTE: 'category' is either 'primary' or 'secondary' – loop over both

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -371,7 +371,12 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
       }
     });
 
-    usgsDailyAverages.data.allParamsMean.value?.timeSeries.forEach((site) => {
+    const usgsDailyTimeSeriesData = [
+      ...(usgsDailyAverages.data.allParamsMean.value?.timeSeries || []),
+      ...(usgsDailyAverages.data.precipitationSum.value.timeSeries || []),
+    ];
+
+    usgsDailyTimeSeriesData.forEach((site) => {
       const siteId = site.sourceInfo.siteCode[0].value;
       const sitesHasObservations = site.values[0].value.length > 0;
 

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -546,7 +546,13 @@ function MonitoringAndSensorsTab({
 
         const paramCode = site.variable.variableCode[0].value;
         const observations = site.values[0].value.map(({ value, dateTime }) => {
-          return { measurement: value, date: new Date(dateTime) };
+          let measurement = value;
+          // convert measurements recorded in celsius to fahrenheit
+          if (['00010', '00020', '85583'].includes(paramCode)) {
+            measurement = measurement * (9 / 5) + 32;
+          }
+
+          return { measurement, date: new Date(dateTime) };
         });
 
         // NOTE: 'category' is either 'primary' or 'secondary' – loop over both

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -530,7 +530,12 @@ function MonitoringAndSensorsTab({
       }
     });
 
-    usgsDailyAverages.data.allParamsMean.value?.timeSeries.forEach((site) => {
+    const usgsDailyTimeSeriesData = [
+      ...(usgsDailyAverages.data.allParamsMean.value?.timeSeries || []),
+      ...(usgsDailyAverages.data.precipitationSum.value.timeSeries || []),
+    ];
+
+    usgsDailyTimeSeriesData.forEach((site) => {
       const siteId = site.sourceInfo.siteCode[0].value;
       const sitesHasObservations = site.values[0].value.length > 0;
 

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -498,7 +498,8 @@ function MonitoringAndSensorsTab({
   // web service) to each streamgage if it exists for that particular location
   useEffect(() => {
     if (!usgsPrecipitation.data.value) return;
-    if (!usgsDailyAverages.data.value) return;
+    if (!usgsDailyAverages.data?.allParamsMean?.value) return;
+    if (!usgsDailyAverages.data?.precipitationSum?.value) return;
     if (normalizedUsgsStreamgages.length === 0) return;
 
     const streamgageSiteIds = normalizedUsgsStreamgages.map((gage) => {
@@ -529,7 +530,7 @@ function MonitoringAndSensorsTab({
       }
     });
 
-    usgsDailyAverages.data.value?.timeSeries.forEach((site) => {
+    usgsDailyAverages.data.allParamsMean.value?.timeSeries.forEach((site) => {
       const siteId = site.sourceInfo.siteCode[0].value;
       const sitesHasObservations = site.values[0].value.length > 0;
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1312,13 +1312,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
   const fetchUsgsDailyAverages = useCallback(
     (huc12) => {
-      const url =
-        services.data.usgsDailyValues +
-        `?format=json` +
-        `&siteStatus=active` +
-        `&period=P7D` +
-        `&huc=${huc12.substring(0, 8)}`;
-
       // https://help.waterdata.usgs.gov/stat_code
       const meanValues = '00003';
       const sumValues = '00006';
@@ -1326,6 +1319,13 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       // https://help.waterdata.usgs.gov/codes-and-parameters/parameters
       const allParams = 'all';
       const precipitation = '00045'; // Precipitation, total, inches
+
+      const url =
+        services.data.usgsDailyValues +
+        `?format=json` +
+        `&siteStatus=active` +
+        `&period=P7D` +
+        `&huc=${huc12.substring(0, 8)}`;
 
       fetchedDataDispatch({ type: 'USGS_DAILY_AVERAGES/FETCH_REQUEST' });
 

--- a/app/client/src/components/shared/Sparkline.js
+++ b/app/client/src/components/shared/Sparkline.js
@@ -71,9 +71,6 @@ export function Sparkline({ data }: { data: Observation[] }) {
           glyphStyle={{ fill: color }}
           renderTooltip={({ tooltipData }) => {
             const datum: Observation = tooltipData?.nearestDatum?.datum;
-
-            console.log(tooltipData);
-
             return (
               <p css={tooltipStyles}>
                 <span>{accessors.xAccessor(datum)}:&nbsp;</span>

--- a/app/client/src/components/shared/Sparkline.js
+++ b/app/client/src/components/shared/Sparkline.js
@@ -57,6 +57,7 @@ export function Sparkline({ data }: { data: Observation[] }) {
       >
         <AreaSeries
           data={data}
+          dataKey="area"
           curve={curveMonotoneX}
           lineProps={{ stroke: color }}
           fill={color}
@@ -70,6 +71,9 @@ export function Sparkline({ data }: { data: Observation[] }) {
           glyphStyle={{ fill: color }}
           renderTooltip={({ tooltipData }) => {
             const datum: Observation = tooltipData?.nearestDatum?.datum;
+
+            console.log(tooltipData);
+
             return (
               <p css={tooltipStyles}>
                 <span>{accessors.xAccessor(datum)}:&nbsp;</span>

--- a/app/client/src/contexts/FetchedData.js
+++ b/app/client/src/contexts/FetchedData.js
@@ -96,7 +96,10 @@ type UsgsPrecipitationData = {
   },
 };
 
-type UsgsDailyAveragesData = Object;
+type UsgsDailyAveragesData = {
+  allParamsMean: Object,
+  precipitationSum: Object,
+};
 
 type State = {
   usgsStreamgages:


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-189

## Main Changes:
* Ensures sparkline tooltip updates properly as you mouse over different points in the sparkline chart
* Fetches USGS daily values data for precipitation using the summation values statistic code
* Converts measurements recorded in Celsius to Fahrenheit

## Steps To Test:
1. Visit http://localhost:3000/community/031300021301/overview. From the Community/Overview tab, toggle "Current Water Conditions" switch in the "Monitoring & Sensors" subtab and verify a sparkline chart is displayed in the layerlist to the left of a measurement.
2. If the site has measurements for "Total Daily Rainfall", ensure it has a sparkline chart (it will only be displayed if precipitation data is returned from the USGS daily values web service, which currently should for the HUC above as of today).

## TODO:
- [ ] Ask EPA about rounding measurement data returned in the web services used to display streamgage measurements
