### PR TITLE
feature/262_hide-epa-tribal-layer

### DIFF
--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -733,13 +733,6 @@ function TribalMap({
     // add the shared layers to the map and set the tribal layer visible
     const sharedLayers = getSharedLayers();
 
-    // turn the tribal layer on by default on the tribal tab
-    sharedLayers.forEach((layer) => {
-      if (layer.id !== 'tribalLayer') return;
-
-      layer.visible = true;
-    });
-
     setLayers([
       ...sharedLayers,
       selectedTribeLayer,

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -730,7 +730,7 @@ function TribalMap({
     });
     setMonitoringLocationsLayer(monitoringLocationsLayer);
 
-    // add the shared layers to the map and set the tribal layer visible
+    // add the shared layers to the map
     const sharedLayers = getSharedLayers();
 
     setLayers([


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-262

## Main Changes:
* Hide the EPA tribal layer from the tribe page.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/ABSHAWNEE
2. Open the layer list
3. Verify the "Tribal Areas" layer is off by default
4. Turn on the "Tribal Areas" layer
5. Verify the "Tribal Areas" layer is visible on the map
