### PR TITLE
Feature/11 location page updates

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -452,7 +452,7 @@ function Monitoring() {
                     setVisibleLayers(newVisibleLayers);
                   }}
                   disabled={!Boolean(monitoringLocations.data.features?.length)}
-                  ariaLabel="Monitoring Locations"
+                  ariaLabel="Past Water Conditions"
                 />
               </div>
             </>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -452,7 +452,7 @@ function Monitoring() {
                     setVisibleLayers(newVisibleLayers);
                   }}
                   disabled={!Boolean(monitoringLocations.data.features?.length)}
-                  ariaLabel="Monitoring Stations"
+                  ariaLabel="Monitoring Locations"
                 />
               </div>
             </>

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -223,7 +223,6 @@ const inlineBoxSectionStyles = css`
     margin-right: 0.5em;
   }
 
-  div,
   p {
     grid-column: 2;
   }
@@ -252,6 +251,17 @@ const mapContainerStyles = css`
   position: relative;
 `;
 
+const messageBoxStyles = (baseStyles) => {
+  return css`
+    ${baseStyles};
+    text-align: center;
+    margin: 1rem auto;
+    padding: 0.7rem 1rem !important;
+    max-width: max-content;
+    width: 90%;
+  `;
+};
+
 const modifiedBoxStyles = css`
   ${boxStyles}
   padding-bottom: 0;
@@ -261,22 +271,6 @@ const modifiedDisclaimerStyles = css`
   ${disclaimerStyles};
 
   padding-bottom: 0;
-`;
-
-const modifiedErrorBoxStyles = css`
-  ${errorBoxStyles};
-  text-align: center;
-  margin: 1rem auto;
-  padding: 0.7rem 1rem !important;
-  width: min(100%, max-content);
-`;
-
-const modifiedInfoBoxStyles = css`
-  ${infoBoxStyles};
-  text-align: center;
-  margin: 1rem auto;
-  padding: 0.7rem 1rem !important;
-  width: max-content;
 `;
 
 const modifiedSplitLayoutColumnsStyles = css`
@@ -416,6 +410,11 @@ const treeStyles = (level, styles) => {
     margin-right: calc(${level} * 1.25em);
   `;
 };
+
+const wideBoxSectionStyles = css`
+  ${inlineBoxSectionStyles}
+  grid-template-columns: minmax(100px, 300px) minmax(100px, 1fr);
+`;
 
 /*
 ## Helpers
@@ -845,6 +844,10 @@ const sectionRowInline = (label, value, dataStatus = 'success') => {
   return sectionRow(label, value, inlineBoxSectionStyles, dataStatus);
 };
 
+const sectionRowWide = (label, value, dataStatus = 'success') => {
+  return sectionRow(label, value, wideBoxSectionStyles, dataStatus);
+};
+
 function sortMeasurements(measurements) {
   // store in arrays by unit,fraction,speciation and sort by date
   Object.entries(measurements).forEach(([unitKey, unitMeasurements]) => {
@@ -1246,16 +1249,18 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       </h2>
       <StatusContent
         empty={
-          <p css={modifiedInfoBoxStyles}>
+          <p css={messageBoxStyles(infoBoxStyles)}>
             No data available for this monitoring location.
           </p>
         }
-        failure={<p css={modifiedErrorBoxStyles}>{monitoringError}</p>}
+        failure={
+          <p css={messageBoxStyles(errorBoxStyles)}>{monitoringError}</p>
+        }
         fetching={<LoadingSpinner />}
         status={charcsStatus}
       >
         {infoText ? (
-          <p css={modifiedInfoBoxStyles}>{infoText}</p>
+          <p css={messageBoxStyles(infoBoxStyles)}>{infoText}</p>
         ) : (
           <>
             <SliderContainer
@@ -1349,7 +1354,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
             />
             {chartData?.length && (
               <div css={shadedBoxSectionStyles}>
-                {sectionRowInline(
+                {sectionRowWide(
                   'Selected Date Range',
                   `${new Date(domain[0]).toLocaleDateString(
                     'en-us',
@@ -1360,22 +1365,22 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
                       dateOptions,
                     )}`,
                 )}
-                {sectionRowInline(
+                {sectionRowWide(
                   'Number of Measurements Shown',
                   chartData.length.toLocaleString(),
                 )}
-                {sectionRowInline('Average of Values', average)}
-                {sectionRowInline(
+                {sectionRowWide('Average of Values', average)}
+                {sectionRowWide(
                   'Median Value',
                   `${median.toLocaleString()} ${unit}`,
                 )}
                 {range &&
-                  sectionRowInline(
+                  sectionRowWide(
                     'Minimum Value',
                     `${range[0].toLocaleString()} ${unit}`,
                   )}
                 {range &&
-                  sectionRowInline(
+                  sectionRowWide(
                     'Maximum Value',
                     `${range[1].toLocaleString()} ${unit}`,
                   )}
@@ -1454,12 +1459,12 @@ function CharacteristicsTableSection({
       <div css={charcsTableStyles}>
         <StatusContent
           empty={
-            <p css={modifiedInfoBoxStyles}>
+            <p css={messageBoxStyles(infoBoxStyles)}>
               No records found for this location.
             </p>
           }
           failure={
-            <div css={modifiedErrorBoxStyles}>
+            <div css={messageBoxStyles(errorBoxStyles)}>
               <p>{monitoringError}</p>
             </div>
           }
@@ -1469,7 +1474,7 @@ function CharacteristicsTableSection({
           <span className="selected">
             {sectionRowInline(
               'Selected Characteristic',
-              selected,
+              selected ?? 'None',
               charcsStatus,
             )}
           </span>
@@ -1542,7 +1547,7 @@ function ChartContainer({ range, data, charcName, scaleType, yTitle, unit }) {
 
   if (!data?.length)
     return (
-      <p css={modifiedInfoBoxStyles}>
+      <p css={messageBoxStyles(infoBoxStyles)}>
         No measurements available for the selected options.
       </p>
     );
@@ -1697,11 +1702,13 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
       <h2 css={infoBoxHeadingStyles}>Download Location Data</h2>
       <StatusContent
         empty={
-          <p css={modifiedInfoBoxStyles}>
+          <p css={messageBoxStyles(infoBoxStyles)}>
             No data available for this monitoring location.
           </p>
         }
-        failure={<p css={modifiedErrorBoxStyles}>{monitoringError}</p>}
+        failure={
+          <p css={messageBoxStyles(errorBoxStyles)}>{monitoringError}</p>
+        }
         fetching={<LoadingSpinner />}
         status={charcsStatus}
       >
@@ -2068,7 +2075,7 @@ function MonitoringLocationContent({ fullscreen }) {
   return (
     <StatusContent
       empty={noSiteView}
-      failure={<p css={modifiedErrorBoxStyles}>{monitoringError}</p>}
+      failure={<p css={messageBoxStyles(errorBoxStyles)}>{monitoringError}</p>}
       fetching={content}
       success={content}
       status={siteStatus}

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -1896,7 +1896,7 @@ function InformationSection({ siteId, site, siteStatus }) {
   );
 }
 
-function MonitoringSiteContent({ fullscreen }) {
+function MonitoringLocationContent({ fullscreen }) {
   const { orgId, provider, siteId } = useParams();
   const [site, siteStatus] = useSiteDetails(provider, orgId, siteId);
   const [characteristics, characteristicsStatus] = useCharacteristics(
@@ -2046,12 +2046,12 @@ function MonitoringSiteContent({ fullscreen }) {
   );
 }
 
-function MonitoringSite(props) {
+function MonitoringLocation(props) {
   return (
     <FullscreenProvider>
       <FullscreenContext.Consumer>
         {(fullscreen) => (
-          <MonitoringSiteContent fullscreen={fullscreen} {...props} />
+          <MonitoringLocationContent fullscreen={fullscreen} {...props} />
         )}
       </FullscreenContext.Consumer>
     </FullscreenProvider>
@@ -2272,4 +2272,4 @@ function StatusContent({
   }
 }
 
-export default MonitoringSite;
+export default MonitoringLocation;

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -1036,9 +1036,11 @@ function useCharacteristics(provider, orgId, siteId) {
     const url =
       `${services.data.waterQualityPortal.resultSearch}` +
       `&mimeType=csv&zip=no&dataProfile=narrowResult` +
-      `&providers=${provider}&organization=${encodeURIComponent(
-        orgId,
-      )}&siteid=${encodeURIComponent(siteId)}`;
+      `&providers=${encodeURIComponent(
+        provider,
+      )}&organization=${encodeURIComponent(orgId)}&siteid=${encodeURIComponent(
+        siteId,
+      )}`;
     fetchParseCsv(url)
       .then((results) => structureRecords(results.data))
       .catch((_err) => {
@@ -1059,9 +1061,11 @@ function useSiteDetails(provider, orgId, siteId) {
   useEffect(() => {
     const url =
       `${services.data.waterQualityPortal.monitoringLocation}` +
-      `search?mimeType=geojson&zip=no&provider=${provider}&organization=${encodeURIComponent(
-        orgId,
-      )}&siteid=${encodeURIComponent(siteId)}`;
+      `search?mimeType=geojson&zip=no&provider=${encodeURIComponent(
+        provider,
+      )}&organization=${encodeURIComponent(orgId)}&siteid=${encodeURIComponent(
+        siteId,
+      )}`;
 
     fetchSiteDetails(url, setSite, setSiteStatus).catch((err) => {
       console.error(err);

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -831,12 +831,6 @@ function sortMeasurements(measurements) {
         Object.entries(fractionMeasurements).forEach(
           ([specKey, specMeasurements]) => {
             Object.values(specMeasurements).forEach((date) => {
-              /* date.measurement = parseFloat(
-                (
-                  date.measurement.reduce((a, b) => a + b) /
-                  date.measurement.length
-                ).toFixed(3),
-              ); */
               date.measurements = date.measurements.map((measurement) =>
                 parseFloat(measurement.toFixed(3)),
               );

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -44,6 +44,7 @@ import { monitoringError } from 'config/errorMessages';
 import { FullscreenContext, FullscreenProvider } from 'contexts/Fullscreen';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
+import { MapHighlightProvider } from 'contexts/MapHighlight';
 // helpers
 import { fetchCheck, fetchPost } from 'utils/fetchUtils';
 import { useSharedLayers } from 'utils/hooks';
@@ -2241,7 +2242,9 @@ function SiteMap({ layout, site, siteStatus, widthRef }) {
 function SiteMapContainer({ ...props }) {
   return (
     <MapErrorBoundary>
-      <SiteMap {...props} />
+      <MapHighlightProvider>
+        <SiteMap {...props} />
+      </MapHighlightProvider>
     </MapErrorBoundary>
   );
 }

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -1398,6 +1398,7 @@ function CharacteristicsTableSection({
         const selector = (
           <div css={radioTableStyles}>
             <input
+              aria-label={charc.name}
               checked={selected === charc.name}
               id={charc.name}
               onChange={(e) => setSelected(e.target.value)}

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -1036,7 +1036,9 @@ function useCharacteristics(provider, orgId, siteId) {
     const url =
       `${services.data.waterQualityPortal.resultSearch}` +
       `&mimeType=csv&zip=no&dataProfile=narrowResult` +
-      `&providers=${provider}&organization=${orgId}&siteid=${siteId}`;
+      `&providers=${provider}&organization=${encodeURIComponent(
+        orgId,
+      )}&siteid=${encodeURIComponent(siteId)}`;
     fetchParseCsv(url)
       .then((results) => structureRecords(results.data))
       .catch((_err) => {
@@ -1057,7 +1059,9 @@ function useSiteDetails(provider, orgId, siteId) {
   useEffect(() => {
     const url =
       `${services.data.waterQualityPortal.monitoringLocation}` +
-      `search?mimeType=geojson&zip=no&provider=${provider}&organization=${orgId}&siteid=${siteId}`;
+      `search?mimeType=geojson&zip=no&provider=${provider}&organization=${encodeURIComponent(
+        orgId,
+      )}&siteid=${encodeURIComponent(siteId)}`;
 
     fetchSiteDetails(url, setSite, setSiteStatus).catch((err) => {
       console.error(err);
@@ -1606,28 +1610,31 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
   if (range && range[1] !== maxYear)
     queryData.startDateHi = `12-31-${range[1]}`;
 
-  const selectedCharcs = Object.values(checkboxes.charcs)
-    .filter((charc) => charc.selected === Checkbox.checked)
-    .map((charc) => charc.id);
-  const selectedTypes = Object.values(checkboxes.types)
-    .filter((type) => type.selected !== Checkbox.unchecked)
-    .map((type) => type.id);
-
   let portalUrl =
     services.status === 'success' &&
     Object.entries(queryData).reduce((query, [key, value]) => {
       let queryPartial = '';
       if (Array.isArray(value))
-        value.forEach((item) => (queryPartial += `&${key}=${item}`));
-      else queryPartial += `&${key}=${value}`;
+        value.forEach(
+          (item) => (queryPartial += `&${key}=${encodeURIComponent(item)}`),
+        );
+      else queryPartial += `&${key}=${encodeURIComponent(value)}`;
       return query + queryPartial;
     }, `${services.data.waterQualityPortal.userInterface}#dataProfile=narrowResult`);
 
   if (checkboxes.all === Checkbox.indeterminate) {
+    const selectedTypes = Object.values(checkboxes.types)
+      .filter((type) => type.selected !== Checkbox.unchecked)
+      .map((type) => type.id);
     selectedTypes.forEach(
-      (type) => (portalUrl += `&characteristicType=${type}`),
+      (type) =>
+        (portalUrl += `&characteristicType=${encodeURIComponent(type)}`),
     );
-    if (selectedCharcs.length) queryData.characteristicName = selectedCharcs;
+
+    const selectedCharcs = Object.values(checkboxes.charcs)
+      .filter((charc) => charc.selected === Checkbox.checked)
+      .map((charc) => charc.id);
+    queryData.characteristicName = selectedCharcs;
   }
 
   useEffect(() => {

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -111,11 +111,14 @@ const charcsTableStyles = css`
   .rt-table .rt-td {
     margin: auto;
   }
+  .selected div {
+    border-bottom: 1px solid #d8dfe2;
+    margin-bottom: 0.5rem;
+  }
 `;
 
 const chartContainerStyles = css`
-  margin-top: 1rem;
-  margin-right: 0.625rem;
+  margin: 1rem 0.625rem;
 `;
 
 const containerStyles = css`
@@ -174,6 +177,7 @@ const fileLinkStyles = css`
 const flexboxSectionStyles = css`
   ${boxSectionStyles}
   display: flex;
+  justify-content: flex-start;
 `;
 
 const iconStyles = css`
@@ -184,6 +188,7 @@ const infoBoxHeadingStyles = css`
   ${boxHeadingStyles};
   display: flex;
   align-items: flex-start;
+  margin-bottom: 0;
 
   small {
     display: block;
@@ -198,8 +203,14 @@ const infoBoxHeadingStyles = css`
 `;
 
 const inlineBoxSectionStyles = css`
-  padding: 0.4375rem 0.875rem;
-
+  ${boxSectionStyles}
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid #d8dfe2;
+  padding: 0.5em;
+  &:last-of-type {
+    border-bottom: none;
+  }
   /* loading icon */
   svg {
     display: inline-block;
@@ -208,15 +219,21 @@ const inlineBoxSectionStyles = css`
   }
 
   h3 {
+    grid-column: 1;
     margin-right: 0.5em;
   }
 
-  h3,
+  div,
   p {
+    grid-column: 2;
+  }
+
+  .label,
+  .value {
     display: inline-block;
-    margin-top: 0;
-    margin-bottom: 0;
     line-height: 1.25;
+    margin-bottom: auto;
+    margin-top: auto;
   }
 `;
 
@@ -235,6 +252,11 @@ const mapContainerStyles = css`
   position: relative;
 `;
 
+const modifiedBoxStyles = css`
+  ${boxStyles}
+  padding-bottom: 0;
+`;
+
 const modifiedDisclaimerStyles = css`
   ${disclaimerStyles};
 
@@ -246,7 +268,7 @@ const modifiedErrorBoxStyles = css`
   text-align: center;
   margin: 1rem auto;
   padding: 0.7rem 1rem !important;
-  width: max-content;
+  width: min(100%, max-content);
 `;
 
 const modifiedInfoBoxStyles = css`
@@ -285,7 +307,7 @@ const radioStyles = css`
     font-size: inherit;
     margin: auto;
     padding-left: 1em;
-    text-indent: -1em;
+    text-indent: -1.1em;
     &:before {
       background: ${colors.white()};
       border-radius: 100%;
@@ -337,18 +359,15 @@ const selectContainerStyles = css`
     font-weight: bold;
     white-space: nowrap;
 
-    @media (min-width: 560px) {
+    @media (min-width: 960px) {
       margin-bottom: 0;
     }
-  }
-
-  @media (min-width: 560px) {
-    flex-wrap: nowrap;
   }
 
   .radio-container {
     display: inline-flex;
     flex-direction: column;
+    gap: 0.2em;
   }
 
   .radios {
@@ -368,10 +387,16 @@ const selectContainerStyles = css`
   }
 `;
 
+const shadedBoxSectionStyles = css`
+  ${boxSectionStyles}
+  background-color: #f0f6f9;
+`;
+
 const sliderContainerStyles = css`
   align-items: flex-end;
   display: flex;
   justify-content: center;
+  margin-top: 0.4375rem;
   width: 100%;
   span {
     margin-bottom: 0.1em;
@@ -807,16 +832,12 @@ function parseRecord(record, measurements) {
   return { unit, speciation, fraction };
 }
 
-const sectionRow = (label, value, style, dataStatus) => (
+const sectionRow = (label, value, style, dataStatus = 'success') => (
   <div css={style}>
-    <h3>{label}:</h3>
+    <h3 className="label">{label}:</h3>
     {dataStatus === 'fetching' && <LoadingSpinner />}
-    {dataStatus === 'failure' && (
-      <div css={modifiedErrorBoxStyles}>
-        <p>{monitoringError}</p>
-      </div>
-    )}
-    {dataStatus === 'success' && <p>{value}</p>}
+    {dataStatus === 'failure' && <p className="value">N/A</p>}
+    {dataStatus === 'success' && <p className="value">{value}</p>}
   </div>
 );
 
@@ -1216,7 +1237,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
   average += ` ${unit}`;
 
   return (
-    <div css={boxStyles}>
+    <div css={modifiedBoxStyles}>
       <h2 css={infoBoxHeadingStyles}>
         Chart of Results for{' '}
         {!charcName
@@ -1327,7 +1348,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
               unit={unit}
             />
             {chartData?.length && (
-              <div css={boxSectionStyles}>
+              <div css={shadedBoxSectionStyles}>
                 {sectionRowInline(
                   'Selected Date Range',
                   `${new Date(domain[0]).toLocaleDateString(
@@ -1445,14 +1466,20 @@ function CharacteristicsTableSection({
           fetching={<LoadingSpinner />}
           status={charcsStatus}
         >
-          {sectionRowInline('Selected Characteristic', selected, charcsStatus)}
+          <span className="selected">
+            {sectionRowInline(
+              'Selected Characteristic',
+              selected,
+              charcsStatus,
+            )}
+          </span>
           <ReactTable
             autoResetFilters={false}
             autoResetSortBy={false}
             data={tableData}
             defaultSort="name"
             placeholder="Filter..."
-            striped={false}
+            striped={true}
             getColumns={(tableWidth) => {
               const columnWidth = 2 * (tableWidth / 7) - 6;
               const halfColumnWidth = tableWidth / 7 - 6;
@@ -1667,7 +1694,7 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
 
   return (
     <div css={boxStyles}>
-      <h2 css={boxHeadingStyles}>Download Location Data</h2>
+      <h2 css={infoBoxHeadingStyles}>Download Location Data</h2>
       <StatusContent
         empty={
           <p css={modifiedInfoBoxStyles}>
@@ -1692,6 +1719,7 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
               title={
                 <span>
                   <input
+                    style={{ top: '2px' }}
                     type="checkbox"
                     checked={checkboxes.all === Checkbox.checked}
                     ref={(input) => {
@@ -1861,7 +1889,7 @@ function FileLink({ disabled, fileType, data, url }) {
 
 function InformationSection({ siteId, site, siteStatus }) {
   return (
-    <div css={boxStyles}>
+    <div css={modifiedBoxStyles}>
       <h2 css={infoBoxHeadingStyles}>
         {siteStatus === 'fetching' && <LoadingSpinner />}
         <span>
@@ -1874,24 +1902,26 @@ function InformationSection({ siteId, site, siteStatus }) {
           </small>
         </span>
       </h2>
-      {sectionRowInline('Organization Name', site.orgName, siteStatus)}
-      {sectionRowInline('Organization ID', site.orgId, siteStatus)}
-      {sectionRowInline(
-        'Location',
-        `${site.county}, ${site.state}`,
-        siteStatus,
-      )}
-      {sectionRowInline('Water Type', site.locationType, siteStatus)}
-      {sectionRowInline(
-        'Total Sample Count',
-        site.totalSamples?.toLocaleString(),
-        siteStatus,
-      )}
-      {sectionRowInline(
-        'Total Measurement Count',
-        site.totalMeasurements?.toLocaleString(),
-        siteStatus,
-      )}
+      <div css={boxSectionStyles}>
+        {sectionRowInline('Organization Name', site.orgName, siteStatus)}
+        {sectionRowInline('Organization ID', site.orgId, siteStatus)}
+        {sectionRowInline(
+          'Location',
+          `${site.county}, ${site.state}`,
+          siteStatus,
+        )}
+        {sectionRowInline('Water Type', site.locationType, siteStatus)}
+        {sectionRowInline(
+          'Total Sample Count',
+          site.totalSamples?.toLocaleString(),
+          siteStatus,
+        )}
+        {sectionRowInline(
+          'Total Measurement Count',
+          site.totalMeasurements?.toLocaleString(),
+          siteStatus,
+        )}
+      </div>
     </div>
   );
 }

--- a/app/client/src/components/shared/DateSlider.js
+++ b/app/client/src/components/shared/DateSlider.js
@@ -36,6 +36,7 @@ const sliderContainerStyles = css`
   align-items: flex-end;
   display: flex;
   gap: 1em;
+  height: 3.5em;
   justify-content: center;
   width: 100%;
 `;
@@ -43,7 +44,6 @@ const sliderContainerStyles = css`
 const sliderStyles = css`
   align-items: flex-end;
   display: inline-flex;
-  height: 3.5em;
   width: 100%;
   z-index: 0;
 `;
@@ -94,31 +94,37 @@ function DateSlider({
   return (
     <div css={sliderContainerStyles}>
       <span>{!disabled && minYear}</span>
-      <div css={sliderStyles}>
-        <div {...getTrackProps({ style: trackStyles })}>
-          {segments.map(({ getSegmentProps }, i) => (
-            <div
-              {...getSegmentProps({
-                key: i,
-                style:
-                  !disabled && i === 1 ? segmentStylesActive : segmentStyles,
-              })}
-            />
-          ))}
-          {!disabled &&
-            handles.map(({ value, active, getHandleProps }, i) => (
-              <div
-                {...getHandleProps({
-                  key: i,
-                  style: active ? handleStylesActive : handleStyles,
-                })}
-              >
-                <div css={tooltipStyles}>{value}</div>
-              </div>
-            ))}
-        </div>
-      </div>
-      <span>{!disabled && maxYear}</span>
+      {minYear !== maxYear && (
+        <>
+          <div css={sliderStyles}>
+            <div {...getTrackProps({ style: trackStyles })}>
+              {segments.map(({ getSegmentProps }, i) => (
+                <div
+                  {...getSegmentProps({
+                    key: i,
+                    style:
+                      !disabled && i === 1
+                        ? segmentStylesActive
+                        : segmentStyles,
+                  })}
+                />
+              ))}
+              {!disabled &&
+                handles.map(({ value, active, getHandleProps }, i) => (
+                  <div
+                    {...getHandleProps({
+                      key: i,
+                      style: active ? handleStylesActive : handleStyles,
+                    })}
+                  >
+                    <div css={tooltipStyles}>{value}</div>
+                  </div>
+                ))}
+            </div>
+          </div>
+          <span>{!disabled && maxYear}</span>
+        </>
+      )}
     </div>
   );
 }

--- a/app/client/src/components/shared/HelpTooltip.js
+++ b/app/client/src/components/shared/HelpTooltip.js
@@ -25,7 +25,7 @@ const tooltipIconStyles = css`
 `;
 
 const tooltipStyles = css`
-  background: ${colors.steel(0.9)};
+  background: ${colors.steel(0.95)};
   border: none;
   border-radius: 6px;
   color: white;

--- a/app/client/src/components/shared/HelpTooltip.js
+++ b/app/client/src/components/shared/HelpTooltip.js
@@ -83,6 +83,7 @@ function HelpTooltip({ label }) {
         <span aria-hidden>
           <i className="fas fa-question-circle" />
         </span>
+        <span className="sr-only">Information Tooltip</span>
       </button>
     </Tooltip>
   );

--- a/app/client/src/components/shared/HelpTooltip.js
+++ b/app/client/src/components/shared/HelpTooltip.js
@@ -76,6 +76,7 @@ function HelpTooltip({ label }) {
     <Tooltip label={label} triggerRef={triggerRef}>
       <button
         css={tooltipIconStyles}
+        data-testid="tooltip-trigger"
         onClick={(_ev) => triggerRef.current?.focus()}
         ref={triggerRef}
       >

--- a/app/client/src/components/shared/HelpTooltip.js
+++ b/app/client/src/components/shared/HelpTooltip.js
@@ -76,7 +76,6 @@ function HelpTooltip({ label }) {
     <Tooltip label={label} triggerRef={triggerRef}>
       <button
         css={tooltipIconStyles}
-        data-testid="tooltip-trigger"
         onClick={(_ev) => triggerRef.current?.focus()}
         ref={triggerRef}
       >

--- a/app/client/src/components/shared/ReactTable.js
+++ b/app/client/src/components/shared/ReactTable.js
@@ -127,6 +127,10 @@ const containerStyles = css`
     }
 
     .rt-col-title {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-between;
       padding: 2px;
     }
 
@@ -148,6 +152,7 @@ type Props = {
   autoResetFilters?: boolean,
   autoResetSortBy?: boolean,
   data: Array<Object>,
+  defaultSort: ?string,
   getColumns: Function,
   placeholder: ?string,
   striped: ?boolean,
@@ -157,6 +162,7 @@ function ReactTable({
   autoResetFilters = true,
   autoResetSortBy = true,
   data,
+  defaultSort = null,
   getColumns,
   placeholder,
   striped = false,
@@ -193,6 +199,9 @@ function ReactTable({
       columns,
       data,
       defaultColumn,
+      initialState: {
+        sortBy: defaultSort ? [{ id: defaultSort }] : [],
+      },
     },
     useResizeColumns,
     useBlockLayout,

--- a/app/client/src/components/shared/ScatterPlot.tsx
+++ b/app/client/src/components/shared/ScatterPlot.tsx
@@ -8,8 +8,8 @@ import {
   XYChart,
 } from '@visx/xychart';
 // types
-import type { ReactChildren, ReactChild } from 'react';
-import type { XYChartTheme } from '@visx/xychart';
+import type { ReactChildren, ReactChild, ReactNode } from 'react';
+import type { TooltipData, XYChartTheme } from '@visx/xychart';
 
 // NOTE: EPA's _reboot.css file causes the tooltip series glyph to be clipped
 const VisxStyles = createGlobalStyle`
@@ -43,26 +43,26 @@ type Props = {
   data: Datum[];
   dataKey: string;
   range?: number[];
+  buildTooltip?: (tooltipData?: TooltipData<Datum>) => ReactNode;
   xAccessor?: (d: Datum) => string;
   xTitle?: string;
   yAccessor?: (d: Datum) => number;
   yScale?: 'log' | 'linear';
   yTitle?: string;
-  yUnit: string;
 };
 
-function LineChart({
+function ScatterPlot({
   data,
   dataKey,
   range,
   color,
   containerRef,
+  buildTooltip,
   xAccessor = (d: Datum) => d.x,
   xTitle,
   yAccessor = (d: Datum) => d.y,
   yScale = 'linear',
   yTitle,
-  yUnit,
 }: Props) {
   const [theme, setTheme] = useState<XYChartTheme>(customTheme);
   useEffect(() => {
@@ -105,6 +105,14 @@ function LineChart({
     };
   }, [containerRef]);
 
+  const defaultBuildTooltip = (tooltipData?: TooltipData<Datum>) => (
+    <>
+      {tooltipData?.nearestDatum && xAccessor(tooltipData.nearestDatum.datum)}:{' '}
+      {tooltipData?.nearestDatum && yAccessor(tooltipData.nearestDatum.datum)}{' '}
+    </>
+  );
+  const renderTooltip = buildTooltip ?? defaultBuildTooltip;
+
   return (
     <>
       <VisxStyles />
@@ -144,24 +152,14 @@ function LineChart({
           yAccessor={yAccessor}
         />
         <Tooltip<Datum>
-          // detectBounds={false}
           showDatumGlyph
           showVerticalCrosshair
           snapTooltipToDatumX
-          renderTooltip={({ tooltipData }) => (
-            <>
-              {tooltipData?.nearestDatum &&
-                xAccessor(tooltipData.nearestDatum.datum)}
-              :{' '}
-              {tooltipData?.nearestDatum &&
-                yAccessor(tooltipData.nearestDatum.datum)}{' '}
-              {yUnit}
-            </>
-          )}
+          renderTooltip={({ tooltipData }) => renderTooltip(tooltipData)}
         />
       </XYChart>
     </>
   );
 }
 
-export default LineChart;
+export default ScatterPlot;

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -1239,7 +1239,7 @@ function MonitoringLocationsContent({ attributes, services }) {
             <td>
               <em>Monitor&shy;ing Site ID:</em>
             </td>
-            <td>{siteId.replace(`${orgId}-`, '')}</td>
+            <td>{siteId}</td>
           </tr>
           <tr>
             <td>
@@ -1490,7 +1490,7 @@ function UsgsStreamgagesContent({ feature }: { feature: Object }) {
             <td>
               <em>Monitor&shy;ing Site ID:</em>
             </td>
-            <td>{siteId.replace(`${orgId}-`, '')}</td>
+            <td>{siteId}</td>
           </tr>
         </tbody>
       </table>

--- a/app/client/src/components/shared/WaterbodyInfo.js
+++ b/app/client/src/components/shared/WaterbodyInfo.js
@@ -1205,7 +1205,7 @@ function MonitoringLocationsContent({ attributes, services }) {
     `&providers=NWIS&providers=STEWARDS&providers=STORET`;
 
   const onMonitoringReportPage =
-    window.location.pathname.indexOf('station') === 1;
+    window.location.pathname.indexOf('location') === 1;
 
   return (
     <>
@@ -1251,7 +1251,7 @@ function MonitoringLocationsContent({ attributes, services }) {
             </td>
             <td>
               {Number(stationTotalSamples).toLocaleString()}
-              <span css={dateRangeStyles}>(all time)</span>
+              {timeframe && <span css={dateRangeStyles}>(all time)</span>}
             </td>
           </tr>
           <tr>

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -14,6 +14,10 @@ export const streamgagesError =
 export const monitoringError =
   'Sample locations information is temporarily unavailable, please try again later.';
 
+// waterqualitydata.us - Result Search (downloads)
+export const monitoringDownloadError =
+  'There was an error downloading the monitoring location data, please try again later.';
+
 // attains.epa.gov - Huc12summary Service
 export const huc12SummaryError =
   'Waterbody information is temporarily unavailable, please try again later.';

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -15,7 +15,7 @@ import StateTribal from 'components/pages/StateTribal';
 import StateTribalIntro from 'components/pages/StateTribal.Routes.StateTribalIntro';
 import StateTribalTabs from 'components/pages/StateTribal.Routes.StateTribalTabs';
 import National from 'components/pages/National';
-import MonitoringStation from 'components/pages/MonitoringStation';
+import MonitoringLocation from 'components/pages/MonitoringLocation';
 import DrinkingWater from 'components/pages/DrinkingWater';
 import Swimming from 'components/pages/Swimming';
 import EatingFish from 'components/pages/EatingFish';
@@ -94,8 +94,8 @@ function AppRoutes() {
         <Route path="/aquatic-life" element={<AquaticLife />} />
         <Route path="/plan-summary/:orgId/:actionId" element={<Actions />} />
         <Route
-          path="/station/:provider/:orgId/:siteId"
-          element={<MonitoringStation />}
+          path="/location/:provider/:orgId/:siteId"
+          element={<MonitoringLocation />}
         />
         <Route
           path="/waterbody-report/:orgId/:auId"

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -69,6 +69,7 @@ export function fetchPost(
   data: object,
   headers: object,
   timeout: number = defaultTimeout,
+  responseType = 'json',
 ) {
   const startTime = performance.now();
   return timeoutPromise(
@@ -81,7 +82,7 @@ export function fetchPost(
   )
     .then((response) => {
       logCallToGoogleAnalytics(apiUrl, response.status, startTime);
-      return checkResponse(response);
+      return checkResponse(response, responseType);
     })
     .catch((err) => {
       onError(err, apiUrl, startTime);
@@ -184,10 +185,13 @@ function timeoutPromise(timeout, promise) {
   });
 }
 
-export function checkResponse(response) {
+export function checkResponse(response, responseType = 'json') {
   return new Promise((resolve, reject) => {
     if (response.status === 200) {
-      response.json().then((json) => resolve(json));
+      if (responseType === 'json')
+        response.json().then((json) => resolve(json));
+      else if (responseType === 'blob')
+        response.blob().then((blob) => resolve(blob));
     } else {
       reject(response);
     }

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -73,8 +73,10 @@ function buildStations(locations, layer) {
       locationUrl:
         `/location/` +
         `${station.properties.ProviderName}/` +
-        `${station.properties.OrganizationIdentifier}/` +
-        `${station.properties.MonitoringLocationIdentifier}/`,
+        `${encodeURIComponent(station.properties.OrganizationIdentifier)}/` +
+        `${encodeURIComponent(
+          station.properties.MonitoringLocationIdentifier,
+        )}/`,
       // monitoring station specific properties:
       stationProviderName: station.properties.ProviderName,
       stationTotalSamples: parseInt(station.properties.activityCount),

--- a/app/client/src/utils/hooks.js
+++ b/app/client/src/utils/hooks.js
@@ -71,7 +71,7 @@ function buildStations(locations, layer) {
       // TODO: explore if the built up locationUrl below is ever different from
       // `station.properties.siteUrl`. from a quick test, they seem the same
       locationUrl:
-        `/station/` +
+        `/location/` +
         `${station.properties.ProviderName}/` +
         `${station.properties.OrganizationIdentifier}/` +
         `${station.properties.MonitoringLocationIdentifier}/`,

--- a/app/cypress/e2e/location.cy.ts
+++ b/app/cypress/e2e/location.cy.ts
@@ -14,10 +14,10 @@ const siteId = "IL_EPA_WQX-C-19";
 describe("Entering URL parameters for a nonexistent location", () => {
   const gibberishSiteId = "sdfsdfasdf";
 
-  it("Should display an 'information unavailable' error message when the parameters are invalid", () => {
+  it("Should display a 'location could not be found' error message when the parameters are for a nonexistent location", () => {
     cy.visit(`/location/${provider}/${orgId}/${gibberishSiteId}`);
-    cy.findByText(
-      `Sample locations information is temporarily unavailable, please try again later.`
+    cy.contains(
+      `The monitoring location ${gibberishSiteId} could not be found.`
     ).should("be.visible");
   });
 });
@@ -27,8 +27,8 @@ describe("Entering URL parameters for an existent site", () => {
     cy.visit(`/location/${provider}/${orgId}/${siteId}`);
   });
 
-  it("Should display the site ID", () => {
-    cy.contains(`Site ID: ${siteId}`).should("be.visible");
+  it("Should display the organization name", () => {
+    cy.findByText("illinois epa").should("be.visible");
   });
 
   it("Should instruct the user to select a characteristic for the graph", () => {
@@ -59,7 +59,7 @@ describe("The characteristic chart section", () => {
 describe("The Site ID tooltip", () => {
   it("Should be displayed when focusing the help icon", () => {
     cy.visit(`/location/${provider}/${orgId}/${siteId}`);
-    cy.findByTestId("tooltip-trigger").focus();
+    cy.findByRole("button", { name: "Information Tooltip" }).focus();
     cy.findByRole("tooltip").should("be.visible");
   });
 });

--- a/app/cypress/e2e/location.cy.ts
+++ b/app/cypress/e2e/location.cy.ts
@@ -1,0 +1,63 @@
+// This is a workaround for making the tests more reliable when running
+// cypress in headless mode, particularly for running code coverage.
+Cypress.on("uncaught:exception", (_err, _runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  debugger;
+  return false;
+});
+
+describe("Entering URL parameters for a nonexistent location", () => {
+  const provider = "STORET";
+  const orgId = "31ORWUNT";
+  const gibberishSiteId = "sdfsdfasdf";
+
+  it("Should display a 'site not found' error message when no data is returned", () => {
+    cy.visit(`/location/${provider}/${orgId}/${orgId}-${gibberishSiteId}`);
+    cy.contains(
+      `The monitoring location ${orgId}-${gibberishSiteId} could not be found.`
+    ).should("be.visible");
+  });
+  it("Should display a 'information unavailable' error message when the parameters are invalid", () => {
+    cy.visit(`/location/${provider}/${orgId}/${gibberishSiteId}`);
+    cy.findByText(
+      `Sample locations information is temporarily unavailable, please try again later.`
+    ).should("be.visible");
+  });
+});
+
+describe("Entering URL parameters for an existent site", () => {
+  const provider = "STORET";
+  const orgId = "CBP_WQX";
+  const siteId = "01651770";
+
+  beforeEach(() => {
+    cy.visit(`/location/${provider}/${orgId}/${orgId}-${siteId}`);
+  });
+
+  it("Should display the trimmed site ID", () => {
+    cy.contains(`Site ID: ${siteId}`).should("be.visible");
+    cy.contains(`Site ID: ${orgId}-${siteId}`).should("not.exist");
+  });
+
+  it("Should instruct the user to select a characteristic for the graph", () => {
+    cy.findByText(
+      "Select a characteristic from the table above to graph its results."
+    ).should("be.visible");
+  });
+});
+
+describe("Selecting a characteristic from the table", () => {
+  const provider = "NWIS";
+  const orgId = "USGS-MD";
+  const siteId = "USGS-391800076303201";
+
+  beforeEach(() => {
+    cy.visit(`/location/${provider}/${orgId}/${siteId}`);
+  });
+
+  /* it("Should display a graph when a characteristic with measured results is selected", () => {
+    cy.findByLabelText("Total dissolved solids").click({ force: true });
+    cy.findByLabelText("XYChart").should("be.visible");
+  }); */
+});

--- a/app/cypress/e2e/location.cy.ts
+++ b/app/cypress/e2e/location.cy.ts
@@ -7,18 +7,14 @@ Cypress.on("uncaught:exception", (_err, _runnable) => {
   return false;
 });
 
+const provider = "STORET";
+const orgId = "IL_EPA_WQX";
+const siteId = "IL_EPA_WQX-C-19";
+
 describe("Entering URL parameters for a nonexistent location", () => {
-  const provider = "STORET";
-  const orgId = "31ORWUNT";
   const gibberishSiteId = "sdfsdfasdf";
 
-  it("Should display a 'site not found' error message when no data is returned", () => {
-    cy.visit(`/location/${provider}/${orgId}/${orgId}-${gibberishSiteId}`);
-    cy.contains(
-      `The monitoring location ${orgId}-${gibberishSiteId} could not be found.`
-    ).should("be.visible");
-  });
-  it("Should display a 'information unavailable' error message when the parameters are invalid", () => {
+  it("Should display an 'information unavailable' error message when the parameters are invalid", () => {
     cy.visit(`/location/${provider}/${orgId}/${gibberishSiteId}`);
     cy.findByText(
       `Sample locations information is temporarily unavailable, please try again later.`
@@ -27,17 +23,12 @@ describe("Entering URL parameters for a nonexistent location", () => {
 });
 
 describe("Entering URL parameters for an existent site", () => {
-  const provider = "STORET";
-  const orgId = "CBP_WQX";
-  const siteId = "01651770";
-
   beforeEach(() => {
-    cy.visit(`/location/${provider}/${orgId}/${orgId}-${siteId}`);
+    cy.visit(`/location/${provider}/${orgId}/${siteId}`);
   });
 
-  it("Should display the trimmed site ID", () => {
+  it("Should display the site ID", () => {
     cy.contains(`Site ID: ${siteId}`).should("be.visible");
-    cy.contains(`Site ID: ${orgId}-${siteId}`).should("not.exist");
   });
 
   it("Should instruct the user to select a characteristic for the graph", () => {
@@ -47,17 +38,28 @@ describe("Entering URL parameters for an existent site", () => {
   });
 });
 
-describe("Selecting a characteristic from the table", () => {
-  const provider = "NWIS";
-  const orgId = "USGS-MD";
-  const siteId = "USGS-391800076303201";
-
+describe("The characteristic chart section", () => {
   beforeEach(() => {
     cy.visit(`/location/${provider}/${orgId}/${siteId}`);
   });
 
-  /* it("Should display a graph when a characteristic with measured results is selected", () => {
-    cy.findByLabelText("Total dissolved solids").click({ force: true });
+  it("Should display a graph when a characteristic with measured results is selected", () => {
+    cy.findByLabelText("Total dissolved solids").check({ force: true });
     cy.findByLabelText("XYChart").should("be.visible");
-  }); */
+  });
+
+  it("Should display an info message when a characteristic without results is selected", () => {
+    cy.findByLabelText("Antimony").check({ force: true });
+    cy.findByText(
+      "No measurements available to be charted for this characteristic."
+    ).should("be.visible");
+  });
+});
+
+describe("The Site ID tooltip", () => {
+  it("Should be displayed when focusing the help icon", () => {
+    cy.visit(`/location/${provider}/${orgId}/${siteId}`);
+    cy.findByTestId("tooltip-trigger").focus();
+    cy.findByRole("tooltip").should("be.visible");
+  });
 });


### PR DESCRIPTION
## Related Issues:
* [HMW-11](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-11)

## Main Changes:
* Changed occurrences of 'station' to 'location'.
* Re-combined the added the org ID back to the site ID.
* Added a help tooltip to describe the site ID.
* Updated the download link to use only characteristic names and to use a POST request, while the WQP link uses only characteristic types.
* Updated the date slider to only show the year if the start and end dates are the same.
* Added some Cypress tests.

## Steps To Test:
1. Go to a monitoring location page, e.g. [http://localhost:3000/location/STORET/CBP_WQX/CBP_WQX-01651770/](http://localhost:3000/location/STORET/CBP_WQX/CBP_WQX-01651770/)
2. Select a characteristic from the upper-right table that only has one year of data, such as _Orthoposphate_
3. Confirm that only the year is shown where the date slider would be
4. Select the characteristic _Height, gage_
5. Confirm that on days with multiple measurements, both are shown on the graph and in the hover tooltip
6. In the download section, deselect a type, then select a single characteristic from that type
7. Confirm that the download link returns the correct number of results