### PR TITLE
Feature/212 educator icon additions

### DIFF
--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -10,7 +10,7 @@ import { useEducatorMaterialsContext } from 'contexts/LookupFiles';
 import { educatorContentError } from 'config/errorMessages';
 // styles
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
-import { fonts } from 'styles/index.js';
+import { colors, fonts } from 'styles/index.js';
 
 // NOTE: matching styles used in tabs in `AboutContent` component
 const containerStyles = css`
@@ -59,6 +59,10 @@ const containerStyles = css`
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
   }
+`;
+
+const iconStyles = css`
+  color: ${colors.navyBlue()};
 `;
 
 const modifiedErrorBoxStyles = css`
@@ -112,7 +116,11 @@ function EducatorsContent() {
   return (
     <div css={containerStyles} className="container">
       <h2>
-        <i className="fas fa-graduation-cap" aria-hidden="true" />
+        <i
+          css={iconStyles}
+          className="fas fa-graduation-cap"
+          aria-hidden="true"
+        />
         &nbsp; Educational Materials from How’s My Waterway
       </h2>
       <hr />
@@ -139,7 +147,11 @@ function EducatorsContent() {
 
       <div css={modifiedInfoBoxStyles}>
         <h3>
-          <i className="fas fa-graduation-cap" aria-hidden="true" />
+          <i
+            css={iconStyles}
+            className="fas fa-graduation-cap"
+            aria-hidden="true"
+          />
           &nbsp; If you’re an educator, we would like to know how you're using{' '}
           <em>How’s My Waterway</em>.
         </h3>

--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -111,7 +111,10 @@ function EducatorsContent() {
 
   return (
     <div css={containerStyles} className="container">
-      <h2>Educational Materials from How’s My Waterway</h2>
+      <h2>
+        <i className="fas fa-graduation-cap" aria-hidden="true" />
+        &nbsp; Educational Materials from How’s My Waterway
+      </h2>
       <hr />
 
       {status === 'failure' && (
@@ -136,7 +139,8 @@ function EducatorsContent() {
 
       <div css={modifiedInfoBoxStyles}>
         <h3>
-          If you’re an educator, we would like to know how you're using{' '}
+          <i className="fas fa-graduation-cap" aria-hidden="true" />
+          &nbsp; If you’re an educator, we would like to know how you're using{' '}
           <em>How’s My Waterway</em>.
         </h3>
         <p>


### PR DESCRIPTION
## Related Issues:
* [HMW-212](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-212&quickFilter=2479)

## Main Changes:
* Added the _Font Awesome_ graduation cap icon next to the header and contact prompt on the **Educators** page.
* Colored the icon with a color from the site's theme.

## Steps To Test:
1. Visit the **Educators** page, i.e [http://localhost:3000/educators](http://localhost:3000/educators) and confirm the icons are present in two places (in addition to the icon in the nav links)

## TODO:
- [ ] Check with the team about the color choice (navy blue or black?)
