### PR TITLE
Feature/211 update sparklines

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -490,81 +490,11 @@ function MonitoringAndSensorsTab({
     setMonitoringAndSensorsDisplayed,
   ]);
 
-  const normalizedUsgsStreamgages = useStreamgageData(usgsStreamgages);
-
-  // once streamgages have been normalized, add precipitation data and
-  // daily average measurements data (both fetched from the usgs daily values
-  // web service) to each streamgage if it exists for that particular location
-  useEffect(() => {
-    if (!usgsPrecipitation.data.value) return;
-    if (!usgsDailyAverages.data?.allParamsMean?.value) return;
-    if (!usgsDailyAverages.data?.precipitationSum?.value) return;
-    if (normalizedUsgsStreamgages.length === 0) return;
-
-    const streamgageSiteIds = normalizedUsgsStreamgages.map((gage) => {
-      return gage.siteId;
-    });
-
-    usgsPrecipitation.data.value?.timeSeries.forEach((site) => {
-      const siteId = site.sourceInfo.siteCode[0].value;
-      const observation = site.values[0].value[0];
-
-      if (streamgageSiteIds.includes(siteId)) {
-        const streamgage = normalizedUsgsStreamgages.find((gage) => {
-          return gage.siteId === siteId;
-        });
-
-        streamgage?.streamgageMeasurements.primary.push({
-          parameterCategory: 'primary',
-          parameterOrder: 5,
-          parameterName: 'Total Daily Rainfall',
-          parameterUsgsName: 'Precipitation (USGS Daily Value)',
-          parameterCode: '00045',
-          measurement: observation.value,
-          datetime: new Date(observation.dateTime).toLocaleDateString(),
-          dailyAverages: [],
-          unitAbbr: 'in',
-          unitName: 'inches',
-        });
-      }
-    });
-
-    const usgsDailyTimeSeriesData = [
-      ...(usgsDailyAverages.data.allParamsMean.value?.timeSeries || []),
-      ...(usgsDailyAverages.data.precipitationSum.value.timeSeries || []),
-    ];
-
-    usgsDailyTimeSeriesData.forEach((site) => {
-      const siteId = site.sourceInfo.siteCode[0].value;
-      const sitesHasObservations = site.values[0].value.length > 0;
-
-      if (streamgageSiteIds.includes(siteId) && sitesHasObservations) {
-        const streamgage = normalizedUsgsStreamgages.find((gage) => {
-          return gage.siteId === siteId;
-        });
-
-        const paramCode = site.variable.variableCode[0].value;
-        const observations = site.values[0].value.map(({ value, dateTime }) => {
-          let measurement = value;
-          // convert measurements recorded in celsius to fahrenheit
-          if (['00010', '00020', '85583'].includes(paramCode)) {
-            measurement = measurement * (9 / 5) + 32;
-          }
-
-          return { measurement, date: new Date(dateTime) };
-        });
-
-        // NOTE: 'category' is either 'primary' or 'secondary' – loop over both
-        for (const category in streamgage?.streamgageMeasurements) {
-          streamgage.streamgageMeasurements[category].forEach((measurement) => {
-            if (measurement.parameterCode === paramCode.toString()) {
-              measurement.dailyAverages = observations;
-            }
-          });
-        }
-      }
-    });
-  }, [normalizedUsgsStreamgages, usgsPrecipitation, usgsDailyAverages]);
+  const normalizedUsgsStreamgages = useStreamgageData(
+    usgsStreamgages,
+    usgsPrecipitation,
+    usgsDailyAverages,
+  );
 
   const [normalizedMonitoringLocations, setNormalizedMonitoringLocations] =
     useState([]);

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -713,7 +713,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       legendEnabled: false,
       fields: [
         { name: 'OBJECTID', type: 'oid' },
-        { name: 'gageHeight', type: 'string' },
         { name: 'monitoringType', type: 'string' },
         { name: 'siteId', type: 'string' },
         { name: 'orgId', type: 'string' },
@@ -741,25 +740,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           style: 'square',
           color: '#fffe00', // '#989fa2'
         },
-        // NOTE: rendering all streamgages in a single color until we can set
-        //       color stops from data returned in USGS STA web service
-        // visualVariables: [
-        //   {
-        //     type: 'color',
-        //     field: 'gageHeight',
-        //     stops: [
-        //       // TODO: determine how to map of gage height values to NWD streamflow percentile stops
-        //       // (National Water Dashboard: https://dashboard.waterdata.usgs.gov/app/nwd/?aoi=default)
-        //       { value: '0', color: '#ea2c38' }, // All-time low for this day  (0th percentile, minimum)
-        //       { value: '1', color: '#b54246' }, // Much below normal          (<10th percentile)
-        //       { value: '2', color: '#eaae3f' }, // Below normal               (10th – 24th percentile)
-        //       { value: '3', color: '#32f242' }, // Normal                     (25th – 75th percentile)
-        //       { value: '4', color: '#56d7da' }, // Above normal               (76th – 90th percentile)
-        //       { value: '5', color: '#2639f6' }, // Much above normal          (>90th percentile)
-        //       { value: '6', color: '#22296e' }, // All-time high for this day (100th percentile, maximum)
-        //     ],
-        //   },
-        // ],
       },
       popupTemplate: {
         outFields: ['*'],
@@ -1311,22 +1291,13 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     if (!usgsStreamgagesLayer || !normalizedUsgsStreamgages.length) return;
 
     const graphics = normalizedUsgsStreamgages.map((gage) => {
-      const gageHeightMeasurements = gage.streamgageMeasurements.primary.filter(
-        (d) => d.parameterCode === '00065',
-      );
-
-      const gageHeight =
-        gageHeightMeasurements.length === 1
-          ? gageHeightMeasurements[0]?.measurement
-          : null;
-
       return new Graphic({
         geometry: {
           type: 'point',
           longitude: gage.locationLongitude,
           latitude: gage.locationLatitude,
         },
-        attributes: { gageHeight, ...gage },
+        attributes: { gage },
       });
     });
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1297,7 +1297,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           longitude: gage.locationLongitude,
           latitude: gage.locationLatitude,
         },
-        attributes: { gage },
+        attributes: gage,
       });
     });
 

--- a/app/client/src/components/shared/Sparkline.js
+++ b/app/client/src/components/shared/Sparkline.js
@@ -13,8 +13,8 @@ type Observation = {
 const VisxStyles = createGlobalStyle`
   .visx-tooltip-glyph svg {
     overflow: visible;
-    width: 1px;
-    height: 1px;
+    width: 10px;
+    height: 10px;
   }
 `;
 

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -134,7 +134,22 @@ const additionalTextStyles = css`
 const measurementStyles = css`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
+`;
+
+const chartStyles = css`
+  padding-right: 8px;
+  width: 128px;
+  text-align: center;
+  line-height: 1;
+
+  small {
+    color: ${colors.gray9};
+  }
+`;
+
+const unitStyles = css`
+  overflow-wrap: break-word;
 `;
 
 const popupIconStyles = css`
@@ -1426,7 +1441,7 @@ function UsgsStreamgageParameter({ url, data }) {
           {data.parameterCode} &ndash; {data.parameterUsgsName}
         </small>
       </td>
-      <td style={{ width: '256px' }}>
+      <td>
         {data.multiple ? (
           <>
             <em>multiple&nbsp;measurements&nbsp;found</em>
@@ -1440,15 +1455,18 @@ function UsgsStreamgageParameter({ url, data }) {
             </small>
           </>
         ) : (
-          <div css={measurementStyles} style={{ width: '256px' }}>
-            {data.dailyAverages.length > 0 ? (
-              <div style={{ width: '128px' }}>
+          <div css={measurementStyles}>
+            <div css={chartStyles}>
+              {data.dailyAverages.length > 0 ? (
                 <Sparkline data={data.dailyAverages} />
-              </div>
-            ) : (
-              <div>&nbsp;</div>
-            )}
-            <div>
+              ) : (
+                <small css={additionalTextStyles}>
+                  No hourly data available
+                </small>
+              )}
+            </div>
+
+            <div css={unitStyles}>
               <strong>{data.measurement}</strong>
               &nbsp;
               <small title={data.unitName}>{data.unitAbbr}</small>


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-211

## Main Changes:
* Properly stores precipitation data and hourly measurements in the right place, so they can be rendered appropriately everywhere used (e.g. in the listview and also in the chart popup).
* Displays a message in place of sparkline chart when no hourly data exists, so chart cannot be displayed.
* Removes lingering no longer used `gage height` data from ESRI `usgsStreamgagesLayer` map layer.
* (Hopefully) fixes tooltip dot from being distorted (see: https://github.com/airbnb/visx/issues/1447).

## Steps To Test:
1. Navigate to http://localhost:3000/community/160501020201/overview. Confirm the visual changes indicated above. In particular, notice the last streamgage in the list (DONNER LK PRECIP GAGE NR TRUCKEE CA) has precipitation data – view that info in the map popup. Compare that with the current version on the dev site, which doesn't show precipitation data in the map popup, due to the bug indicated above: https://mywaterway-dev.app.cloud.gov/community/160501020201/overview