### PR TITLE
Feature/229 monitoring text changes

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -318,7 +318,10 @@ function Monitoring() {
           <TabPanels>
             <TabPanel>
               <p>
-                Find out about current water conditions at sensor locations.
+                Click on each monitoring location on the map or in the list
+                below to find out about current water conditions. Water
+                conditions are measured in real-time using water quality sensors
+                deployed at each location.
               </p>
 
               <SensorsTab
@@ -328,8 +331,12 @@ function Monitoring() {
             </TabPanel>
             <TabPanel>
               <p>
-                View available monitoring sample locations in your local
-                watershed or view by category.
+                Click on each monitoring location on the map or in the list
+                below to find out what was monitored at each location, as well
+                as the number of samples and measurements taken. These locations
+                may have monitoring data available from as recently as last
+                week, to multiple decades old, or anywhere in between, depending
+                on the location.
               </p>
               <p>
                 <a

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -21,6 +21,7 @@ import {
   keyMetricNumberStyles,
   keyMetricLabelStyles,
 } from 'components/shared/KeyMetrics';
+import ShowLessMore from 'components/shared/ShowLessMore';
 import { tabsStyles } from 'components/shared/ContentTabs';
 import VirtualizedList from 'components/shared/VirtualizedList';
 // contexts
@@ -594,6 +595,24 @@ function MonitoringAndSensorsTab({
   ) {
     return (
       <>
+        <p>
+          Water is monitored by state, federal, tribal, and local agencies.
+          Universities, volunteers and others also help detect water quality
+          concerns.
+        </p>
+
+        <p>
+          Water quality monitoring locations are shown on the map as both purple
+          circles and yellow squares.
+          <ShowLessMore
+            charLimit={0}
+            text=" The yellow squares represent monitoring
+            locations that provide real time water quality measurements for a
+            subset of categories– such as water level, water temperature,
+            dissolved oxygen saturation, and other water quality indicators. The purple circles represent monitoring locations where all other past water conditions data is available. These locations may have monitoring data available from as recently as last week, to multiple decades old, or anywhere in between, depending on the location."
+          />
+        </p>
+
         {allMonitoringAndSensors.length === 0 && (
           <p css={centeredTextStyles}>
             There are no locations with data in the <em>{watershed}</em>{' '}
@@ -614,11 +633,6 @@ function MonitoringAndSensorsTab({
                 <p>{monitoringError}</p>
               </div>
             )}
-
-            <p>
-              Find out about current water conditions at sensor locations and
-              explore sample data from water quality monitoring locations.
-            </p>
 
             <table css={toggleTableStyles} className="table">
               <thead>

--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -71,6 +71,10 @@ const modifiedErrorBoxStyles = css`
   margin-bottom: 1.25rem;
 `;
 
+const contentStyles = css`
+  margin-top: 1rem;
+`;
+
 const modifiedInfoBoxStyles = css`
   ${infoBoxStyles}
   margin-top: 1rem;
@@ -126,7 +130,12 @@ function EducatorsContent() {
 
       <hr />
 
-      <div dangerouslySetInnerHTML={{ __html: data.content }} />
+      <em>Links below open in a new browser tab.</em>
+
+      <div
+        css={contentStyles}
+        dangerouslySetInnerHTML={{ __html: data.content }}
+      />
 
       <div
         css={modifiedInfoBoxStyles}

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -239,6 +239,15 @@ function MonitoringUpper() {
         concerns.
       </p>
 
+      <p>
+        Water quality monitoring locations are shown on the map as both purple
+        circles and yellow squares.
+        <ShowLessMore
+          charLimit={0}
+          text=" The yellow squares represent monitoring locations that provide real time water quality measurements for a subset of categories – such as water level, water temperature, dissolved oxygen saturation, and other water quality indicators. The purple circles represent monitoring locations where all other past water conditions data is available for all monitored water quality parameters. These locations may have monitoring data available from as recently as last week, to multiple decades old, or anywhere in between, depending on the location."
+        />
+      </p>
+
       <DisclaimerModal>
         <p>
           The condition of a waterbody is dynamic and can change at any time,

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -1545,6 +1545,9 @@ function useStreamgageData(
           // convert measurements recorded in celsius to fahrenheit
           if (['00010', '00020', '85583'].includes(parameterCode)) {
             measurement = measurement * (9 / 5) + 32;
+
+            // round to 1 decimal place
+            measurement = Math.round(measurement * 10) / 10;
           }
 
           const matchedParam = usgsStaParameters.find((p) => {
@@ -1638,6 +1641,9 @@ function useStreamgageData(
             // convert measurements recorded in celsius to fahrenheit
             if (['00010', '00020', '85583'].includes(paramCode)) {
               measurement = measurement * (9 / 5) + 32;
+
+              // round to 1 decimal place
+              measurement = Math.round(measurement * 10) / 10;
             }
 
             return { measurement, date: new Date(observation.dateTime) };


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-229
* https://jira.epa.gov/browse/HMW-40

## Main Changes:
* Updated text on the Overview and Monitoring panels.
* Updated the temperature data in USGS stream gages so that it is rounded to a single decimal point.
* Added a disclaimer to the Educators page about links opening in new tabs.

## Steps To Test:
1. Navigate to http://localhost:3000/community/portland%20or/overview
2. Click on the "Monitoring Locations" tab 
3. Verify the text at the top of the tab matches the text on the ticket
4. Turn on the "Current Water Conditions" layer
5. Verify the "Water temperature" value is rounded to a single decimal point
6. Mouse over the spark line chart and verify that all values are rounded to a single decimal point
7. Click on the "Monitoring Panel"
8. Verify the text changes match those in the ticket
9. Open the Educators page
10. Verify there is text at the top that says "Links below open in a new browser tab.".

