### PR TITLE
Feature/258 Remove survey section from tribal page

### DIFF
--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
@@ -189,23 +189,29 @@ function Documents({
         </>
       )}
 
-      <h3>Documents Related to Statewide Statistical Surveys</h3>
-
-      {surveyLoading || documentOrder.status === 'fetching' ? (
-        <LoadingSpinner />
-      ) : surveyServiceError ? (
-        <div css={modifiedErrorBoxStyles}>
-          <p>{stateSurveyError(activeState.label)}</p>
-        </div>
-      ) : (
+      {activeState.source !== 'Tribe' && (
         <>
-          {documentOrder.status === 'failure' && (
-            <div css={modifiedInfoBoxStyles}>{stateDocumentSortingError}</div>
+          <h3>Documents Related to Statewide Statistical Surveys</h3>
+
+          {surveyLoading || documentOrder.status === 'fetching' ? (
+            <LoadingSpinner />
+          ) : surveyServiceError ? (
+            <div css={modifiedErrorBoxStyles}>
+              <p>{stateSurveyError(activeState.label)}</p>
+            </div>
+          ) : (
+            <>
+              {documentOrder.status === 'failure' && (
+                <div css={modifiedInfoBoxStyles}>
+                  {stateDocumentSortingError}
+                </div>
+              )}
+              <DocumentsTable
+                documents={surveyDocumentsSorted}
+                type="statewide statistical survey"
+              />
+            </>
           )}
-          <DocumentsTable
-            documents={surveyDocumentsSorted}
-            type="statewide statistical survey"
-          />
         </>
       )}
     </div>


### PR DESCRIPTION
## Related Issues:
* [HMW-258](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-258)

## Main Changes:
* Added a line to conditionally render the survey documents section only for non-'Tribe' sources.

## Steps To Test:
1. Go to a tribe's page, e.g. [http://localhost:3000/tribe/POLSWATER](http://localhost:3000/tribe/POLSWATER)
2. Expand the **Documents** section
3. Confirm that the "Documents Related to Statewide Statistical Surveys" section isn't displayed
4. Go to a state page, e.g. [http://localhost:3000/state/AL/water-quality-overview](http://localhost:3000/state/AL/water-quality-overview), and confirm that the survey section is displayed
