### PR TITLE
290 Update Monitoring Details Page Text

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -163,7 +163,7 @@
         'drinking-water': "How's My Waterway - Explore - Drinking Water",
         attains: "How's My Waterway - ATTAINS",
         educators: "How's My Waterway - Educators",
-        location: "How's My Waterway - Monitoring Location Details",
+        location: "How's My Waterway - Monitoring Report",
       };
 
       const descriptionMapping = {
@@ -171,7 +171,8 @@
           'An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language.',
         community:
           'Enter a location to learn about water quality in your community. Explore information about local stream conditions, watershed protection, restoration, drinking water and whether your waterways are suitable for swimming or eating fish and aquatic life.',
-        'state-and-tribal': 'Choose a state, tribe, or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites.',
+        'state-and-tribal':
+          'Choose a state, tribe, or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites.',
         state:
           'Choose a state or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites. Search for water conditions throughout your state with the advanced search tool.',
         tribe:
@@ -182,8 +183,10 @@
           'Use the waterbody report page to find information on individual waterbodies including uses, probable sources of impairments and plans to restore water quality. ',
         'plan-summary':
           'The restoration plan summary page includes basic plan information, submitted documents, impairments addressed, and waters covered. ',
-        educators: 'Find How’s My Waterway resources for educators including lesson plans and other materials.',
-        location: 'Use the monitoring location details page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
+        educators:
+          'Find How’s My Waterway resources for educators including lesson plans and other materials.',
+        location:
+          'Use the monitoring report page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
       };
 
       // update page title and description using mapping
@@ -574,8 +577,8 @@
             >
             <br />
             How's My Waterway utilizes Esri's ArcGIS JavaScript API for advanced
-            mapping features, which are not supported by this browser. For
-            more information visit the following links:
+            mapping features, which are not supported by this browser. For more
+            information visit the following links:
             <a
               href="https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later"
               >ArcGIS API for JavaScript System Requirements</a

--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -2065,7 +2065,7 @@ function MonitoringLocationContent() {
 
   const noSiteView = (
     <Page>
-      <NavBar title="Monitoring Location Details" />
+      <NavBar title="Monitoring Report" />
 
       <div css={containerStyles}>
         <div css={pageErrorBoxStyles}>
@@ -2094,7 +2094,7 @@ function MonitoringLocationContent() {
 
   const twoColumnView = (
     <Page>
-      <NavBar title="Monitoring Location Details" />
+      <NavBar title="Monitoring Report" />
       <div css={containerStyles} data-content="container">
         <WindowSize>
           {({ width, height }) => {

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1395,7 +1395,7 @@ function MonitoringLocationsContent({
               className="fas fa-info-circle"
               aria-hidden="true"
             />
-            Monitoring Report page
+            View Monitoring Report
           </a>
           &nbsp;&nbsp;
           <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Added Monitoring Location Details pages for each monitoring location, listed under Past Water Conditions, where users can view/download historical data and view graphs for sample results of characteristics.
+- Added Monitoring Report pages for each monitoring location, listed under Past Water Conditions, where users can view/download historical data and view graphs for sample results of characteristics.
 
 - Added historical data and a date slider to the Monitoring panel on the Community page.
 


### PR DESCRIPTION
## Related Issues:
* [HMW-290](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-290)

## Main Changes:
* Changed occurrences of _Monitoring Location Details_ to _Monitoring Report_, and updated other text to match the nomenclature used for the _Waterbody Report_ page.

## Steps to Test:
- Check that the popup/accordion links to the page reflect the changes, and that the corresponding page title reads "Monitoring Report"