### PR TITLE
Feature/252 state page navigation

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -66,13 +66,15 @@ function StateTribalTabs() {
   // activeState, so we need to set it.
   const { states, tribes } = useOutletContext();
   useEffect(() => {
+    if (tribes.status !== 'success' || states.status !== 'success') return;
     if (activeState.value === '' || activeState.value !== stateCode) {
-      const match = [...tribes, ...states.data].find((stateTribe) => {
+      const match = [...tribes.data, ...states.data].find((stateTribe) => {
         return stateTribe.value === stateCode.toUpperCase();
       });
       if (match) setActiveState(match);
+      else navigate('/state-and-tribal', { replace: true });
     }
-  }, [activeState.value, setActiveState, stateCode, states, tribes]);
+  }, [activeState.value, navigate, setActiveState, stateCode, states, tribes]);
 
   const tabListRef = useRef();
 

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -42,7 +42,9 @@ function StateTribalTabs() {
     if (pathname === `/tribe/${stateCode.toLowerCase()}`) return;
 
     if (stateCode && !tabName) {
-      navigate(`/state/${stateCode.toUpperCase()}/water-quality-overview`);
+      navigate(`/state/${stateCode.toUpperCase()}/water-quality-overview`, {
+        replace: true,
+      });
     }
   }, [navigate, stateCode, tabName]);
 
@@ -60,7 +62,7 @@ function StateTribalTabs() {
     );
 
     if (tabIndex === -1) {
-      navigate('/state-and-tribal');
+      navigate('/state-and-tribal', { replace: true });
     }
 
     if (activeTabIndex !== tabIndex) {
@@ -72,7 +74,7 @@ function StateTribalTabs() {
   // string, so we'll need to query the attains states service for the states
   useEffect(() => {
     if (tribeMapping.status === 'fetching') return;
-    if (activeState.value === '') {
+    if (activeState.value === '' || activeState.value !== stateCode) {
       // check if the stateID is a tribe id by checking the control table
       const matchTribes = tribeMapping.data.filter(
         (tribe) => tribe.attainsId === stateCode.toUpperCase(),
@@ -96,7 +98,7 @@ function StateTribalTabs() {
           )[0];
 
           // redirect to /state if no state was found
-          if (!match) navigate('/state-and-tribal');
+          if (!match) navigate('/state-and-tribal', { replace: true });
 
           setActiveState({
             value: match.code,
@@ -105,7 +107,7 @@ function StateTribalTabs() {
           });
         })
         .catch((_err) => {
-          navigate('/state-and-tribal');
+          navigate('/state-and-tribal', { replace: true });
         });
     }
   }, [

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -66,13 +66,11 @@ function StateTribalTabs() {
   // activeState, so we need to set it.
   const { states, tribes } = useOutletContext();
   useEffect(() => {
-    if (!tribes.length || states.status !== 'success') return;
     if (activeState.value === '' || activeState.value !== stateCode) {
       const match = [...tribes, ...states.data].find((stateTribe) => {
         return stateTribe.value === stateCode.toUpperCase();
       });
-
-      setActiveState(match);
+      if (match) setActiveState(match);
     }
   }, [activeState.value, setActiveState, stateCode, states, tribes]);
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -180,7 +180,7 @@ function StateTribal() {
   useEffect(() => {
     const pathname = window.location.pathname.toLowerCase();
     if (['/state', '/state/', '/tribe', '/tribe/'].includes(pathname)) {
-      navigate('/state-and-tribal');
+      navigate('/state-and-tribal', { replace: true });
     }
   }, [navigate]);
 
@@ -355,6 +355,18 @@ function StateTribal() {
     }
   }, [sourceCursor, sourceEnterPress]);
 
+  const handleSubmit = (selection) => {
+    if (!selection) return;
+    setActiveState(selection);
+
+    if (selection.source === 'State') {
+      navigate(`/state/${selection.value}/water-quality-overview`);
+    }
+    if (selection.source === 'Tribe') {
+      navigate(`/tribe/${selection.value}`);
+    }
+  };
+
   return (
     <Page>
       <TabLinks />
@@ -378,22 +390,7 @@ function StateTribal() {
               </em>
             </label>
 
-            <form
-              css={formStyles}
-              onSubmit={(ev) => {
-                ev.preventDefault();
-                setActiveState(selectedStateTribe);
-
-                if (selectedStateTribe.source === 'State') {
-                  navigate(
-                    `/state/${selectedStateTribe.value}/water-quality-overview`,
-                  );
-                }
-                if (selectedStateTribe.source === 'Tribe') {
-                  navigate(`/tribe/${selectedStateTribe.value}`);
-                }
-              }}
-            >
+            <div css={formStyles}>
               <div
                 css={searchContainerStyles}
                 role="presentation"
@@ -492,20 +489,9 @@ function StateTribal() {
                   value={selectedStateTribe}
                   onKeyDown={(ev) => {
                     if (ev.key !== 'Enter') return;
-
                     const selection = statesSelect.current.state.focusedOption;
                     if (!selection) return;
-
-                    setActiveState(selection);
-
-                    if (selectedStateTribe.source === 'State') {
-                      navigate(
-                        `/state/${selectedStateTribe.value}/water-quality-overview`,
-                      );
-                    }
-                    if (selectedStateTribe.source === 'Tribe') {
-                      navigate(`/tribe/${selectedStateTribe.value}`);
-                    }
+                    handleSubmit(statesSelect.current.state.focusedOption);
                   }}
                   onChange={(ev) => {
                     setSelectedStateTribe(ev);
@@ -514,11 +500,15 @@ function StateTribal() {
                 />
               </div>
 
-              <button type="submit" className="btn" css={buttonStyles}>
+              <button
+                onClick={() => handleSubmit(selectedStateTribe)}
+                className="btn"
+                css={buttonStyles}
+              >
                 <i className="fas fa-angle-double-right" aria-hidden="true" />{' '}
                 Go
               </button>
-            </form>
+            </div>
           </>
         )}
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -632,7 +632,7 @@ function StateTribal() {
             )}
 
             {/* Outlet is either StateIntro or StateTabs */}
-            <Outlet />
+            <Outlet context={{ tribes, states }} />
           </div>
         )}
       </div>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -185,7 +185,7 @@ function StateTribal() {
   }, [navigate]);
 
   // get tribes from the tribeMapping data
-  const [tribes, setTribes] = useState([]);
+  const [tribes, setTribes] = useState({ status: 'fetching', data: [] });
   useEffect(() => {
     if (tribeMapping.status !== 'success') return;
 
@@ -199,7 +199,7 @@ function StateTribal() {
       });
     });
 
-    setTribes(tempTribes);
+    setTribes({ status: 'success', data: tempTribes });
   }, [tribeMapping]);
 
   // query attains for the list of states
@@ -260,11 +260,11 @@ function StateTribal() {
       });
       options.push({
         label: 'Tribe',
-        options: tribes,
+        options: tribes.data,
       });
     }
     if (selectedSource === 'State') options.push(...states.data);
-    if (selectedSource === 'Tribe') options.push(...tribes);
+    if (selectedSource === 'Tribe') options.push(...tribes.data);
 
     setSelectOptions(options);
   }, [selectedSource, states, tribes]);

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -836,7 +836,6 @@ function TribalMap({
   }, [
     activeState,
     mapView,
-    navigate,
     selectedTribeLayer,
     setTribalBoundaryError,
     tribalLayer,


### PR DESCRIPTION
## Related Issues:
* [HMW-252](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-252)

## Main Changes:
* When using the back and forward buttons, the active state wouldn't match the URL parameters, so a check was added alongside the block of logic that checks empty `activeState`.
* Passed the `states` and `tribes` variables down to the `StateTribalTabs` page through the `Outlet` context to avoid excess service calls in the logic mentioned above.
* Switched the submit button from a form to a click handler to avoid a race condition that was occurring.
* Added `{ replace: true }` to several calls to `navigate`, in cases where an invalid URL was changed to a default value.

## Steps To Test:
1. Navigate to the base "State and Tribal" page: [http://localhost:3000/state-and-tribal](http://localhost:3000/state-and-tribal)
2. Select a state from the drop-down, and click "Go"
3. Similarly, go to a tribe page
4. Select a state from the drop-down with the arrow keys, and press enter
5. Click on the _Advanced Search_ tab
6. Use the browser navigation and confirm that it works as expected
7. Enter valid state or tribal URL into the search bar ([Alaska Advanced Search](http://localhost:3000/state/AK/advanced-search)), and confirm it lands on the correct page
8. Enter an invalid state or tribal URL into the search bar ([http://localhost:3000/tribe/SFNOS](http://localhost:3000/tribe/SFNOS)), and confirm it lands on the `state-and-tribal` page