### PR TITLE
Feature/209 unify border thickness

### DIFF
--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -166,6 +166,9 @@ function ActionsMap({ layout, unitIds, onLoad }: Props) {
                 planSummarySymbol = new SimpleMarkerSymbol({
                   color,
                   style: 'circle',
+                  outline: {
+                    width: 0.65,
+                  },
                 });
               }
               if (type === 'polyline') {

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -647,6 +647,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           type: 'simple-marker',
           style: 'circle',
           color: colors.lightPurple(0.5),
+          outline: {
+            width: 0.75,
+          },
         },
       },
       featureReduction: {
@@ -739,6 +742,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           type: 'simple-marker',
           style: 'square',
           color: '#fffe00', // '#989fa2'
+          outline: {
+            width: 0.75,
+          },
         },
       },
       popupTemplate: {

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -1078,7 +1078,7 @@ function useSharedLayers() {
         outline: {
           style: 'solid',
           color: [0, 0, 0, 1],
-          width: 1,
+          width: 0.75,
         },
       },
     };

--- a/app/client/src/utils/mapFunctions.js
+++ b/app/client/src/utils/mapFunctions.js
@@ -309,6 +309,9 @@ export function createWaterbodySymbol({
   }
 
   if (geometryType === 'point') {
+    symbol.outline = {
+      width: 0.65,
+    };
     if (condition === 'good' || condition === 'nostatus') {
       symbol.style = 'circle';
     }
@@ -411,6 +414,10 @@ export function plotFacilities({
           color: colors.orange,
           style: 'diamond',
           size: 15,
+          outline: {
+            // width units differ between FeatureLayers and GraphicsLayers
+            width: 0.65,
+          },
         },
         attributes: facility,
         popupTemplate: {


### PR DESCRIPTION
## Related Issues:
* [HMW-209](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-209)

## Main Changes:
* Added explicit widths to the symbol outlines in both the `FeatureLayer` renderer and the `GraphicsLayer` additions. I attempted to use consistent pixel units for both, but they were cast to _pts_, and the symbol size had no effect on relative thickness in any case. Instead, I used the default value of `0.75 pts` for `FeatureLayer` features, and dropped it down to `0.65 pts` for `GraphicsLayer` graphics.

## Steps To Test:
1. Go to the **Community** page, and search for any waterbody with sample locations and dischargers
2. On the **Overview** tab, turn on the _Monitoring Locations_ and _Permitted Dischargers_ switches
3. In the layers widget of the map, turn on the _Tribal Areas_ visibility
4. Ensure that all of the symbol borders are consistent _(Tribal Areas symbols can be found in Virginia and Alaska)_

