### PR TITLE
Feature/197 legend widget icon update

### DIFF
--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -466,7 +466,7 @@ function MapWidgets({
       view: view,
       unit: 'dual',
     });
-    view.ui.add(newScaleBar, { position: 'bottom-left', index: 1 });
+    view.ui.add(newScaleBar, { position: 'bottom-left', index: 0 });
     setScaleBar(newScaleBar);
   }, [view, scaleBar]);
 
@@ -491,12 +491,14 @@ function MapWidgets({
       content: legendNode,
       view,
       expanded: false,
-      expandIconClass: 'esri-icon-layer-list',
+      expandIconClass: 'esri-icon-legend',
+      //expandIconClass: 'fas fa-info',
+      //expandIconClass: 'fas fa-shapes',
       expandTooltip: 'Toggle Legend',
       autoCollapse: true,
       mode: 'floating',
     });
-    view.ui.add(newLegend, { position: 'bottom-left', index: 0 });
+    view.ui.add(newLegend, { position: 'top-left', index: 0 });
     setLegend(newLegend);
   }, [view, legend, legendNode]);
 

--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -492,8 +492,6 @@ function MapWidgets({
       view,
       expanded: false,
       expandIconClass: 'esri-icon-legend',
-      //expandIconClass: 'fas fa-info',
-      //expandIconClass: 'fas fa-shapes',
       expandTooltip: 'Toggle Legend',
       autoCollapse: true,
       mode: 'floating',


### PR DESCRIPTION
## Related Issues:
* [HMW-197](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-197)

## Main Changes:
* Moved the legend widget button to the upper left corner of the map view, to make it more apparent.
* Changed the icon to the Esri official legend icon (`esri-icon-legend`).

## Steps To Test:
1. View the legend widget on the location map of the **Community** page
2. In the relevant source code (`app/client/src/components/shared/MapWidgets.js`), the icon class is specified on line **494**, in the _expandIconClass_ property of the _Expand_ constructor
3. On lines **495** and **496**, I have included two commented out lines that specify different _Font Awesome_ icons that might also be considered. They are a bit inconsistent because they're solid, but we don't currently have access to the light versions