### PR TITLE
Feature/238 remove message in waterbody report popup

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -830,10 +830,13 @@ function WaterbodyReport({ fullscreen }: Props) {
 
   // calculate height of div holding waterbody info
   const [infoHeight, setInfoHeight] = useState(0);
-  const measuredRef = useCallback((node) => {
-    if (!node) return;
-    setInfoHeight(node.getBoundingClientRect().height);
-  }, []);
+  const measuredRef = useCallback(
+    (node) => {
+      if (!node) return;
+      setInfoHeight(node.getBoundingClientRect().height);
+    },
+    [reportingCycleFetch, waterbodyLocation, waterbodyStatus, waterbodyTypes],
+  );
 
   const infoBox = (
     <div css={boxStyles} ref={measuredRef}>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -280,7 +280,7 @@ function WaterbodyInfo({
   };
 
   const waterbodyReportLink =
-    !onWaterbodyReportPage && attributes.organizationid ? (
+    onWaterbodyReportPage ? null : attributes.organizationid ? (
       <p css={paragraphStyles}>
         <a
           rel="noopener noreferrer"


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-238
* https://jira.epa.gov/browse/HMW-239

## Main Changes:
* Removed the `Unable to find a waterbody report for this waterbody` message from the popups on the waterbody report page.
* Fixed an issue with a large blank space below the map on the waterbody report page.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/MDNR/MO_2916.00/2020
2. Verify there isn't a large blank space below the map
3. Click the waterbody on the map
4. Verify the popup does not have the `Unable to find a waterbody report for this waterbody` text
5. Verify the popup does not have the `View Waterbody Report` link.

