### PR TITLE
Feature/234 switch to react window

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mywaterway-client",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mywaterway-client",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@arcgis/core": "4.23.7",
@@ -31,7 +31,7 @@
         "react-sticky-box": "1.0.2",
         "react-switch": "6.0.0",
         "react-table": "7.8.0",
-        "react-virtualized": "9.22.3",
+        "react-window": "1.8.7",
         "smoothscroll-polyfill": "0.4.4",
         "styled-components": "5.3.5"
       },
@@ -13564,12 +13564,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pointer-events-polyfill": {
-      "version": "0.4.4-pre",
-      "resolved": "https://registry.npmjs.org/pointer-events-polyfill/-/pointer-events-polyfill-0.4.4-pre.tgz",
-      "integrity": "sha512-t7iitVY5jW9mGOFZEHphJOzB8eMhoYaE6I5HqsUX14rjsPa9F6OlMOCj3EpqDzNb/8XtMk2BxMpOyePPyuefHw==",
-      "peer": true
-    },
     "node_modules/postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -15202,11 +15196,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15503,78 +15492,20 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+    "node_modules/react-window": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.7.tgz",
+      "integrity": "sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==",
       "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha"
-      }
-    },
-    "node_modules/react-zdog": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/react-zdog/-/react-zdog-1.0.11.tgz",
-      "integrity": "sha512-L6/8Zi+Nf+faNMsSZ31HLmLlu6jcbs/jqqFvme7CFnYjAeYfhJ4HyuHKd7Pu/zk9tegv6FaJj1v+hmUwUpKLQw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "lodash-es": "^4.17.11",
-        "pointer-events-polyfill": "^0.4.4-pre",
-        "react-reconciler": "^0.20.4",
-        "resize-observer-polyfill": "^1.5.1",
-        "scheduler": "0.13.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8",
-        "zdog": ">=1.1"
-      }
-    },
-    "node_modules/react-zdog/node_modules/react-reconciler": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.20.4.tgz",
-      "integrity": "sha512-kxERc4H32zV2lXMg/iMiwQHOtyqf15qojvkcZ5Ja2CPkjVohHw9k70pdDBwrnQhLVetUJBSYyqU3yqrlVTOajA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">8.0.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
-    "node_modules/react-zdog/node_modules/react-reconciler/node_modules/scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/react-zdog/node_modules/scheduler": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
-      "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/readable-stream": {
@@ -18564,12 +18495,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/zdog": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/zdog/-/zdog-1.1.3.tgz",
-      "integrity": "sha512-raRj6r0gPzopFm5XWBJZr/NuV4EEnT4iE+U3dp5FV5pCb588Gmm3zLIp/j9yqqcMiHH8VNQlerLTgOqL7krh6w==",
-      "peer": true
     }
   },
   "dependencies": {
@@ -28327,12 +28252,6 @@
         }
       }
     },
-    "pointer-events-polyfill": {
-      "version": "0.4.4-pre",
-      "resolved": "https://registry.npmjs.org/pointer-events-polyfill/-/pointer-events-polyfill-0.4.4-pre.tgz",
-      "integrity": "sha512-t7iitVY5jW9mGOFZEHphJOzB8eMhoYaE6I5HqsUX14rjsPa9F6OlMOCj3EpqDzNb/8XtMk2BxMpOyePPyuefHw==",
-      "peer": true
-    },
     "postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -29352,11 +29271,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -29557,67 +29471,13 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+    "react-window": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.7.tgz",
+      "integrity": "sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==",
       "requires": {
-        "@babel/runtime": "^7.7.2",
-        "clsx": "^1.0.4",
-        "dom-helpers": "^5.1.3",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-zdog": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/react-zdog/-/react-zdog-1.0.11.tgz",
-      "integrity": "sha512-L6/8Zi+Nf+faNMsSZ31HLmLlu6jcbs/jqqFvme7CFnYjAeYfhJ4HyuHKd7Pu/zk9tegv6FaJj1v+hmUwUpKLQw==",
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "lodash-es": "^4.17.11",
-        "pointer-events-polyfill": "^0.4.4-pre",
-        "react-reconciler": "^0.20.4",
-        "resize-observer-polyfill": "^1.5.1",
-        "scheduler": "0.13.3"
-      },
-      "dependencies": {
-        "react-reconciler": {
-          "version": "0.20.4",
-          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.20.4.tgz",
-          "integrity": "sha512-kxERc4H32zV2lXMg/iMiwQHOtyqf15qojvkcZ5Ja2CPkjVohHw9k70pdDBwrnQhLVetUJBSYyqU3yqrlVTOajA==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          },
-          "dependencies": {
-            "scheduler": {
-              "version": "0.13.6",
-              "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-              "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-              "peer": true,
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
-              }
-            }
-          }
-        },
-        "scheduler": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
-          "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "readable-stream": {
@@ -31881,12 +31741,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-    },
-    "zdog": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/zdog/-/zdog-1.1.3.tgz",
-      "integrity": "sha512-raRj6r0gPzopFm5XWBJZr/NuV4EEnT4iE+U3dp5FV5pCb588Gmm3zLIp/j9yqqcMiHH8VNQlerLTgOqL7krh6w==",
-      "peer": true
     }
   }
 }

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mywaterway-client",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "A tool to learn about your water resources.",
   "keywords": [
     "MyWaterway",
@@ -73,7 +73,7 @@
     "react-sticky-box": "1.0.2",
     "react-switch": "6.0.0",
     "react-table": "7.8.0",
-    "react-virtualized": "9.22.3",
+    "react-window": "1.8.7",
     "smoothscroll-polyfill": "0.4.4",
     "styled-components": "5.3.5"
   },

--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -710,8 +710,7 @@ function Actions({ fullscreen }: Props) {
                         >
                           <VirtualizedList
                             items={waters}
-                            expandedRowsSetter={setExpandedRows}
-                            renderer={({ index, allExpanded }) => {
+                            renderer={({ index }) => {
                               const water = waters[index];
 
                               const auId = water.assessmentUnitIdentifier;
@@ -753,9 +752,7 @@ function Actions({ fullscreen }: Props) {
                                   }
                                   feature={graphic}
                                   idKey="assessmentunitidentifier"
-                                  allExpanded={
-                                    allExpanded || expandedRows.includes(index)
-                                  }
+                                  allExpanded={expandedRows.includes(index)}
                                   onChange={() => {
                                     // add the item to the expandedRows array so the accordion item
                                     // will stay expanded when the user scrolls or highlights map items

--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -1,12 +1,6 @@
 // @flow
 
-import React, {
-  Fragment,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { css } from 'styled-components/macro';
 import WindowSize from '@reach/window-size';
@@ -40,10 +34,7 @@ import {
 } from 'components/shared/Box';
 // contexts
 import { FullscreenContext, FullscreenProvider } from 'contexts/Fullscreen';
-import {
-  MapHighlightContext,
-  MapHighlightProvider,
-} from 'contexts/MapHighlight';
+import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { fetchCheck } from 'utils/fetchUtils';
@@ -268,9 +259,6 @@ function Actions({ fullscreen }: Props) {
     status: 'fetching',
     layer: null,
   });
-
-  const { selectedGraphic, highlightedGraphic } =
-    useContext(MapHighlightContext);
 
   // fetch action data from the attains 'actions' web service
   const [organizationName, setOrganizationName] = useState('');
@@ -723,7 +711,7 @@ function Actions({ fullscreen }: Props) {
                           <VirtualizedList
                             items={waters}
                             expandedRowsSetter={setExpandedRows}
-                            renderer={({ index, resizeCell, allExpanded }) => {
+                            renderer={({ index, allExpanded }) => {
                               const water = waters[index];
 
                               const auId = water.assessmentUnitIdentifier;
@@ -742,35 +730,6 @@ function Actions({ fullscreen }: Props) {
                                 ? getTypeFromAttributes(graphic)
                                 : '';
 
-                              let status = null;
-                              // ensure the key exists prior to deciding to highlight
-                              if (
-                                graphic?.attributes.assessmentunitidentifier
-                              ) {
-                                const id =
-                                  graphic.attributes.assessmentunitidentifier;
-
-                                let isSelected = false;
-                                if (selectedGraphic?.attributes) {
-                                  isSelected =
-                                    selectedGraphic.attributes
-                                      .assessmentunitidentifier === id;
-                                }
-
-                                let isHighlighted = false;
-                                if (highlightedGraphic?.attributes) {
-                                  isHighlighted =
-                                    highlightedGraphic.attributes
-                                      .assessmentunitidentifier === id;
-                                }
-
-                                if (isSelected) {
-                                  status = 'selected';
-                                } else if (isHighlighted && !isSelected) {
-                                  status = 'highlighted';
-                                }
-                              }
-
                               const waterbodyReportingCycle = graphic
                                 ? graphic.attributes.reportingcycle
                                 : null;
@@ -782,7 +741,6 @@ function Actions({ fullscreen }: Props) {
                               return (
                                 <AccordionItem
                                   key={symbolType + orgId + auId}
-                                  index={symbolType + orgId + auId}
                                   title={
                                     <strong>
                                       {name || 'Name not provided'}
@@ -795,14 +753,10 @@ function Actions({ fullscreen }: Props) {
                                   }
                                   feature={graphic}
                                   idKey="assessmentunitidentifier"
-                                  status={status}
                                   allExpanded={
                                     allExpanded || expandedRows.includes(index)
                                   }
                                   onChange={() => {
-                                    // ensure the cell is sized appropriately
-                                    resizeCell();
-
                                     // add the item to the expandedRows array so the accordion item
                                     // will stay expanded when the user scrolls or highlights map items
                                     if (expandedRows.includes(index)) {

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1069,8 +1069,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
             >
               <VirtualizedList
                 items={sortedMonitoringLocations}
-                expandedRowsSetter={setExpandedRows}
-                renderer={({ index, allExpanded }) => {
+                renderer={({ index }) => {
                   const item = sortedMonitoringLocations[index];
 
                   const feature = {

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1039,6 +1039,15 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                 </span>
               }
               onSortChange={({ value }) => setSortBy(value)}
+              onExpandCollapse={(allExpanded) => {
+                if (allExpanded) {
+                  setExpandedRows([
+                    ...Array(sortedMonitoringLocations.length).keys(),
+                  ]);
+                } else {
+                  setExpandedRows([]);
+                }
+              }}
               sortOptions={[
                 {
                   label: 'Monitoring Location Name',
@@ -1092,7 +1101,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       }
                       feature={feature}
                       idKey="siteId"
-                      allExpanded={allExpanded || expandedRows.includes(index)}
+                      allExpanded={expandedRows.includes(index)}
                       onChange={() => {
                         // add the item to the expandedRows array so the accordion item
                         // will stay expanded when the user scrolls or highlights map items

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -126,9 +126,6 @@ function Monitoring() {
   const navigate = useNavigate();
   const { usgsStreamgages } = useFetchedDataState();
 
-  // draw the waterbody on the map
-  useWaterbodyOnMap();
-
   const {
     cipSummary,
     monitoringLocations,
@@ -375,6 +372,9 @@ function Monitoring() {
 function SensorsTab({ usgsStreamgagesDisplayed, setUsgsStreamgagesDisplayed }) {
   const { usgsStreamgages, usgsPrecipitation, usgsDailyAverages } =
     useFetchedDataState();
+
+  // draw the waterbody on the map
+  useWaterbodyOnMap();
 
   const services = useServicesContext();
 
@@ -1061,7 +1061,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
               <VirtualizedList
                 items={sortedMonitoringLocations}
                 expandedRowsSetter={setExpandedRows}
-                renderer={({ index, resizeCell, allExpanded }) => {
+                renderer={({ index, allExpanded }) => {
                   const item = sortedMonitoringLocations[index];
 
                   const feature = {
@@ -1094,9 +1094,6 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       idKey="siteId"
                       allExpanded={allExpanded || expandedRows.includes(index)}
                       onChange={() => {
-                        // ensure the cell is sized appropriately
-                        resizeCell();
-
                         // add the item to the expandedRows array so the accordion item
                         // will stay expanded when the user scrolls or highlights map items
                         if (expandedRows.includes(index)) {

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -711,6 +711,15 @@ function MonitoringAndSensorsTab({
               onSortChange={({ value }) =>
                 setMonitoringAndSensorsSortedBy(value)
               }
+              onExpandCollapse={(allExpanded) => {
+                if (allExpanded) {
+                  setExpandedRows([
+                    ...Array(filteredMonitoringAndSensors.length).keys(),
+                  ]);
+                } else {
+                  setExpandedRows([]);
+                }
+              }}
               sortOptions={[
                 {
                   label: 'Location Name',
@@ -777,7 +786,7 @@ function MonitoringAndSensorsTab({
                       }
                       feature={feature}
                       idKey="siteId"
-                      allExpanded={allExpanded || expandedRows.includes(index)}
+                      allExpanded={expandedRows.includes(index)}
                       onChange={() => {
                         // add the item to the expandedRows array so the accordion item
                         // will stay expanded when the user scrolls or highlights map items

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -746,9 +746,7 @@ function MonitoringAndSensorsTab({
             >
               <VirtualizedList
                 items={filteredMonitoringAndSensors}
-                expandedRowsSetter={setExpandedRows}
-                displayedTypes={listTypes}
-                renderer={({ index, allExpanded }) => {
+                renderer={({ index }) => {
                   const item = filteredMonitoringAndSensors[index];
 
                   const feature = {

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -466,10 +466,6 @@ function MonitoringAndSensorsTab({
 
   const [expandedRows, setExpandedRows] = useState([]);
 
-  const [listTypes, setListTypes] = useState({
-    usgsStreamgages: usgsStreamgagesDisplayed,
-    monitoringLocations: monitoringLocationsDisplayed,
-  });
   // if either of the "Current Water Conditions" or "Past Water Conditions" switches
   // are turned on, or if both switches are turned off, keep the "Monitoring
   // Stations" switch in sync
@@ -481,11 +477,6 @@ function MonitoringAndSensorsTab({
     if (!usgsStreamgagesDisplayed && !monitoringLocationsDisplayed) {
       setMonitoringAndSensorsDisplayed(false);
     }
-
-    setListTypes({
-      usgsStreamgages: usgsStreamgagesDisplayed,
-      monitoringLocations: monitoringLocationsDisplayed,
-    });
   }, [
     usgsStreamgagesDisplayed,
     monitoringLocationsDisplayed,

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -739,7 +739,7 @@ function MonitoringAndSensorsTab({
                 items={filteredMonitoringAndSensors}
                 expandedRowsSetter={setExpandedRows}
                 displayedTypes={listTypes}
-                renderer={({ index, resizeCell, allExpanded }) => {
+                renderer={({ index, allExpanded }) => {
                   const item = filteredMonitoringAndSensors[index];
 
                   const feature = {
@@ -779,9 +779,6 @@ function MonitoringAndSensorsTab({
                       idKey="siteId"
                       allExpanded={allExpanded || expandedRows.includes(index)}
                       onChange={() => {
-                        // ensure the cell is sized appropriately
-                        resizeCell();
-
                         // add the item to the expandedRows array so the accordion item
                         // will stay expanded when the user scrolls or highlights map items
                         if (expandedRows.includes(index)) {

--- a/app/client/src/components/pages/State.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/State.Tabs.AdvancedSearch.js
@@ -1168,29 +1168,6 @@ function MenuList({ ...props }) {
     return props.children;
   }
 
-  function MenuItem({
-    index,
-    width,
-    setSize,
-  }: {
-    index: number,
-    width: number,
-    setSize: (index: number, size: number) => void,
-  }) {
-    const rowValue = props.children[index];
-
-    const rowRef = useRef();
-
-    // keep track of the height of the rows to autosize rows
-    useEffect(() => {
-      if (!rowRef?.current) return;
-
-      setSize(index, rowRef.current.getBoundingClientRect().height);
-    }, [setSize, index, width]);
-
-    return <div ref={rowRef}>{rowValue}</div>;
-  }
-
   return (
     <VariableSizeList
       ref={listRef}
@@ -1201,11 +1178,36 @@ function MenuList({ ...props }) {
     >
       {({ index, style }) => (
         <div style={{ ...style, overflowX: 'hidden' }}>
-          <MenuItem index={index} width={width} setSize={setSize} />
+          <MenuItem
+            index={index}
+            width={width}
+            setSize={setSize}
+            value={props.children[index]}
+          />
         </div>
       )}
     </VariableSizeList>
   );
+}
+
+type MenuItemProps = {
+  index: number,
+  width: number,
+  setSize: (index: number, size: number) => void,
+  value: string,
+};
+
+function MenuItem({ index, width, setSize, value }: MenuItemProps) {
+  const rowRef = useRef();
+
+  // keep track of the height of the rows to autosize rows
+  useEffect(() => {
+    if (!rowRef?.current) return;
+
+    setSize(index, rowRef.current.getBoundingClientRect().height);
+  }, [setSize, index, width]);
+
+  return <div ref={rowRef}>{value}</div>;
 }
 
 export default function AdvancedSearchContainer() {

--- a/app/client/src/components/pages/State.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/State.Tabs.AdvancedSearch.js
@@ -1136,8 +1136,6 @@ function AdvancedSearch() {
         </div>
       )}
 
-      {/* conditionally render the waterbody list to work around a render
-          bug with react-virtualized where only a few list items are renered. */}
       {!showMap && contentVisible && (
         <>
           <hr />

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -71,6 +71,7 @@ type AccordionListProps = {
   expandDisabled: boolean,
   sortOptions: { value: string, label: string }[],
   onSortChange: Function,
+  onExpandCollapse: Function,
 };
 
 function AccordionList({
@@ -80,6 +81,7 @@ function AccordionList({
   expandDisabled = false,
   sortOptions = [],
   onSortChange = () => {},
+  onExpandCollapse = () => {},
 }: AccordionListProps) {
   const [sortBy, setSortBy] = useState(
     sortOptions.length > 0 ? sortOptions[0] : null,
@@ -122,7 +124,11 @@ function AccordionList({
         {!expandDisabled && (
           <button
             css={expandButtonStyles}
-            onClick={(ev) => setAllExpanded(!allExpanded)}
+            onClick={(ev) => {
+              const newAllExpanded = !allExpanded;
+              setAllExpanded(newAllExpanded);
+              onExpandCollapse(newAllExpanded);
+            }}
           >
             {allExpanded ? 'Collapse All' : 'Expand All'}&nbsp;&nbsp;
             <i className={iconClassName} aria-hidden="true" />

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -124,7 +124,7 @@ function AccordionList({
         {!expandDisabled && (
           <button
             css={expandButtonStyles}
-            onClick={(ev) => {
+            onClick={(_ev) => {
               const newAllExpanded = !allExpanded;
               setAllExpanded(newAllExpanded);
               onExpandCollapse(newAllExpanded);

--- a/app/client/src/components/shared/Accordion.js
+++ b/app/client/src/components/shared/Accordion.js
@@ -202,7 +202,6 @@ const colorMap = {
 
 type AccordionItemProps = {
   children: Node,
-  className: string,
   icon: ?Object,
   title: Node,
   subTitle: ?Node,
@@ -210,14 +209,12 @@ type AccordionItemProps = {
   onAddHighlight: () => void,
   onRemoveHighlight: () => void,
   onChange: (isOpen: boolean) => void,
-  idKey: ?string,
   allExpanded: boolean,
   highlightContent: ?boolean,
 };
 
 function AccordionItem({
   children,
-  className = '',
   icon,
   title,
   subTitle,
@@ -225,7 +222,6 @@ function AccordionItem({
   onAddHighlight = () => {},
   onRemoveHighlight = () => {},
   onChange = () => {},
-  idKey,
   allExpanded,
   highlightContent = true,
 }: AccordionItemProps) {
@@ -253,7 +249,7 @@ function AccordionItem({
   return (
     <div
       css={accordionItemContainerStyles}
-      className={`hmw-accordion ${className}`}
+      className={`hmw-accordion`}
       onMouseEnter={(ev) => addHighlight()}
       onMouseLeave={(ev) => removeHighlight()}
       onFocus={(ev) => addHighlight()}

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -2110,7 +2110,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   }, [
     mapView,
     hucBoundaries,
-    boundariesLayer.graphics,
+    boundariesLayer,
     setCurrentExtent,
     setAtHucBoundaries,
     homeWidget,

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -1,6 +1,12 @@
 // @flow
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { Node } from 'react';
 import { css } from 'styled-components/macro';
 import StickyBox from 'react-sticky-box';
@@ -195,11 +201,21 @@ function StateMap({
     navigate,
   ]);
 
-  // Function for resetting the LocationSearch context when the map is removed
+  // Keep track of when the component is unmounting for use elsewhere
+  const unmounting = useRef(false);
   useEffect(() => {
     return function cleanup() {
-      fetchedDataDispatch({ type: 'RESET_FETCHED_DATA' });
-      resetData();
+      unmounting.current = true;
+    };
+  }, []);
+
+  // Resets the LocationSearch context when the map is removed
+  useEffect(() => {
+    return function cleanup() {
+      if (unmounting.current) {
+        fetchedDataDispatch({ type: 'RESET_FETCHED_DATA' });
+        resetData();
+      }
     };
   }, [fetchedDataDispatch, resetData]);
 

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -10,16 +10,9 @@ import { useOnScreen } from 'utils/hooks';
 type Props = {
   items: Array<Object>,
   renderer: Function,
-  allExpanded?: boolean,
-  displayedTypes?: Object,
 };
 
-function VirtualizedListInner({
-  items,
-  renderer,
-  allExpanded,
-  displayedTypes,
-}: Props) {
+function VirtualizedListInner({ items, renderer }: Props) {
   const innerRef = useRef();
   const outerRef = useRef();
   const sizeMap = useRef({});
@@ -40,7 +33,7 @@ function VirtualizedListInner({
       setSize(index, rowRef.current.getBoundingClientRect().height, listRef);
     }, [setSize, index, width, listRef]);
 
-    return <div ref={rowRef}>{renderer({ index, allExpanded })}</div>;
+    return <div ref={rowRef}>{renderer({ index })}</div>;
   }
 
   // make the virtualized list use the window's scroll bar
@@ -100,27 +93,13 @@ function VirtualizedListInner({
 // for an issue where the list would not display anything
 // or jump around when the list is not immediatly visible
 // on the dom (i.e., the list is on the second tab).
-function VirtualizedList({
-  items,
-  renderer,
-  allExpanded,
-  displayedTypes,
-  expandedRowsSetter,
-}: Props) {
+function VirtualizedList({ items, renderer }: Props) {
   const ref = useRef();
   const isVisible = useOnScreen(ref);
 
   return (
     <div ref={ref}>
-      {isVisible && (
-        <VirtualizedListInner
-          items={items}
-          renderer={renderer}
-          allExpanded={allExpanded}
-          expandedRowsSetter={expandedRowsSetter}
-          displayedTypes={displayedTypes}
-        />
-      )}
+      {isVisible && <VirtualizedListInner items={items} renderer={renderer} />}
     </div>
   );
 }

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -1,127 +1,94 @@
 // @flow
 
-import React, { useEffect, useRef, useState } from 'react';
-import {
-  AutoSizer,
-  CellMeasurer,
-  CellMeasurerCache,
-  List,
-  WindowScroller,
-} from 'react-virtualized';
-// utils
-import { useOnScreen } from 'utils/hooks';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useWindowSize } from '@reach/window-size';
+import { VariableSizeList } from 'react-window';
+import throttle from 'lodash/throttle';
 
 type Props = {
   items: Array<Object>,
   renderer: Function,
   allExpanded?: boolean,
   displayedTypes?: Object,
-  expandedRowsSetter?: Function,
 };
 
-function VirtualizedListInner({
-  items,
-  renderer,
-  allExpanded,
-  displayedTypes,
-  expandedRowsSetter,
-}: Props) {
-  const [cache] = useState(
-    new CellMeasurerCache({
-      defaultHeight: 50,
-      fixedWidth: true,
-    }),
-  );
-  const windowScrollRef = useRef(null);
-  const listRef = useRef(null);
-
-  // Resizes the rows (accordion items) of the react-virtualized list.
-  // This is done anytime an accordion item is expanded/collapsed
-  useEffect(() => {
-    cache.clearAll();
-    listRef.current?.recomputeRowHeights();
-    if (expandedRowsSetter) expandedRowsSetter([]);
-  }, [allExpanded, cache, expandedRowsSetter, displayedTypes]);
-
-  function rowRenderer({ index, isScrolling, key, parent, style }) {
-    function resizeCell() {
-      if (!listRef || !listRef.current) return;
-
-      // clear the row height for the accordion item being expanded/collapsed
-      cache.clear(index);
-      listRef.current.recomputeRowHeights(index);
-    }
-
-    return (
-      <CellMeasurer
-        cache={cache}
-        columnIndex={0}
-        rowCount={items.length}
-        parent={parent}
-        key={key}
-        rowIndex={index}
-      >
-        <div style={style} onClick={resizeCell}>
-          {renderer({ index, resizeCell, allExpanded })}
-        </div>
-      </CellMeasurer>
-    );
-  }
-
-  return (
-    <WindowScroller ref={windowScrollRef}>
-      {({ height, isScrolling, onChildScroll, scrollTop }) => (
-        <AutoSizer disableHeight>
-          {({ width }) => (
-            <List
-              ref={listRef}
-              autoHeight
-              deferredMeasurementCache={cache}
-              height={height}
-              width={width}
-              scrollTop={scrollTop}
-              isScrolling={isScrolling}
-              onScroll={onChildScroll}
-              rowCount={items.length}
-              rowHeight={cache.rowHeight}
-              rowRenderer={rowRenderer}
-              overscanRowCount={10}
-            />
-          )}
-        </AutoSizer>
-      )}
-    </WindowScroller>
-  );
-}
-
-// This is a wrapper component that ensures this component
-// is visible on the DOM prior to rendering the actual
-// virtualized list. This component was added as a workaround
-// for an issue where the list would not display anything
-// or jump around when the list is not immediatly visible
-// on the dom (i.e., the list is on the second tab).
 function VirtualizedList({
   items,
   renderer,
   allExpanded,
   displayedTypes,
-  expandedRowsSetter,
 }: Props) {
-  const ref = useRef();
-  const isVisible = useOnScreen(ref);
+  const innerRef = useRef();
+  const outerRef = useRef();
+  const sizeMap = useRef({});
+  const setSize = useCallback((index: number, size: number, listRef: any) => {
+    sizeMap.current = { ...sizeMap.current, [index]: size };
+    listRef.current.resetAfterIndex(index);
+  }, []);
+  const getSize = (index: number) => sizeMap.current[index] || 150;
+  const { width } = useWindowSize();
+
+  function RowRenderer({ index, setSize, width, listRef }) {
+    const rowRef = useRef();
+
+    // keep track of the height of the rows to autosize rows
+    useEffect(() => {
+      if (!rowRef?.current) return;
+
+      setSize(index, rowRef.current.getBoundingClientRect().height, listRef);
+    }, [setSize, index, width, listRef]);
+
+    return <div ref={rowRef}>{renderer({ index, allExpanded })}</div>;
+  }
+
+  // make the virtualized list use the window's scroll bar
+  useEffect(() => {
+    const throttleTime = 10;
+    const handleWindowScroll = throttle(() => {
+      const { offsetTop = 0 } = outerRef.current || {};
+
+      const scrollPosition =
+        window['pageYOffset'] ||
+        document.documentElement['scrollTop'] ||
+        document.body['scrollTop'] ||
+        0;
+
+      const scrollTop = scrollPosition - offsetTop;
+      innerRef.current && innerRef.current.scrollTo(scrollTop);
+    }, throttleTime);
+
+    window.addEventListener('scroll', handleWindowScroll);
+    return () => {
+      handleWindowScroll.cancel();
+      window.removeEventListener('scroll', handleWindowScroll);
+    };
+  }, []);
 
   return (
-    <div ref={ref}>
-      {isVisible && (
-        <VirtualizedListInner
-          items={items}
-          renderer={renderer}
-          allExpanded={allExpanded}
-          expandedRowsSetter={expandedRowsSetter}
-          displayedTypes={displayedTypes}
-        />
+    <VariableSizeList
+      height={window.innerHeight}
+      itemCount={items.length}
+      itemSize={getSize}
+      width="100%"
+      ref={innerRef}
+      outerRef={outerRef}
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'inline-block',
+      }}
+    >
+      {({ index, style }) => (
+        <div style={{ ...style, overflowX: 'hidden' }}>
+          <RowRenderer
+            listRef={innerRef}
+            index={index}
+            setSize={setSize}
+            width={width}
+          />
+        </div>
       )}
-    </div>
+    </VariableSizeList>
   );
 }
 

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -4,6 +4,8 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { useWindowSize } from '@reach/window-size';
 import { VariableSizeList } from 'react-window';
 import throttle from 'lodash/throttle';
+// utils
+import { useOnScreen } from 'utils/hooks';
 
 type Props = {
   items: Array<Object>,
@@ -12,7 +14,7 @@ type Props = {
   displayedTypes?: Object,
 };
 
-function VirtualizedList({
+function VirtualizedListInner({
   items,
   renderer,
   allExpanded,
@@ -89,6 +91,37 @@ function VirtualizedList({
         </div>
       )}
     </VariableSizeList>
+  );
+}
+
+// This is a wrapper component that ensures this component
+// is visible on the DOM prior to rendering the actual
+// virtualized list. This component was added as a workaround
+// for an issue where the list would not display anything
+// or jump around when the list is not immediatly visible
+// on the dom (i.e., the list is on the second tab).
+function VirtualizedList({
+  items,
+  renderer,
+  allExpanded,
+  displayedTypes,
+  expandedRowsSetter,
+}: Props) {
+  const ref = useRef();
+  const isVisible = useOnScreen(ref);
+
+  return (
+    <div ref={ref}>
+      {isVisible && (
+        <VirtualizedListInner
+          items={items}
+          renderer={renderer}
+          allExpanded={allExpanded}
+          expandedRowsSetter={expandedRowsSetter}
+          displayedTypes={displayedTypes}
+        />
+      )}
+    </div>
   );
 }
 

--- a/app/client/src/components/shared/VirtualizedList.js
+++ b/app/client/src/components/shared/VirtualizedList.js
@@ -7,6 +7,33 @@ import throttle from 'lodash/throttle';
 // utils
 import { useOnScreen } from 'utils/hooks';
 
+type RowRendererProps = {
+  index: number,
+  width: number,
+  listRef: React.MutableRefObject<undefined>,
+  setSize: Function,
+  renderer: Function,
+};
+
+function RowRenderer({
+  index,
+  width,
+  listRef,
+  setSize,
+  renderer,
+}: RowRendererProps) {
+  const rowRef = useRef();
+
+  // keep track of the height of the rows to autosize rows
+  useEffect(() => {
+    if (!rowRef?.current) return;
+
+    setSize(index, rowRef.current.getBoundingClientRect().height, listRef);
+  }, [setSize, index, width, listRef]);
+
+  return <div ref={rowRef}>{renderer({ index })}</div>;
+}
+
 type Props = {
   items: Array<Object>,
   renderer: Function,
@@ -22,19 +49,6 @@ function VirtualizedListInner({ items, renderer }: Props) {
   }, []);
   const getSize = (index: number) => sizeMap.current[index] || 150;
   const { width } = useWindowSize();
-
-  function RowRenderer({ index, setSize, width, listRef }) {
-    const rowRef = useRef();
-
-    // keep track of the height of the rows to autosize rows
-    useEffect(() => {
-      if (!rowRef?.current) return;
-
-      setSize(index, rowRef.current.getBoundingClientRect().height, listRef);
-    }, [setSize, index, width, listRef]);
-
-    return <div ref={rowRef}>{renderer({ index })}</div>;
-  }
 
   // make the virtualized list use the window's scroll bar
   useEffect(() => {
@@ -80,6 +94,7 @@ function VirtualizedListInner({ items, renderer }: Props) {
             index={index}
             setSize={setSize}
             width={width}
+            renderer={renderer}
           />
         </div>
       )}

--- a/app/client/src/components/shared/WaterbodyListVirtualized.js
+++ b/app/client/src/components/shared/WaterbodyListVirtualized.js
@@ -110,6 +110,13 @@ function WaterbodyListVirtualized({
           { value: 'assessmentunitidentifier', label: 'Assessment Unit Id' },
         ]}
         onSortChange={(sortBy) => setSortBy(sortBy.value)}
+        onExpandCollapse={(allExpanded) => {
+          if (allExpanded) {
+            setExpandedRows([...Array(waterbodies.length).keys()]);
+          } else {
+            setExpandedRows([]);
+          }
+        }}
       >
         <VirtualizedList
           items={waterbodies}
@@ -170,7 +177,7 @@ function WaterbodyListVirtualized({
                 feature={graphic}
                 idKey="assessmentunitidentifier"
                 status={status}
-                allExpanded={allExpanded || expandedRows.includes(index)}
+                allExpanded={expandedRows.includes(index)}
                 onChange={() => {
                   // add the item to the expandedRows array so the accordion item
                   // will stay expanded when the user scrolls or highlights map items

--- a/app/client/src/components/shared/WaterbodyListVirtualized.js
+++ b/app/client/src/components/shared/WaterbodyListVirtualized.js
@@ -120,8 +120,7 @@ function WaterbodyListVirtualized({
       >
         <VirtualizedList
           items={waterbodies}
-          expandedRowsSetter={setExpandedRows}
-          renderer={({ index, allExpanded }) => {
+          renderer={({ index }) => {
             const graphic = waterbodies[index];
 
             const condition = getWaterbodyCondition(

--- a/app/client/src/components/shared/WaterbodyListVirtualized.js
+++ b/app/client/src/components/shared/WaterbodyListVirtualized.js
@@ -114,7 +114,7 @@ function WaterbodyListVirtualized({
         <VirtualizedList
           items={waterbodies}
           expandedRowsSetter={setExpandedRows}
-          renderer={({ index, resizeCell, allExpanded }) => {
+          renderer={({ index, allExpanded }) => {
             const graphic = waterbodies[index];
 
             const condition = getWaterbodyCondition(
@@ -172,9 +172,6 @@ function WaterbodyListVirtualized({
                 status={status}
                 allExpanded={allExpanded || expandedRows.includes(index)}
                 onChange={() => {
-                  // ensure the cell is sized appropriately
-                  resizeCell();
-
                   // add the item to the expandedRows array so the accordion item
                   // will stay expanded when the user scrolls or highlights map items
                   if (expandedRows.includes(index)) {


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-234

## Main Changes:
* Switched from `react-virtualized` to `react-window`. The `react-virtualized` package is one of the roadblocks to updating to React 18. 
* I removed the `displayedTypes` prop. This prop was added to fix an issue with the `react-virtualized` package. I was unable to reproduce that issue with the new `react-window` package. Here is the related PR where this prop was added https://github.com/Eastern-Research-Group/mywaterway/pull/634. When testing this please also try to reproduce the issue related to this prop.

## Steps To Test:
When testing accordions be sure to test the expand/collapse functionality, expand all/collapse all functionality, and mouse over events. Pay special attention to the accordions in the following places

1. Monitoring Locations tab on the Overview panel of the Community page.
2. Past Water Conditions tab on the Monitoring panel of the Community page.
3. Advanced Search tab on the State page
    * Watershed Names (HUC12) drop down
    * Waterbody Names (IDs) drop down
    * Waterbodies list view after performing a search
4. Actions page (ex. http://localhost:3000/plan-summary/WIDNR/UpperFoxWolf_Protection2020)

