### PR TITLE
feature/242_auto-turn-clustering-off

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1159,7 +1159,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
     // turn off clustering if there are 20 or less stations
     monitoringLocationsLayer.featureReduction =
-      graphics.length > 20 ? monitoringClusterSettings : undefined;
+      graphics.length > 20 ? monitoringClusterSettings : null;
 
     monitoringLocationsLayer.queryFeatures().then((featureSet) => {
       monitoringLocationsLayer.applyEdits({

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -88,6 +88,54 @@ function createQueryString(array) {
 
 const mapPadding = 20;
 
+const monitoringClusterSettings = {
+  type: 'cluster',
+  clusterRadius: '100px',
+  clusterMinSize: '24px',
+  clusterMaxSize: '60px',
+  popupEnabled: true,
+  popupTemplate: {
+    title: 'Cluster summary',
+    content: (feature) => {
+      const content = (
+        <div style={{ margin: '0.625em' }}>
+          This cluster represents {feature.graphic.attributes.cluster_count}{' '}
+          stations
+        </div>
+      );
+
+      const contentContainer = document.createElement('div');
+      render(content, contentContainer);
+
+      // return an esri popup item
+      return contentContainer;
+    },
+    fieldInfos: [
+      {
+        fieldName: 'cluster_count',
+        format: {
+          places: 0,
+          digitSeparator: true,
+        },
+      },
+    ],
+  },
+  labelingInfo: [
+    {
+      deconflictionStrategy: 'none',
+      labelExpressionInfo: {
+        expression: "Text($feature.cluster_count, '#,###')",
+      },
+      symbol: {
+        type: 'text',
+        color: '#000000',
+        font: { size: 10, weight: 'bold' },
+      },
+      labelPlacement: 'center-center',
+    },
+  ],
+};
+
 const containerStyles = css`
   display: flex;
   position: relative;
@@ -649,53 +697,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           color: colors.lightPurple(0.5),
         },
       },
-      featureReduction: {
-        type: 'cluster',
-        clusterRadius: '100px',
-        clusterMinSize: '24px',
-        clusterMaxSize: '60px',
-        popupEnabled: true,
-        popupTemplate: {
-          title: 'Cluster summary',
-          content: (feature) => {
-            const content = (
-              <div style={{ margin: '0.625em' }}>
-                This cluster represents{' '}
-                {feature.graphic.attributes.cluster_count} stations
-              </div>
-            );
-
-            const contentContainer = document.createElement('div');
-            render(content, contentContainer);
-
-            // return an esri popup item
-            return contentContainer;
-          },
-          fieldInfos: [
-            {
-              fieldName: 'cluster_count',
-              format: {
-                places: 0,
-                digitSeparator: true,
-              },
-            },
-          ],
-        },
-        labelingInfo: [
-          {
-            deconflictionStrategy: 'none',
-            labelExpressionInfo: {
-              expression: "Text($feature.cluster_count, '#,###')",
-            },
-            symbol: {
-              type: 'text',
-              color: '#000000',
-              font: { size: 10, weight: 'bold' },
-            },
-            labelPlacement: 'center-center',
-          },
-        ],
-      },
+      featureReduction: monitoringClusterSettings,
       popupTemplate: {
         outFields: ['*'],
         title: (feature) => getPopupTitle(feature.graphic.attributes),
@@ -1154,6 +1156,10 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         },
       });
     });
+
+    // turn off clustering if there are 20 or less stations
+    monitoringLocationsLayer.featureReduction =
+      graphics.length > 20 ? monitoringClusterSettings : undefined;
 
     monitoringLocationsLayer.queryFeatures().then((featureSet) => {
       monitoringLocationsLayer.applyEdits({


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-242

## Main Changes:
* Added code to turn off clustering if there are 20 or less stations in the HUC.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/monitoring
2. Verify that clustering is on
3. Navigate to http://localhost:3000/community/columbia%20sc/monitoring
4. Verify the clustering is off

