### PR TITLE
Fixed a bug that caused features to not be deleted when changing HUCs

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -674,10 +674,17 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   useEffect(() => {
     if (monitoringGroups) return;
     // Reset data if the user switches locations
+    monitoringLocationsLayer.definitionExpression = '';
     resetWorkerData();
     setYearsRange(null);
     setAllToggled(true);
-  }, [monitoringGroups, resetWorkerData]);
+    setMonitoringDisplayed(true);
+  }, [
+    monitoringGroups,
+    monitoringLocationsLayer,
+    resetWorkerData,
+    setMonitoringDisplayed,
+  ]);
 
   const [charGroupFilters, setCharGroupFilters] = useState('');
   // create the filter string for download links based on active toggles

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -629,6 +629,43 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
     };
   }, [setMonitoringFeatureUpdates]);
 
+  const [allToggled, setAllToggled] = useState(true);
+  const toggleAll = useCallback(() => {
+    const updatedGroups = { ...monitoringGroups };
+    for (const label in updatedGroups) {
+      updatedGroups[label].toggled = !allToggled;
+    }
+    setMonitoringDisplayed(!allToggled);
+    setAllToggled((prev) => !prev);
+    setMonitoringGroups(updatedGroups);
+  }, [
+    allToggled,
+    monitoringGroups,
+    setMonitoringDisplayed,
+    setMonitoringGroups,
+  ]);
+
+  const toggleRow = useCallback(
+    (groupLabel) => {
+      const updatedGroups = { ...monitoringGroups };
+      updatedGroups[groupLabel].toggled = !updatedGroups[groupLabel].toggled;
+      setMonitoringGroups(updatedGroups);
+
+      let allOthersToggled = true;
+      for (let key in updatedGroups) {
+        if (!updatedGroups[key].toggled) allOthersToggled = false;
+      }
+      setAllToggled(allOthersToggled);
+
+      // only check the toggles that are on the screen (i.e., ignore Bacterial, Sediments, etc.)
+      const someToggled = Object.keys(updatedGroups)
+        .filter((label) => label !== 'All')
+        .some((key) => updatedGroups[key].toggled);
+      setMonitoringDisplayed(someToggled);
+    },
+    [monitoringGroups, setMonitoringDisplayed, setMonitoringGroups],
+  );
+
   // The data returned by the worker
   const [{ minYear, maxYear, annualData }, resetWorkerData] =
     usePeriodOfRecordData(huc12, 'huc12');
@@ -639,6 +676,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
     // Reset data if the user switches locations
     resetWorkerData();
     setYearsRange(null);
+    setAllToggled(true);
   }, [monitoringGroups, resetWorkerData]);
 
   const [charGroupFilters, setCharGroupFilters] = useState('');
@@ -676,7 +714,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   // All stations in the current time range
   const [currentLocations, setCurrentLocations] = useState([]);
   useEffect(() => {
-    if (!monitoringLocationsLayer) return;
+    if (!monitoringLocationsLayer || !monitoringGroups) return;
 
     const { toggledLocations, allLocations } = filterLocations(
       monitoringGroups,
@@ -778,43 +816,6 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
       buildFilter(monitoringGroups);
     }
   }, [buildFilter, displayedLocations, monitoringGroups]);
-
-  const [allToggled, setAllToggled] = useState(true);
-  const toggleAll = useCallback(() => {
-    const updatedGroups = { ...monitoringGroups };
-    for (const label in updatedGroups) {
-      updatedGroups[label].toggled = !allToggled;
-    }
-    setMonitoringDisplayed(!allToggled);
-    setAllToggled((prev) => !prev);
-    setMonitoringGroups(updatedGroups);
-  }, [
-    allToggled,
-    monitoringGroups,
-    setMonitoringDisplayed,
-    setMonitoringGroups,
-  ]);
-
-  const toggleRow = useCallback(
-    (groupLabel) => {
-      const updatedGroups = { ...monitoringGroups };
-      updatedGroups[groupLabel].toggled = !updatedGroups[groupLabel].toggled;
-      setMonitoringGroups(updatedGroups);
-
-      let allOthersToggled = true;
-      for (let key in updatedGroups) {
-        if (!updatedGroups[key].toggled) allOthersToggled = false;
-      }
-      setAllToggled(allOthersToggled);
-
-      // only check the toggles that are on the screen (i.e., ignore Bacterial, Sediments, etc.)
-      const someToggled = Object.keys(updatedGroups)
-        .filter((label) => label !== 'All')
-        .some((key) => updatedGroups[key].toggled);
-      setMonitoringDisplayed(someToggled);
-    },
-    [monitoringGroups, setMonitoringDisplayed, setMonitoringGroups],
-  );
 
   const downloadUrl =
     `${services.data.waterQualityPortal.resultSearch}zip=no&huc=` +


### PR DESCRIPTION
## Related Issues:
* [HMW-152](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-152&quickFilter=2479)

## Main Changes:
* I found two more bugs that crop up when switching HUCs:
  * Added a line to reset the "All Monitoring Locations" toggle switch to the on position. Previously they would be out of sync if a new location was entered into the search bar with the switch off.
  * Added a null check to a `useEffect` hook that handles location updates. Without it, a null `monitoringGroups` value led to a definition expression that resulted in features not being deleted on change of location. 

## Steps To Test:
1. Go to the _Past Water Conditions_ sub-tab of the **Monitoring** tab on the **Community** page
2. Turn off one of the characteristic group toggles
3. Click on a neighboring watershed, and click 'Yes' to change location
4. Confirm that all toggle switches are re-enabled, and that no monitoring location graphics are visible outside the HUC boundaries
