### PR TITLE
Feature/233 rollback padus

### DIFF
--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -49,7 +49,7 @@
     "queryStringSecondPart": "%29&outFields=*&returnGeometry=false&returnTrueCurves=false&returnIdsOnly=false&returnCountOnly=false&returnZ=false&returnM=false&returnDistinctValues=false&returnExtentsOnly=false&f=json"
   },
   "wildScenicRivers": "https://services1.arcgis.com/fBc8EJBxQRMcHlei/arcgis/rest/services/WildScenicRiversV2_AGOL/FeatureServer/1/",
-  "protectedAreasDatabase": "https://gis1.usgs.gov/arcgis/rest/services/padus3/Protection_Mechanism_Category/MapServer/",
+  "protectedAreasDatabase": "https://gis1.usgs.gov/arcgis/rest/services/padus2_1/ProtectionMechanismCategory/MapServer/",
   "ejscreen": "https://geopub.epa.gov/arcgis/rest/services/ejscreen/Demographic_Indicators_2018_Public/MapServer/",
   "sfdw": "https://ordspub.epa.gov/ords/sfdw/",
   "googleAnalyticsMapping": [


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-233

## Main Changes:
* Rolled back the PAD-US service to version 2.1 from version 3.0. This was done because the PAD-US team has not officially release version 3 and they do not want version 3 to be publicly available yet.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/protect
2. Expand the "Protected Areas" accordion item
3. Verify the layer loads on the map
4. Click "Expand All" under the "Protected Areas" section
5. Scroll through and verify the fields are displaying the data correctly
    * Note: The "Public Access" field has the following possible values: Unknown, Open Access, Restricted Access, and Closed.
6. Click "View on Map" for one of the items
7. Verify the data in the popup matches the data in the list

## TODO:
- [ ] Revisit upgrading PAD-US after version 3.0 is officially released.
