### PR TITLE
Feature/76 download data entire huc

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -63,6 +63,16 @@ const tableFooterStyles = css`
   border-bottom: 1px solid #dee2e6;
   background-color: #f0f6f9;
 
+  span {
+    display: inline-block;
+    &.download-text {
+      margin-bottom: 5px;
+    }
+    &.download-links {
+      margin-left: 5px;
+    }
+  }
+
   td {
     border-top: none;
     font-weight: bold;
@@ -1062,14 +1072,18 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                   </td>
 
                   <td colSpan="2">
-                    Download All Selected Data&nbsp;&nbsp;
-                    <a href={`${downloadUrl}&mimeType=xlsx`}>
-                      <i className="fas fa-file-excel" aria-hidden="true" />
-                    </a>
-                    &nbsp;&nbsp;
-                    <a href={`${downloadUrl}&mimeType=csv`}>
-                      <i className="fas fa-file-csv" aria-hidden="true" />
-                    </a>
+                    <span className="download-text">
+                      Download All Selected Data
+                    </span>
+                    <span className="download-links">
+                      <a href={`${downloadUrl}&mimeType=xlsx`}>
+                        <i className="fas fa-file-excel" aria-hidden="true" />
+                      </a>
+                      &nbsp;&nbsp;
+                      <a href={`${downloadUrl}&mimeType=csv`}>
+                        <i className="fas fa-file-csv" aria-hidden="true" />
+                      </a>
+                    </span>
                   </td>
                 </tr>
               </tfoot>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -63,20 +63,15 @@ const tableFooterStyles = css`
   border-bottom: 1px solid #dee2e6;
   background-color: #f0f6f9;
 
-  span {
-    display: inline-block;
-    &.download-text {
-      margin-bottom: 5px;
-    }
-    &.download-links {
-      margin-left: 5px;
-    }
-  }
-
   td {
     border-top: none;
     font-weight: bold;
     width: 50%;
+  }
+
+  span {
+    display: inline-block;
+    margin-bottom: 0.25em;
   }
 `;
 
@@ -1072,10 +1067,9 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                   </td>
 
                   <td colSpan="2">
-                    <span className="download-text">
-                      Download All Selected Data
-                    </span>
-                    <span className="download-links">
+                    <span>Download All Selected Data</span>
+                    <span>
+                      &nbsp;&nbsp;
                       <a href={`${downloadUrl}&mimeType=xlsx`}>
                         <i className="fas fa-file-excel" aria-hidden="true" />
                       </a>


### PR DESCRIPTION
## Related Issues:
* [HMW-76](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-76&quickFilter=2479)

## Main Changes:
* @courtneymyers had simplified the markup and styles of the download section, but I tweaked it a bit to ensure consistent display of wrapped text.
* In particular, I wrapped the _Download All Selected Data_ text and the download links in inline-block `<span>` elements, so that each wrap as a group.
* Applied margins instead of `&nbsp;` to avoid spacing issues when wrapping.

## Steps To Test:
1. Go to the **Monitoring** tab of the **Community** page
2. Click the **Past Water Conditions** sub-tab
3. Resize the screen, and observe that the download links wrap as a group
