### PR TITLE
Removed the 'Sample Count' column from the toggle table

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -70,6 +70,17 @@ const modifiedErrorBoxStyles = css`
   text-align: center;
 `;
 
+const modifiedToggleTableStyles = css`
+  ${toggleTableStyles}
+  th, td {
+    text-align: right;
+    width: 33%;
+    &:first-of-type {
+      text-align: left;
+    }
+  }
+`;
+
 const sliderContainerStyles = css`
   align-items: flex-end;
   display: flex;
@@ -797,7 +808,6 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   const [totalDisplayedLocations, setTotalDisplayedLocations] = useState(0);
   const [totalDisplayedMeasurements, setTotalDisplayedMeasurements] =
     useState(0);
-  const [totalDisplayedSamples, setTotalDisplayedSamples] = useState(0);
   useEffect(() => {
     if (Object.keys(annualData).length === 0) return;
     if (yearsRange) return;
@@ -808,12 +818,10 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
   useEffect(() => {
     if (monitoringGroups) {
       let newTotalLocations = 0;
-      let newTotalSamples = 0;
       let newTotalMeasurements = 0;
 
       // update the watershed total measurements and samples counts
       displayedLocations.forEach((station) => {
-        newTotalSamples += station.stationTotalSamples;
         newTotalLocations++;
         Object.keys(monitoringGroups)
           .filter((group) => group !== 'All')
@@ -826,7 +834,6 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
 
       setTotalDisplayedLocations(newTotalLocations);
       setTotalDisplayedMeasurements(newTotalMeasurements);
-      setTotalDisplayedSamples(newTotalSamples);
       buildFilter(monitoringGroups);
     }
   }, [buildFilter, displayedLocations, monitoringGroups]);
@@ -901,7 +908,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
               )}
             </div>
             <table
-              css={toggleTableStyles}
+              css={modifiedToggleTableStyles}
               aria-label="Monitoring Location Summary"
               className="table"
             >
@@ -917,8 +924,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       <span>All Monitoring Locations</span>
                     </div>
                   </th>
-                  <th>Location Count</th>
-                  <th>Sample Count</th>
+                  <th colspan="2">Location Count</th>
                   <th>Measurement Count</th>
                 </tr>
               </thead>
@@ -928,12 +934,10 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                   .filter((group) => group.label !== 'All')
                   .map((group) => {
                     // get the number of measurements for this group type
-                    let sampleCount = 0;
                     let measurementCount = 0;
                     let locationCount = 0;
                     currentLocations.forEach((station) => {
                       if (station.stationTotalsByLabel[group.label] > 0) {
-                        sampleCount += station.stationTotalSamples;
                         measurementCount +=
                           station.stationTotalsByLabel[group.label];
                         locationCount++;
@@ -952,8 +956,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                             <span>{group.label}</span>
                           </div>
                         </td>
-                        <td>{locationCount.toLocaleString()}</td>
-                        <td>{sampleCount.toLocaleString()}</td>
+                        <td colspan="2">{locationCount.toLocaleString()}</td>
                         <td>{measurementCount.toLocaleString()}</td>
                       </tr>
                     );
@@ -972,8 +975,9 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       <span>Totals</span>
                     </div>
                   </td>
-                  <td>{Number(totalDisplayedLocations).toLocaleString()}</td>
-                  <td>{Number(totalDisplayedSamples).toLocaleString()}</td>
+                  <td colspan="2">
+                    {Number(totalDisplayedLocations).toLocaleString()}
+                  </td>
                   <td>{Number(totalDisplayedMeasurements).toLocaleString()}</td>
                 </tr>
               </tbody>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -1248,11 +1248,7 @@ function MonitoringLocationsContent({ attributes, services }) {
             </td>
             <td>
               {Number(stationTotalSamples).toLocaleString()}
-              {timeframe && (
-                <span css={dateRangeStyles}>
-                  ({timeframe[0]} - {timeframe[1]})
-                </span>
-              )}
+              <span css={dateRangeStyles}>(all time)</span>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
## Related Issues:
* [HMW-260](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-260)

## Main Changes:
* Removed the "Sample Counts" column from the _Past Water Conditions_ toggle table.
* Changed the date range shown next to the count in the "Monitoring Samples" row of the accordion/popup items to read "(all time)".
* Updated the toggle table spacing.

## Steps To Test:
1. Go to the _Past Water Conditions_ section of the Monitoring tab of the Community page
2. Confirm that the Sample Count column is gone
3. Confirm the measurements still update correctly
4. Check the table spacing