### PR TITLE
Feature/224 various text style changes

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -983,6 +983,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       target="_blank"
                       rel="noopener noreferrer"
                       data-cy="portal"
+                      style={{ fontWeight: 'normal' }}
                     >
                       <i
                         css={iconStyles}

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -50,7 +50,7 @@ const containerStyles = css`
 
   table {
     margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0;
     table-layout: fixed;
   }
 
@@ -1239,13 +1239,13 @@ function WaterbodyReport({ fullscreen }: Props) {
                     <h2 css={boxHeadingStyles}>Assessment Documents</h2>
 
                     <div css={boxSectionStyles}>
-                    {documents.status === 'fetching' && <LoadingSpinner />}
-                    {documents.status === 'failure' && (
-                      <div css={modifiedErrorBoxStyles}>
-                        <p>{waterbodyReportError('Assessment')}</p>
-                      </div>
-                    )}
-                    {documents.status === 'success' && (
+                      {documents.status === 'fetching' && <LoadingSpinner />}
+                      {documents.status === 'failure' && (
+                        <div css={modifiedErrorBoxStyles}>
+                          <p>{waterbodyReportError('Assessment')}</p>
+                        </div>
+                      )}
+                      {documents.status === 'success' && (
                         <>
                           {documents.data.length === 0 ? (
                             <p>No documents are available</p>

--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -476,6 +476,7 @@ function MapWidgets({
   const hmwLegendTemp = document.createElement('div');
   const esriLegendTemp = document.createElement('div');
   esriLegendTemp.id = 'esri-legend-container';
+  esriLegendTemp.style.maxWidth = '240px';
   legendTemp.appendChild(hmwLegendTemp);
   legendTemp.appendChild(esriLegendTemp);
   const [hmwLegendNode] = useState(hmwLegendTemp);

--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -492,7 +492,8 @@ function MapWidgets({
       view,
       expanded: false,
       expandIconClass: 'esri-icon-legend',
-      expandTooltip: 'Toggle Legend',
+      expandTooltip: 'Open Legend',
+      collapseTooltip: 'Close Legend',
       autoCollapse: true,
       mode: 'floating',
     });
@@ -590,17 +591,19 @@ function MapWidgets({
   }) {
     const [hover, setHover] = useState(false);
 
+    const widget = document.getElementById('add-data-widget');
+    const widgetHidden = widget.classList.contains('hidden');
+
     return (
       <div
         className="add-data-widget"
-        title="Add Data Widget"
+        title={widgetHidden ? 'Open Add Data Widget' : 'Close Add Data Widget'}
         style={hover ? divHoverStyle : divStyle}
         onMouseOver={() => setHover(true)}
         onMouseOut={() => setHover(false)}
         onClick={(ev) => {
-          const widget = document.getElementById('add-data-widget');
           if (!widget) return;
-          if (widget.classList.contains('hidden')) {
+          if (widgetHidden) {
             widget.classList.remove('hidden');
             setAddDataWidgetVisibleParam(true);
           } else {
@@ -757,6 +760,8 @@ function MapWidgets({
 
     const expandWidget = new Expand({
       expandIconClass: 'esri-icon-layers',
+      expandTooltip: 'Open Basemaps and Layers',
+      collapseTooltip: 'Close Basemaps and Layers',
       view: view,
       mode: 'floating',
       autoCollapse: true,
@@ -1499,7 +1504,11 @@ function ExpandCollapse({
 
   return (
     <div
-      title={fullscreenActive() ? 'Exit fullscreen' : 'Enter fullscreen'}
+      title={
+        fullscreenActive()
+          ? 'Exit Fullscreen Map View'
+          : 'Enter Fullscreen Map View'
+      }
       style={hover ? divHoverStyle : divStyle}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -9,9 +9,9 @@
 }
 
 .esri-widget--panel,
-.esri-basemap-gallery {
-  min-width: 200px !important;
-  max-width: 200px !important;
+.esri-view .esri-basemap-gallery {
+  min-width: 200px;
+  max-width: 200px;
 }
 
 .esri-basemap-gallery__item-thumbnail {


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-224

## Main Changes:
* Reduced padding below the Assessment Documents section on the Waterbody Report.
* Removed the boldness from the "Advanced Filtering" link.
* Updated the tooltips for the map widgets.
* Fixed some scroll bar issues with the Past Water Conditions" in the legend.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/DOEE/DCANA00E_01/2020
2. Verify the padding at the bottom of the Assessment Documents section has been reduced and is similar to that of the other sections.
3. Navigate to http://localhost:3000/community/dc/monitoring
4. Click on "Past Water Conditions"
5. Verify that "Advanced Filtering" is no longer bold
6. Mouse over the widgets on the map and verify they have more helpful tooltips
    * Before some of these widgets had something to like "Expand/Collapse".
