### PR TITLE
Feature/249 plans popup table

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -119,6 +119,9 @@ const checkboxCellStyles = css`
 
 const checkboxStyles = css`
   appearance: checkbox;
+  left: 2px;
+  position: relative;
+  top: 2px;
   transform: scale(1.2);
 `;
 

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -759,7 +759,7 @@ function WaterbodyInfo({
                       <tr>
                         <th>Plan (ID)</th>
                         <th>Impairments</th>
-                        <th>Type</th>
+                        <th style={{ minWidth: '4em' }}>Type</th>
                         <th>Date</th>
                       </tr>
                     </thead>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -76,6 +76,7 @@ const dateRangeStyles = css`
 `;
 
 const popupContainerStyles = css`
+  font-size: 14px;
   margin: 0;
   overflow-y: auto;
 


### PR DESCRIPTION
## Related Issues:
* [HMW-249](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-249)

## Main Changes:
* Added an inline style to one column that wasn't sizing correctly.
* Adjusted checkbox positioning to be in line with text.
* Set a standard base font size for popups.

## Steps To Test:
1. Go to the **Restore** tab of a location with restoration plans, i.e. [Colorado Springs, CO](http://localhost:3000/community/Colorado%20Springs,%20CO,%20USA/restore)
2. Click the dark blue waterbody on the map to view its popup
3. Confirm that the headers for the table all fit on one line

