### PR TITLE
Feature/256 tribe page disable change location popup

### DIFF
--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -109,12 +109,15 @@ function MapMouseEvents({ view }: Props) {
             setSelectedGraphic('');
           }
 
+          const onTribePage = window.location.pathname.startsWith('/tribe/');
+
           // get the currently selected huc boundaries, if applicable
           const hucBoundaries = getHucBoundaries();
           // only look for huc boundaries if no graphics were clicked and the
           // user clicked outside of the selected huc boundaries
           if (
             !graphic &&
+            !onTribePage &&
             (!hucBoundaries ||
               hucBoundaries.features.length === 0 ||
               !hucBoundaries.features[0].geometry.contains(location))

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -924,9 +924,11 @@ function MapPopup({
   const huc12 = clickedHuc?.data?.huc12;
   const watershed = clickedHuc?.data?.watershed;
 
+  const onTribePage = window.location.pathname.startsWith('/tribe/');
+
   return (
     <div css={popupContainerStyles}>
-      {clickedHuc && (
+      {clickedHuc && !onTribePage && (
         <>
           {clickedHuc.status === 'no-data' && null}
           {clickedHuc.status === 'fetching' && <LoadingSpinner />}


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-256

## Main Changes:
* Disable the change location popup on the tribe page.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/DELAWARENATION
2. Click outside of the tribal boundaries and verify no popup is displayed
3. Open the layer list and turn on the Tribal Areas layer
4. Click on one of the tribal boundaries outside of the selected tribal boundary
5. Verify the tribe popup does not include the "Change to this location?" section
6. Navigate to http://localhost:3000/community/dc/overview
7. Click outside of the HUC boundaries
8. Verify the "Change to this location?" section is visible in the popup

