### PR TITLE
bugfix/220_glossary-crashes-server

### DIFF
--- a/app/server/app/server/routes/proxy.js
+++ b/app/server/app/server/routes/proxy.js
@@ -66,6 +66,8 @@ module.exports = function (app) {
       }
 
       function deleteTSHeaders(response) {
+        if (!response) return;
+
         /* The EPA Terminology Services (TS) exposes sensitive 
           information about its underlying technology. While we 
           notified the TS Team about this, they have not had time 
@@ -109,17 +111,16 @@ module.exports = function (app) {
             log.error(logger.formatLogMsg(metadataObj, messageWithUrl));
           }
 
-          deleteTSHeaders(err.response);
-          res
-            .status(err.response.status)
-            .header(err.response.headers)
-            .send(err.response.data);
+          message = 'Proxy Request Error';
+          messageWithUrl = `${message}. parsedUrl = ${parsedUrl}`;
+          log.error(logger.formatLogMsg(metadataObj, messageWithUrl));
+          res.status(503).json({ message });
         });
     } catch (err) {
-      message = 'URL Request Error';
+      message = 'Proxy Server Error';
       messageWithUrl = `${message}. parsedUrl = ${parsedUrl}`;
       log.error(logger.formatLogMsg(metadataObj, messageWithUrl));
-      res.status(403).json({ message });
+      res.status(500).json({ message });
       return;
     }
   });


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-220

## Main Changes:
* Fixed an issue where the terminology services (glossary) causes the server to crash.

## Steps To Test:
1. Change the axios timeout on line 87 from `10000` to `parsedUrl.includes('etss.epa.gov') ? 1 : 10000`. 
2. Start the app
3. Verify the app starts and the server keeps running
4. Open the glossary 
5. Verify the glossary opens and displays an error. 

