### PR TITLE
Feature/291 Monitoring Report page slider tooltips

### DIFF
--- a/app/client/src/components/pages/MonitoringLocation.js
+++ b/app/client/src/components/pages/MonitoringLocation.js
@@ -215,7 +215,17 @@ const infoBoxHeadingStyles = css`
   ${boxHeadingStyles};
   display: flex;
   align-items: flex-start;
+  justify-content: space-between;
   margin-bottom: 0;
+
+  & > * {
+    margin-bottom: auto;
+    margin-top: auto;
+  }
+
+  button {
+    font-size: 1rem;
+  }
 
   small {
     display: block;
@@ -224,6 +234,7 @@ const infoBoxHeadingStyles = css`
 
   /* loading icon */
   svg {
+    display: inline-block;
     margin: 0 -0.375rem 0 -0.875rem;
     height: 1.5rem;
   }
@@ -1276,6 +1287,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
         {!charcName
           ? 'Selected Characteristic'
           : titleCaseWithExceptions(charcName)}
+        <HelpTooltip label="Adjust the slider handles to filter the data displayed on the chart by the selected year range, and use the drop-down inputs to filter  the data by the corresponding fields" />
       </h2>
       <StatusContent
         empty={
@@ -1749,7 +1761,10 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
 
   return (
     <div css={boxStyles}>
-      <h2 css={infoBoxHeadingStyles}>Download Location Data</h2>
+      <h2 css={infoBoxHeadingStyles}>
+        Download Location Data
+        <HelpTooltip label="Adjust the slider handles to filter download results by the selected year range, and use the checkboxes to filter the results by individual characteristics and characteristic groups" />
+      </h2>
       <StatusContent
         empty={
           <p css={messageBoxStyles(infoBoxStyles)}>
@@ -1969,8 +1984,8 @@ function InformationSection({ siteId, site, siteStatus }) {
   return (
     <div css={modifiedBoxStyles}>
       <h2 css={infoBoxHeadingStyles}>
-        {siteStatus === 'fetching' && <LoadingSpinner />}
         <span>
+          {siteStatus === 'fetching' && <LoadingSpinner />}
           {siteStatus === 'success' && site.locationName}
           <small>
             <strong>

--- a/app/client/src/components/shared/ScatterPlot.tsx
+++ b/app/client/src/components/shared/ScatterPlot.tsx
@@ -137,16 +137,12 @@ function ScatterPlot({
 
   const renderTooltip = buildTooltip ?? defaultBuildTooltip;
 
-  let displayedYTitle = yTitle;
-  if (yTitle && yTitle.length >= height / 8)
-    displayedYTitle = `${yTitle.slice(0, height / 8)}...`;
-
   return (
     <>
       <VisxStyles />
       <XYChart
         height={height}
-        margin={{ top: 20, bottom: 45, left: 70, right: 30 }}
+        margin={{ top: 20, bottom: 45, left: 85, right: 30 }}
         theme={theme}
         xScale={{ type: 'band', paddingInner: 1, paddingOuter: 0.5 }}
         yScale={{ type: yScale, domain: range }}
@@ -163,12 +159,15 @@ function ScatterPlot({
           strokeWidth={2}
         />
         <Axis
-          label={displayedYTitle}
+          label={yTitle}
           labelProps={{
             fill: '#2C2E43',
             dx: -30,
+            lineHeight: '1.2em',
             style: { fontWeight: 'bold' },
+            scaleToFit: false,
             textAnchor: 'middle',
+            width: height,
           }}
           orientation="left"
           strokeWidth={2}

--- a/app/client/src/components/shared/ScatterPlot.tsx
+++ b/app/client/src/components/shared/ScatterPlot.tsx
@@ -75,6 +75,7 @@ type Props = {
   containerRef?: HTMLElement | null;
   data: Datum[];
   dataKeys: string[];
+  height?: number;
   range?: number[];
   xTitle?: string;
   yScale?: 'log' | 'linear';
@@ -87,6 +88,7 @@ function ScatterPlot({
   containerRef,
   data,
   dataKeys,
+  height = 500,
   range,
   xTitle,
   yScale = 'linear',
@@ -135,11 +137,15 @@ function ScatterPlot({
 
   const renderTooltip = buildTooltip ?? defaultBuildTooltip;
 
+  let displayedYTitle = yTitle;
+  if (yTitle && yTitle.length >= height / 8)
+    displayedYTitle = `${yTitle.slice(0, height / 8)}...`;
+
   return (
     <>
       <VisxStyles />
       <XYChart
-        height={500}
+        height={height}
         margin={{ top: 20, bottom: 45, left: 70, right: 30 }}
         theme={theme}
         xScale={{ type: 'band', paddingInner: 1, paddingOuter: 0.5 }}
@@ -157,7 +163,7 @@ function ScatterPlot({
           strokeWidth={2}
         />
         <Axis
-          label={yTitle}
+          label={displayedYTitle}
           labelProps={{
             fill: '#2C2E43',
             dx: -30,


### PR DESCRIPTION
## Related Issues:
* [HMW-291](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-291)

## Main Changes:
* Added information tooltips to the Download and Characteristic Chart sections of the **Monitoring Report** page, which briefly explain the uses of various inputs (sliders, checkboxes, and selects).
* Added logic to the `ScatterPlot` component to wrap long Y axis labels. 

## Steps To Test:
1. Go to a Monitoring Report page, e.g. http://localhost:3000/location/STORET/CBP_WQX/CBP_WQX-1651800/
2. Observe the tooltips positioned beside the headings of the _Download Location Data_ section and the _Chart of Results for Selected Characteristic_ section
3. Select a long characteristic name from the table, such as _Inorganic nitrogen (nitrate and nitrite) \***retired\***use Nitrate + Nitrite_
4. Confirm that the chart's Y axis title wraps, and that there is no overflow