### PR TITLE
Removed a return statement that was preventing some map updates

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -677,10 +677,6 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   const [currentLocations, setCurrentLocations] = useState([]);
   useEffect(() => {
     if (!monitoringLocationsLayer) return;
-    if (!monitoringDisplayed) {
-      monitoringLocationsLayer.visible = false;
-      return;
-    }
 
     const { toggledLocations, allLocations } = filterLocations(
       monitoringGroups,
@@ -709,9 +705,9 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
       )}')`;
     }
 
-    monitoringLocationsLayer.visible = true;
     setCurrentLocations(allLocations);
     setDisplayedLocations(toggledLocations);
+    monitoringLocationsLayer.visible = monitoringDisplayed;
   }, [
     monitoringDisplayed,
     monitoringGroups,


### PR DESCRIPTION
## Related Issues:
* [HMW-152](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-152)

## Main Changes:
* Removed a return statement that was preventing some map updates. It was included in an attempt to prevent blinking that was occurring on changes in the `monitoringLocationsLayer` visibility.

## Steps To Test:
1. Go the _Past Water Conditions_ sub-tab of the **Monitoring** tab on the **Community** page
2. Turn off the "All Monitoring Locations" toggle switch
3. Confirm that the location count reads zero, and no locations are shown in the accordion list below
