### PR TITLE
Fixed a few iOS bugs

### DIFF
--- a/app/client/src/components/shared/DateSlider.js
+++ b/app/client/src/components/shared/DateSlider.js
@@ -41,7 +41,7 @@ const sliderContainerStyles = css`
 `;
 
 const sliderStyles = css`
-  align-items: end;
+  align-items: flex-end;
   display: inline-flex;
   height: 3.5em;
   width: 60%;

--- a/app/client/src/components/shared/HelpTooltip.js
+++ b/app/client/src/components/shared/HelpTooltip.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { TooltipPopup, useTooltip } from '@reach/tooltip';
 import { css } from 'styled-components/macro';
 // styles
@@ -52,8 +52,10 @@ function centered(triggerRect, tooltipRect) {
  * Components
  */
 
-function Tooltip({ children, label }) {
-  const [trigger, tooltip] = useTooltip();
+function Tooltip({ children, label, triggerRef }) {
+  const [trigger, tooltip] = useTooltip({
+    ref: triggerRef,
+  });
 
   return (
     <>
@@ -69,9 +71,14 @@ function Tooltip({ children, label }) {
 }
 
 function HelpTooltip({ label }) {
+  const triggerRef = useRef();
   return (
-    <Tooltip label={label}>
-      <button css={tooltipIconStyles}>
+    <Tooltip label={label} triggerRef={triggerRef}>
+      <button
+        css={tooltipIconStyles}
+        onClick={(_ev) => triggerRef.current?.focus()}
+        ref={triggerRef}
+      >
         <span aria-hidden>
           <i className="fas fa-question-circle" />
         </span>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -1006,9 +1006,7 @@ function parseAttributes(structuredAttributes, attributes) {
 
 function buildGroups(checkMappings, totalsByGroup) {
   const stationGroups = totalsByGroup;
-  const newGroups = {
-    Other: { characteristicGroups: [], resultCount: 0 },
-  };
+  const newGroups = {};
   // get the feature where the provider matches this stations provider
   characteristicGroupMappings.forEach((mapping) => {
     for (const groupName in stationGroups) {
@@ -1028,14 +1026,15 @@ function buildGroups(checkMappings, totalsByGroup) {
             resultCount: stationGroups[groupName],
           };
         }
-      }
-      // push to Other
-      else if (
-        !checkMappings(groupName) &&
-        !newGroups['Other'].characteristicGroups.includes(groupName)
-      ) {
-        newGroups['Other'].characteristicGroups.push(groupName);
-        newGroups['Other'].resultCount += stationGroups[groupName];
+      } else if (!checkMappings(groupName)) {
+        if (!newGroups['Other']) {
+          newGroups['Other'] = { characteristicGroups: [], resultCount: 0 };
+        }
+        if (!newGroups['Other'].characteristicGroups.includes(groupName)) {
+          // push to Other
+          newGroups['Other'].characteristicGroups.push(groupName);
+          newGroups['Other'].resultCount += stationGroups[groupName];
+        }
       }
     }
   });

--- a/app/client/src/styles/index.js
+++ b/app/client/src/styles/index.js
@@ -122,6 +122,7 @@ const toggleTableStyles = css`
   td,
   th {
     overflow-wrap: anywhere;
+    word-break: break-word;
   }
 `;
 


### PR DESCRIPTION
## Related Issues:
* [HMW-248](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-248&quickFilter=2479)

## Main Changes:
* Added the ability to view the date slider tooltip on touch screens.
* Fixed a small bug with the `MonitoringLocationsContent` in the `WaterbodyInfo` component. Initializing the characteristic groups with an empty 'Other' property caused the 'All' checkbox to show as indeterminate even if no group boxes were checked.
* Added a CSS property to the toggle tables: iOS doesn't respect `overflow-wrap: anywhere`, but it does respect the deprecated `word-break: break-word` property.

## Steps To Test:
1. Connect to the local server with an iOS device, then navigate to the **Monitoring** tab of the **Community** page
2. Tap the _Past Water Conditions_ sub-tab
3. Tap the (?) icon, confirm that the tooltip appears and that it is entirely visible
4. Confirm that the date slider track is in line with its end dates
5. Confirm that the toggle table isn't overflowing its container
6. Find a location that doesn't have any characteristics in the 'Other' group (e.g. several in Cincinnati, OH), and confirm that toggling off all of the individual groups also turns off the 'All' checkbox entirely

## TODO:
- [ ] The Current Water Conditions `WaterbodyInfo` component still overflows on narrow screens, both on iOS and the browser. Since it contains the sparkchart components, word wrapping isn't possible. It might be better to switch to a different (stacked?) structure on narrow screens.
