### PR TITLE
Feature/245 one click cluster zoom

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -676,7 +676,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   // All stations in the current time range
   const [currentLocations, setCurrentLocations] = useState([]);
   useEffect(() => {
-    if (!monitoringLocationsLayer) return;
+    if (!monitoringLocationsLayer || !monitoringGroups) return;
     if (!monitoringDisplayed) {
       monitoringLocationsLayer.visible = false;
       return;

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -271,7 +271,7 @@ function Overview() {
           ) : (
             <>
               <span css={keyMetricNumberStyles}>
-                {Boolean(waterbodies.length) && cipSummary.status === 'success'
+                {Boolean(waterbodies?.length) && cipSummary.status === 'success'
                   ? waterbodies.length.toLocaleString()
                   : 'N/A'}
               </span>

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -89,9 +89,10 @@ function createQueryString(array) {
 
 const mapPadding = 20;
 
+// export const monitoringClusterSettings = {
 const monitoringClusterSettings = {
   type: 'cluster',
-  clusterRadius: '100px',
+  clusterRadius: '80px',
   clusterMinSize: '24px',
   clusterMaxSize: '60px',
   popupEnabled: true,
@@ -281,7 +282,7 @@ function buildStations(locations, layer, services) {
     );
   });
 
-  // Attributes common to both the layer and the context object
+  // attributes common to both the layer and the context object
   return stationsSorted.map((station) => {
     return {
       monitoringType: 'Past Water Conditions',
@@ -317,8 +318,8 @@ function buildStations(locations, layer, services) {
   });
 }
 
-// Hook that centralizes updates to the `monitoringLocationsLayer`
-// and the `monitoringGroups` context object
+// hook that centralizes initialization of the `monitoringLocationsLayer`
+// and the `monitoringGroups` context objects
 function useMonitoringLocations() {
   const services = useServicesContext();
   const {

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -89,10 +89,9 @@ function createQueryString(array) {
 
 const mapPadding = 20;
 
-// export const monitoringClusterSettings = {
-const monitoringClusterSettings = {
+export const monitoringClusterSettings = {
   type: 'cluster',
-  clusterRadius: '80px',
+  clusterRadius: '100px',
   clusterMinSize: '24px',
   clusterMaxSize: '60px',
   popupEnabled: true,

--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -11,7 +11,7 @@ import { MapHighlightContext } from 'contexts/MapHighlight';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // config
-// import { monitoringClusterSettings } from 'components/shared/LocationMap';
+import { monitoringClusterSettings } from 'components/shared/LocationMap';
 import {
   getPopupContent,
   getPopupTitle,
@@ -107,18 +107,15 @@ function MapMouseEvents({ view }: Props) {
               graphic.layer.id === 'monitoringLocationsLayer' &&
               graphic.isAggregate
             ) {
-              if (view.zoom >= 20) {
-                // graphics likely overlap, so show cluster popup
-                setSelectedGraphic(graphic);
-              } else {
-                // zoom in towards the cluster
-                getClusterExtent(graphic, view, monitoringLocationsLayer).then(
-                  (extent) => {
-                    // monitoringLocationsLayer.featureReduction = null;
-                    view.goTo(extent);
-                  },
-                );
-              }
+              // zoom in towards the cluster
+              getClusterExtent(graphic, view, monitoringLocationsLayer).then(
+                (extent) => {
+                  if (graphic.attributes.cluster_count <= 20) {
+                    monitoringLocationsLayer.featureReduction = null;
+                  }
+                  view.goTo(extent);
+                },
+              );
             } else {
               setSelectedGraphic(graphic);
             }
@@ -362,7 +359,7 @@ function MapMouseEvents({ view }: Props) {
     };
   }, [popupWatchHandler]);
 
-  /* const [zoomWatchHandler, setZoomWatchHandler] = useState(null);
+  const [zoomWatchHandler, setZoomWatchHandler] = useState(null);
   useEffect(() => {
     if (!view || !monitoringLocationsLayer) return;
     if (zoomWatchHandler) return;
@@ -378,7 +375,7 @@ function MapMouseEvents({ view }: Props) {
     return function cleanup() {
       zoomWatchHandler?.remove();
     };
-  }, [zoomWatchHandler]); */
+  }, [zoomWatchHandler]);
 
   function getGraphicFromResponse(
     res: Object,

--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -383,7 +383,6 @@ function MapMouseEvents({ view }: Props) {
 
   useEffect(() => {
     if (!view || !monitoringLocationsLayer) return;
-    console.log(zoomWatchHandler);
     if (zoomWatchHandler) return;
     const handler = view.watch('zoom', (newZoom, oldZoom) => {
       if (locationCount <= 20) return;

--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -21,8 +21,8 @@ import {
 import { useDynamicPopup } from 'utils/hooks';
 
 // --- helpers ---
-async function getClusterExtent(cluster, mapView, featureLayer) {
-  const layerView = await mapView.whenLayerView(featureLayer);
+async function getClusterExtent(cluster, mapView, layer) {
+  const layerView = await mapView.whenLayerView(layer);
   const query = layerView.createQuery();
   query.aggregateIds = [cluster.getObjectId()];
   const { extent } = await layerView.queryExtent(query);


### PR DESCRIPTION
## Related Issues:
* [HMW-245](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-245&quickFilter=2479)

## Main Changes:
* Added functionality to the map click listener that zooms towards aggregate features instead of selecting them.
  * If the cluster count of a clicked aggregate feature is 20 or less, clustering is turned off.
* Added a zoom level watcher that turns clustering back on if it is off and the user zooms out.

## Steps To Test:
1. Go to any watershed with over 20 locations, e.g. [DC](http://localhost:3000/community/dc/monitoring)
2. Click on a cluster with a label over 20, and confirm that the map zooms toward the cluster and breaks apart, likely into a mix of single locations and other clusters
3. Click on a cluster with a label 20 or less, and confirm that the map zooms toward the cluster, and the cluster breaks into single features
4. Test that zooming out, changing location, and clicking various widgets restores the cluster settings (if the location initially had clustering enabled), repeating steps 1-3 before each test
