### PR TITLE
Feature/206 associated document updates

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -206,39 +206,6 @@ const disclaimerStyles = css`
   display: inline-block;
 `;
 
-const introTextStyles = css`
-  margin-top: 0 !important;
-  padding-bottom: 0.4375em !important;
-`;
-
-const listStyles = css`
-  padding-bottom: 0;
-  &.document-list {
-    padding-left: 0;
-    width: 100%;
-  }
-`;
-
-const listItemStyles = css`
-  align-items: center;
-  display: grid;
-  grid-template-columns: 1fr 3em 1fr;
-  padding-bottom: 1em;
-  .row-center {
-    justify-self: center;
-  }
-  .row-end {
-    justify-self: start;
-  }
-  .row-start {
-    justify-self: end;
-    text-align: right;
-  }
-  &:last-of-type {
-    padding-bottom: 0;
-  }
-`;
-
 type Props = {
   fullscreen: Object,
 };
@@ -1272,56 +1239,43 @@ function WaterbodyReport({ fullscreen }: Props) {
                     <h2 css={boxHeadingStyles}>Assessment Documents</h2>
 
                     <div css={boxSectionStyles}>
-                      {documents.status === 'fetching' && <LoadingSpinner />}
-                      {documents.status === 'failure' && (
-                        <div css={modifiedErrorBoxStyles}>
-                          <p>{waterbodyReportError('Assessment')}</p>
-                        </div>
-                      )}
-                      {documents.status === 'success' && (
-                        <>
-                          {documents.data.length > 0 && (
-                            <div css={[boxSectionStyles, { paddingBottom: 0 }]}>
-                              <p css={introTextStyles}>
-                                <em>Links below open in a new browser tab.</em>
-                              </p>
-                            </div>
-                          )}
-                          <div css={boxSectionStyles}>
-                            <ul css={listStyles} className="document-list">
-                              {documents.data.length === 0 && (
-                                <li>No documents are available</li>
-                              )}
-
-                              {documents.data.length > 0 &&
-                                documents.data.map((document) => (
-                                  <li css={listItemStyles} key={document.documentName}>
-                                    <span className='row-start'>
-                                      <a
-                                        href={document.documentURL}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                      >
-                                        {document.documentName}
-                                      </a>
-                                      <DynamicExitDisclaimer
-                                        url={document.documentURL}
-                                      />
-                                    </span>
-                                    {document.documentTypes.length && (
-                                      <>
-                                        <strong className='row-center'>&mdash;</strong>
-                                        <strong className='row-end'>
-                                          {document.documentTypes.map((type) => type.documentTypeCode).join(' / ')}
-                                        </strong>
-                                      </>
-                                    )}
-                                  </li>
-                                ))}
-                            </ul>
-                          </div>
-                        </>
-                      )}
+                    {documents.status === 'fetching' && <LoadingSpinner />}
+                    {documents.status === 'failure' && (
+                      <div css={modifiedErrorBoxStyles}>
+                        <p>{waterbodyReportError('Assessment')}</p>
+                      </div>
+                    )}
+                    {documents.status === 'success'
+                        && documents.data.length === 0 ? (
+                      <p>No documents are available</p>
+                    ) : (
+                      <>
+                        <em>Links below open in a new browser tab.</em>
+                        <table className="table">
+                          <thead>
+                            <tr>
+                              <th>Assessment</th>
+                              <th>Type</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                          {documents.data.map((document) => (
+                            <tr key={document.documentName}>
+                              <td>
+                                <a href={document.documentURL} target="_blank" rel="noopener noreferrer">
+                                  {document.documentName}
+                                </a>
+                                <DynamicExitDisclaimer url={document.documentURL} />
+                              </td>
+                              <td>
+                                {document.documentTypes.length && document.documentTypes[0].documentTypeCode}
+                              </td>
+                            </tr>
+                          ))}
+                          </tbody>
+                        </table>
+                      </>
+                    )}
                     </div>
                   </div>
 


### PR DESCRIPTION
## Related Issues:
* [HMW-206](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-206&quickFilter=2479)

## Main Changes:
* Updated the layout of the _Assessment Documents_ table on the **Waterbody Report** page to reflect the table in the _Plans to Restore Water Quality_ section.

## Steps To Test:
1. Go to a **Waterbody Report** page with assessment documents, i.e. [http://localhost:3000/waterbody-report/TDECWR/TN03150101012_0100](http://localhost:3000/waterbody-report/TDECWR/TN03150101012_0100)
2. Locate the **Assessment Documents** box in the second column of the page, or below the **Assessment Information** section if viewing on a narrow screen
