### PR TITLE
Bugfix/271 surrounding waterbodies layer edge cases

### DIFF
--- a/app/client/src/components/shared/MapWidgets.js
+++ b/app/client/src/components/shared/MapWidgets.js
@@ -262,7 +262,6 @@ function MapWidgets({
     setErrorMessage,
     getWatershed,
     allWaterbodiesLayer,
-    getAllWaterbodiesLayer,
     allWaterbodiesWidgetDisabled,
     setAllWaterbodiesWidgetDisabled,
     getAllWaterbodiesWidgetDisabled,
@@ -1320,7 +1319,6 @@ function MapWidgets({
     setAllWaterbodiesWidget(node); // store the widget in context so it can be shown or hidden later
     render(
       <ShowAllWaterbodies
-        getLayer={getAllWaterbodiesLayer}
         getDisabled={getAllWaterbodiesWidgetDisabled}
         mapView={view}
       />,
@@ -1329,24 +1327,18 @@ function MapWidgets({
     setAllWaterbodiesWidgetCreated(true);
   }, [
     allWaterbodiesWidgetCreated,
-    getAllWaterbodiesLayer,
     getAllWaterbodiesWidgetDisabled,
     setAllWaterbodiesWidget,
     view,
   ]);
 
   type allWaterbodiesProps = {
-    getLayer: Function,
     getDisabled: Function,
     mapView: Object,
   };
 
   // Defines the show all waterbodies widget
-  function ShowAllWaterbodies({
-    getLayer,
-    getDisabled,
-    mapView,
-  }: allWaterbodiesProps) {
+  function ShowAllWaterbodies({ getDisabled, mapView }: allWaterbodiesProps) {
     const [firstLoad, setFirstLoad] = useState(true);
     const [hover, setHover] = useState(false);
 
@@ -1374,11 +1366,15 @@ function MapWidgets({
     }
 
     const widgetDisabled = getDisabled();
-    const layer = getLayer();
+
+    // get the layer from the mapView
+    const layer = mapView.map.layers.find(
+      (l) => l.id === 'allWaterbodiesLayer',
+    );
 
     let title = 'View Surrounding Waterbodies';
     if (widgetDisabled) title = 'Surrounding Waterbodies Widget Not Available';
-    else if (layer.visible) title = 'Hide Surrounding Waterbodies';
+    else if (layer?.visible) title = 'Hide Surrounding Waterbodies';
 
     return (
       <div
@@ -1388,7 +1384,7 @@ function MapWidgets({
         onMouseOut={() => setHover(false)}
         onClick={(ev) => {
           // if widget is disabled do nothing
-          if (widgetDisabled) return;
+          if (widgetDisabled || !layer) return;
 
           layer.visible = !layer.visible;
           setAllWaterbodiesLayerVisible(layer.visible);

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -395,9 +395,6 @@ export class LocationSearchProvider extends Component<Props, State> {
     getUpstreamWidgetDisabled: () => {
       return this.state.upstreamWidgetDisabled;
     },
-    getAllWaterbodiesLayer: () => {
-      return this.state.allWaterbodiesLayer;
-    },
     getCurrentExtent: () => {
       return this.state.currentExtent;
     },


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-271

## Main Changes:
* Fixed an edge case where the surrounding waterbodies layer does not respond to clicks.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Toggle the surrounding waterbodies widget off and back on
3. Verify the layer actually turns off and back on
4. Click on the "State & Tribal" button
5. Select the `Citizen Potawatomi Nation, Oklahoma` tribe
6. Turn on the surrounding waterbodies layer
7. Verify the surrounding waterbodies layer turns on
8. Select `Wyoming` from the drop down
9. Click on the Advanced Search tab
10. Do a search
11. Click on the "Community" button
12. Search for DC
13. Toggle the surrounding waterbodies widget off and back on
14. Verify the layer actually turns off and back on

