### PR TITLE
feature/coverage-clear-outjson

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "start": "concurrently -kc \"blue.dim,green.dim\" \"npm:server\" \"npm:client\"",
     "setup": "echo \"Installing project dependencies...\" && npm ci && echo \"Installing client dependencies...\" && cd client && npm ci && echo \"Installing server dependencies...\" && cd .. && cd server && npm ci",
     "cypress": "concurrently -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server\" \"npm:client\" \"cypress open --env coverage=false\"",
-    "coverage": "concurrently -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server\" \"npm:client\" \"cypress run --browser edge\""
+    "coverage": "concurrently -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server\" \"npm:client\" \"npx rimraf .nyc_output/out.json && cypress run --spec cypress/e2e/community.cy.ts --browser edge\""
   },
   "devDependencies": {
     "@cypress/code-coverage": "3.10.0",


### PR DESCRIPTION
## Related Issues:
* None

## Main Changes:
* Added code to the coverage script so the out.json file is cleared prior to running coverage, so the coverage results are accurate.
  * This is needed because coverage numbers would keep increasing after each subsequent run and coverage numbers would not go down if you ran it for just one test.

## Steps To Test:
1. Run `npm run coverage`
2. Watch the `app/.nyc_output/out.json` file 
3. Confirm that it is deleted when the script above starts
4. Confirm a new `app/.nyc_output/out.json` file is created when the above script ends

