### PR TITLE
Feature/196 remove location name

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -457,13 +457,7 @@ function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
           return (
             <AccordionItem
               key={index}
-              title={
-                <>
-                  <em css={subtitleStyles}>Location Name:</em>
-                  &nbsp;&nbsp;
-                  <strong>{item.locationName || 'Unknown'}</strong>
-                </>
-              }
+              title={<strong>{item.locationName || 'Unknown'}</strong>}
               subTitle={
                 <>
                   <em>Organization Name:</em>&nbsp;&nbsp;
@@ -1111,13 +1105,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                     <AccordionItem
                       key={index}
                       index={index}
-                      title={
-                        <>
-                          <em css={subtitleStyles}>Location Name:</em>
-                          &nbsp;&nbsp;
-                          <strong>{item.locationName || 'Unknown'}</strong>
-                        </>
-                      }
+                      title={<strong>{item.locationName || 'Unknown'}</strong>}
                       subTitle={
                         <>
                           <em>Organization Name:</em>&nbsp;&nbsp;

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -799,13 +799,7 @@ function MonitoringAndSensorsTab({
                     <AccordionItem
                       key={index}
                       index={index}
-                      title={
-                        <>
-                          <em css={subtitleStyles}>Location Name:</em>
-                          &nbsp;&nbsp;
-                          <strong>{item.locationName || 'Unknown'}</strong>
-                        </>
-                      }
+                      title={<strong>{item.locationName || 'Unknown'}</strong>}
                       subTitle={
                         <>
                           <em>Monitoring Type:</em>&nbsp;&nbsp;


### PR DESCRIPTION
## Related Issues:
* [HMW-196](https://jira.epa.gov/browse/HMW-196)

## Main Changes:
*  Per a discussion with @courtneymyers this morning, removed the location name label from the monitoring accordion headers. This label just looked weird and causes UX issues.

## Steps To Test:
1. Navigate to http://localhost:3000/community/auburn%20al/overview
2. Turn on "Monitoring Locations"
3. Verify the "Location Name:" label is gone
4. Repeat the same test on the Monitoring panel.

