### PR TITLE
Feature/255 tribe page popup ordering

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -933,7 +933,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       <span>All Monitoring Locations</span>
                     </div>
                   </th>
-                  <th colspan="2">Location Count</th>
+                  <th colSpan="2">Location Count</th>
                   <th>Measurement Count</th>
                 </tr>
               </thead>
@@ -965,7 +965,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                             <span>{group.label}</span>
                           </div>
                         </td>
-                        <td colspan="2">{locationCount.toLocaleString()}</td>
+                        <td colSpan="2">{locationCount.toLocaleString()}</td>
                         <td>{measurementCount.toLocaleString()}</td>
                       </tr>
                     );
@@ -984,7 +984,7 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       <span>Totals</span>
                     </div>
                   </td>
-                  <td colspan="2">
+                  <td colSpan="2">
                     {Number(totalDisplayedLocations).toLocaleString()}
                   </td>
                   <td>{Number(totalDisplayedMeasurements).toLocaleString()}</td>

--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -182,6 +182,7 @@ function MapMouseEvents({ view }: Props) {
             view.popup.open({ features: graphics, location: point });
           } else {
             setSelectedGraphic('');
+            view.popup.close();
           }
 
           // get the currently selected huc boundaries, if applicable

--- a/app/client/src/components/shared/MapMouseEvents.js
+++ b/app/client/src/components/shared/MapMouseEvents.js
@@ -294,7 +294,6 @@ function MapMouseEvents({ view }: Props) {
 
   const updateSingleFeature = useCallback(
     (graphic) => {
-      view.popup.clear();
       updateAttributes(graphic, updates);
       const structuredProps = ['stationTotalsByGroup', 'timeframe'];
       graphic.attributes = parseAttributes(structuredProps, graphic.attributes);

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -210,7 +210,7 @@ type State = {
 
   // monitoring panel
   monitoringGroups: MonitoringLocationGroups,
-  monitoringFeatureUpdates: Object,
+  monitoringFeatureUpdates: ?Object,
 
   // identified issues panel
   showDischargers: boolean,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -295,11 +295,7 @@ export class LocationSearchProvider extends Component<Props, State> {
 
     // monitoring panel
     monitoringGroups: null,
-    monitoringFeatureUpdates: {
-      stationTotalMeasurements: 0,
-      stationTotalsByGroup: {},
-      timeframe: null,
-    },
+    monitoringFeatureUpdates: null,
 
     // identified issues panel
     showAllPolluted: true,


### PR DESCRIPTION
## Related Issues:
* [HMW-255](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-255)

## Main Changes:
* Changed the order of the popup features on the **Tribe** page to be waterbodies, monitoring locations, tribe boundaries, then other layers.
* Removed the date slider popup watcher, and moved the feature updates inside the `handleMapClick` function.
* Removed the improper initialization of the `monitoringFeatureUpdates` context variable.

## Steps To Test:
1. Go to a Tribe page, e.g. [http://localhost:3000/tribe/DELAWARENATION](http://localhost:3000/tribe/DELAWARENATION)
2. Turn on the Tribal Areas layer visibility
3. Click on a red waterbody symbol, which will have a monitoring location hidden behind it
4. Check that the popup displays the waterbody content first, then the monitoring location info, followed by the tribe names
5. Go to the **Monitoring** tab for a location, on the **Community** page, e.g. [http://localhost:3000/community/dc/monitoring](http://localhost:3000/community/dc/monitoring)
6. Adjust the date slider, and click on a monitoring location to check that the total measurements, and the date range next to it, are updated in the popup