### PR TITLE
Feature/254 hide tribes without data

### DIFF
--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -42,7 +42,11 @@ import { impairmentFields, useFields } from 'config/attainsToHmwMapping';
 // styles
 import { reactSelectStyles } from 'styles/index.js';
 // errors
-import { stateGeneralError, state303dStatusError } from 'config/errorMessages';
+import {
+  stateGeneralError,
+  status303dError,
+  status303dShortError,
+} from 'config/errorMessages';
 
 const defaultDisplayOption = {
   label: 'Overall Waterbody Condition',
@@ -228,7 +232,7 @@ function AdvancedSearch() {
   const services = useServicesContext();
 
   const {
-    currentReportStatus,
+    organizationData,
     currentSummary,
     currentReportingCycle,
     setCurrentReportingCycle,
@@ -1028,7 +1032,7 @@ function AdvancedSearch() {
         style={{ width: fullscreenActive ? width : '100%' }}
       >
         {reportStatusMapping.status === 'failure' && (
-          <div css={mapFooterMessageStyles}>{state303dStatusError}</div>
+          <div css={mapFooterMessageStyles}>{status303dError}</div>
         )}
         <div css={mapFooterStatusStyles}>
           <strong>
@@ -1038,28 +1042,32 @@ function AdvancedSearch() {
             / Year Last Reported:
           </strong>
           &nbsp;&nbsp;
-          {!currentReportStatus ? (
-            <LoadingSpinner />
-          ) : (
+          {organizationData.status === 'fetching' && <LoadingSpinner />}
+          {organizationData.status === 'failure' && <>{status303dShortError}</>}
+          {organizationData.status === 'success' && (
             <>
               {reportStatusMapping.status === 'fetching' && <LoadingSpinner />}
               {reportStatusMapping.status === 'failure' && (
-                <>{currentReportStatus}</>
+                <>{organizationData.data.reportStatusCode}</>
               )}
               {reportStatusMapping.status === 'success' && (
                 <>
-                  {reportStatusMapping.data.hasOwnProperty(currentReportStatus)
-                    ? reportStatusMapping.data[currentReportStatus]
-                    : currentReportStatus}
+                  {reportStatusMapping.data.hasOwnProperty(
+                    organizationData.data.reportStatusCode,
+                  )
+                    ? reportStatusMapping.data[
+                        organizationData.data.reportStatusCode
+                      ]
+                    : organizationData.data.reportStatusCode}
                 </>
               )}
             </>
           )}
           <> / </>
+          {currentReportingCycle.status === 'fetching' && <LoadingSpinner />}
           {currentReportingCycle.status === 'success' && (
             <>{currentReportingCycle.reportingCycle}</>
           )}
-          {currentReportingCycle.status === 'fetching' && <LoadingSpinner />}
         </div>
       </div>
     </StateMap>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
@@ -267,8 +267,9 @@ function WaterQualityOverview() {
     setCurrentReportingCycle,
     introText,
     setIntroText,
-    setCurrentReportStatus,
     setCurrentSummary,
+    organizationData,
+    setOrganizationData,
     setUsesStateSummaryServiceError,
     stateAndOrganization,
     setStateAndOrganization,
@@ -276,9 +277,7 @@ function WaterQualityOverview() {
 
   const [loading, setLoading] = useState(true);
   const [surveyLoading, setSurveyLoading] = useState(true);
-  const [assessmentsLoading, setAssessmentsLoading] = useState(true);
   const [serviceError, setServiceError] = useState(false);
-  const [documentServiceError, setDocumentServiceError] = useState(false);
   const [surveyServiceError, setSurveyServiceError] = useState(false);
   const [noDataError, setNoDataError] = useState(false);
   const [currentState, setCurrentState] = useState('');
@@ -291,7 +290,6 @@ function WaterQualityOverview() {
   const [waterTypeData, setWaterTypeData] = useState(null);
 
   const [surveyData, setSurveyData] = useState(null);
-  const [assessmentDocuments, setAssessmentDocuments] = useState(null);
 
   const [fishingAdvisoryData, setFishingAdvisoryData] = useState({
     status: 'fetching',
@@ -328,26 +326,15 @@ function WaterQualityOverview() {
       const url = `${services.data.attains.serviceUrl}assessments?organizationId=${orgID}&reportingCycle=${year}&excludeAssessments=Y`;
       fetchCheck(url)
         .then((res) => {
-          setAssessmentsLoading(false);
-
-          if (!res || !res.items || res.items.length === 0) {
-            setAssessmentDocuments([]);
-          }
-
           const orgData = res.items[0];
-          if (orgData) {
-            setAssessmentDocuments(orgData.documents);
-            setCurrentReportStatus(orgData.reportStatusCode);
-          }
+          setOrganizationData({ status: 'success', data: orgData ?? {} });
         })
         .catch((err) => {
           console.error(err);
-          setDocumentServiceError(true);
-          setAssessmentsLoading(false);
-          setCurrentReportStatus('Error getting 303(d) List Status');
+          setOrganizationData({ status: 'failure', data: {} });
         });
     },
-    [setCurrentReportStatus, services],
+    [services, setOrganizationData],
   );
 
   // Get the state intro text
@@ -626,14 +613,11 @@ function WaterQualityOverview() {
       setWaterType('');
       setUseSelected('');
       setServiceError(false);
-      setDocumentServiceError(false);
       setSurveyServiceError(false);
       setNoDataError(false);
       setSurveyData(null);
-      setAssessmentsLoading(true);
-      setAssessmentDocuments([]);
       setSubPopulationCodes([]);
-      setCurrentReportStatus('');
+      setOrganizationData({ status: 'fetching', data: {} });
       setUsesStateSummaryCalled(false);
       setCurrentReportingCycle({
         status: 'fetching',
@@ -662,9 +646,9 @@ function WaterQualityOverview() {
     currentState,
     activeState,
     setCurrentReportingCycle,
-    setCurrentReportStatus,
     setCurrentSummary,
     setIntroText,
+    setOrganizationData,
     fetchStateOrgId,
     fetchFishingAdvisoryData,
     services,
@@ -1191,9 +1175,7 @@ function WaterQualityOverview() {
               activeState={activeState}
               surveyLoading={surveyLoading}
               surveyDocuments={surveyDocuments}
-              assessmentsLoading={assessmentsLoading}
-              assessmentDocuments={assessmentDocuments}
-              documentServiceError={documentServiceError}
+              organizationData={organizationData}
               surveyServiceError={surveyServiceError}
             />
           </div>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -25,6 +25,7 @@ import {
   StateTribalTabsProvider,
 } from 'contexts/StateTribalTabs';
 import {
+  useOrganizationsContext,
   useServicesContext,
   useTribeMappingContext,
 } from 'contexts/LookupFiles';
@@ -173,6 +174,7 @@ const searchSourceButtonStyles = css`
 function StateTribal() {
   const location = useLocation();
   const navigate = useNavigate();
+  const organizations = useOrganizationsContext();
   const services = useServicesContext();
   const tribeMapping = useTribeMappingContext();
 
@@ -187,20 +189,34 @@ function StateTribal() {
   // get tribes from the tribeMapping data
   const [tribes, setTribes] = useState([]);
   useEffect(() => {
-    if (tribeMapping.status !== 'success') return;
+    if (
+      organizations.status !== 'success' ||
+      tribeMapping.status !== 'success'
+    ) {
+      return;
+    }
 
     const tempTribes = [];
     tribeMapping.data.forEach((tribe) => {
+      const tribeAttains = organizations.data.features.find(
+        (item) =>
+          item.attributes.orgtype === 'Tribe' &&
+          item.attributes.organizationid.toUpperCase() ===
+            tribe.attainsId.toUpperCase(),
+      );
+      if (!tribeAttains) return;
+
       tempTribes.push({
         ...tribe,
         value: tribe.attainsId,
         label: tribe.name,
         source: 'Tribe',
+        reportingCycle: tribeAttains.attributes.reportingcycle,
       });
     });
 
     setTribes(tempTribes);
-  }, [tribeMapping]);
+  }, [organizations, tribeMapping]);
 
   // query attains for the list of states
   const [states, setStates] = useState({ status: 'fetching', data: [] });

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -211,7 +211,6 @@ function StateTribal() {
         value: tribe.attainsId,
         label: tribe.name,
         source: 'Tribe',
-        reportingCycle: tribeAttains.attributes.reportingcycle,
       });
     });
 

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -144,8 +144,10 @@ export const stateGeneralError = (source = 'State') =>
 export const stateNoDataError = (stateName) =>
   `No data available ${stateName && 'for ' + stateName}.`; // conditionals in case state name is undefined or an empty string
 
-export const state303dStatusError =
+export const status303dError =
   'There was an issue looking up the 303(d) List Status code. Because of this, the status code may not look familiar.';
+
+export const status303dShortError = 'Error getting 303(d) List Status';
 
 // this message is displayed in the State metrics section and more information section when the metrics service is down
 export const stateMetricsError = (source) =>

--- a/app/client/src/contexts/StateTribalTabs.js
+++ b/app/client/src/contexts/StateTribalTabs.js
@@ -5,7 +5,7 @@ import type { Node } from 'react';
 
 // --- components ---
 export const StateTribalTabsContext: Object = createContext({
-  currentReportStatus: '',
+  organizationData: { status: 'fetching', data: '' },
   currentSummary: { status: 'fetching', data: {} },
   currentReportingCycle: { status: 'fetching', currentReportingCycle: '' },
   activeState: { value: '', label: '', source: 'All' },
@@ -18,7 +18,7 @@ type Props = {
 };
 
 type State = {
-  currentReportStatus: string,
+  organizationData: string,
   currentSummary: object,
   currentReportingCycle: object,
   activeState: {
@@ -33,7 +33,7 @@ type State = {
 export class StateTribalTabsProvider extends Component<Props, State> {
   state: State = {
     activeTabIndex: 0,
-    currentReportStatus: '',
+    organizationData: { status: 'fetching', data: '' },
     currentSummary: {
       status: 'fetching',
       data: {},
@@ -53,8 +53,8 @@ export class StateTribalTabsProvider extends Component<Props, State> {
     setActiveTabIndex: (activeTabIndex: number) => {
       this.setState({ activeTabIndex });
     },
-    setCurrentReportStatus: (currentReportStatus: string) => {
-      this.setState({ currentReportStatus });
+    setOrganizationData: (organizationData: object) => {
+      this.setState({ organizationData });
     },
     setCurrentSummary: (currentSummary: string) => {
       this.setState({ currentSummary });

--- a/app/client/src/contexts/StateTribalTabs.js
+++ b/app/client/src/contexts/StateTribalTabs.js
@@ -18,7 +18,7 @@ type Props = {
 };
 
 type State = {
-  organizationData: string,
+  organizationData: object,
   currentSummary: object,
   currentReportingCycle: object,
   activeState: {


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-254

## Main Changes:
* Updated the dropdown on the state-and-tribal page to only include tribes that have GIS data.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/DELAWARENATION
2. Verify there is a footer below the map that has the Year Last Reported.
3. Switch to other tribes and verify the Year Last Reported value changes.
4. In the drop down scroll through the tribes list and verify there are only 12 tribes in the list, instead of 31 on the dev site.

## TODO:
- [ ] May need to revisit how the filter logic works at a later date. Based on today's meeting (07/27/2022), it sounds like it is expected for the GIS control table data to be synced up with the attains data. If this ends up not being the case, we will need to update the logic to query the attains assessments service to do the filtering.
- [ ] The tribe map footnote text needs to be changed once EPA provides the new text. The `303(d) List Status` text is not applicable for Tribes. 
