### PR TITLE
Feature/274 update title description tags

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -149,7 +149,9 @@
       const pathnameMapping = {
         default: "How's My Waterway - Home",
         community: "How's My Waterway - Community",
+        'state-and-tribal': "How's My Waterway - State and Tribal",
         state: "How's My Waterway - State",
+        tribe: "How's My Waterway - Tribe",
         national: "How's My Waterway - National",
         'waterbody-report': "How's My Waterway - Waterbody Report",
         'plan-summary': "How's My Waterway - Plan Summary",
@@ -160,6 +162,8 @@
         'aquatic-life': "How's My Waterway - Explore - Aquatic Life",
         'drinking-water': "How's My Waterway - Explore - Drinking Water",
         attains: "How's My Waterway - ATTAINS",
+        educators: "How's My Waterway - Educators",
+        location: "How's My Waterway - Monitoring Location Details",
       };
 
       const descriptionMapping = {
@@ -167,14 +171,19 @@
           'An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language.',
         community:
           'Enter a location to learn about water quality in your community. Explore information about local stream conditions, watershed protection, restoration, drinking water and whether your waterways are suitable for swimming or eating fish and aquatic life.',
+        'state-and-tribal': 'Choose a state, tribe, or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites.',
         state:
-          'Choose a state or territory to get a comprehensive picture of water quality statewide. Search for water conditions throughout your state with the advanced search tool.',
+          'Choose a state or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites. Search for water conditions throughout your state with the advanced search tool.',
+        tribe:
+          'Choose a tribe to get the most recent information on water quality submitted to EPA, documents, and links to organizational websites.',
         national:
           'Explore information about overall water quality in the United State and the basics of EPA’s drinking water program.',
         'waterbody-report':
           'Use the waterbody report page to find information on individual waterbodies including uses, probable sources of impairments and plans to restore water quality. ',
         'plan-summary':
           'The restoration plan summary page includes basic plan information, submitted documents, impairments addressed, and waters covered. ',
+        educators: 'Find How’s My Waterway resources for educators including lesson plans and other materials.',
+        location: 'Use the monitoring location details page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
       };
 
       // update page title and description using mapping

--- a/app/client/public/sitemap.xml
+++ b/app/client/public/sitemap.xml
@@ -25,11 +25,47 @@
         <changefreq>weekly</changefreq>
     </url>
     <url>
+        <loc>https://mywaterway.epa.gov/state-and-tribal</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
         <loc>https://mywaterway.epa.gov/state</loc>
         <changefreq>weekly</changefreq>
     </url>
     <url>
+        <loc>https://mywaterway.epa.gov/tribe</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
         <loc>https://mywaterway.epa.gov/swimming</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/about</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/data</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/attains</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/plan-summary</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/location</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/waterbody-report</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/educators</loc>
         <changefreq>weekly</changefreq>
     </url>
 </urlset>

--- a/app/client/public/sitemap.xml
+++ b/app/client/public/sitemap.xml
@@ -29,14 +29,6 @@
         <changefreq>weekly</changefreq>
     </url>
     <url>
-        <loc>https://mywaterway.epa.gov/state</loc>
-        <changefreq>weekly</changefreq>
-    </url>
-    <url>
-        <loc>https://mywaterway.epa.gov/tribe</loc>
-        <changefreq>weekly</changefreq>
-    </url>
-    <url>
         <loc>https://mywaterway.epa.gov/swimming</loc>
         <changefreq>weekly</changefreq>
     </url>
@@ -50,18 +42,6 @@
     </url>
     <url>
         <loc>https://mywaterway.epa.gov/attains</loc>
-        <changefreq>weekly</changefreq>
-    </url>
-    <url>
-        <loc>https://mywaterway.epa.gov/plan-summary</loc>
-        <changefreq>weekly</changefreq>
-    </url>
-    <url>
-        <loc>https://mywaterway.epa.gov/location</loc>
-        <changefreq>weekly</changefreq>
-    </url>
-    <url>
-        <loc>https://mywaterway.epa.gov/waterbody-report</loc>
         <changefreq>weekly</changefreq>
     </url>
     <url>


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-274

## Main Changes:
* Updated the title and meta description tags for new pages (i.e., educators, location, state-and-tribal, state, and tribe). 
* Updated the `sitemap.xml` file to have all of the new pages.
  * Note: I didn't include pages that need parameters (i.e., location, plan-summary, waterbody-report. state, and tribe). 

## Steps To Test:
1. Look at the `sitemap.xml` file and verify all pages are captured, except for those pages that require parameters.
2. Navigate to the following pages and verify the title (hover mouse over tab) and meta description (inspect header in Chrome dev tools) tags match up with those in the ticket
    *  http://localhost:3000/educators
    * http://localhost:3000/location/STORET/CBP_WQX/CBP_WQX-01651770/
    * http://localhost:3000/state-and-tribal
    * http://localhost:3000/state/AL/water-quality-overview
    * http://localhost:3000/tribe/DELAWARENATION

