### PR TITLE
Feature/292 Drinking Water Use glossary links

### DIFF
--- a/app/client/src/components/shared/AssessmentSummary.js
+++ b/app/client/src/components/shared/AssessmentSummary.js
@@ -38,7 +38,12 @@ function AssessmentSummary({ waterbodies, fieldName, usageName }: Props) {
 
   const summary = summarizeAssessments(waterbodies, fieldName);
 
-  const glossaryUsageNames = ['aquatic life', 'fish and shellfish consumption'];
+  const glossaryUsageNames = [
+    'aquatic life',
+    'drinking water use',
+    'fish and shellfish consumption',
+    'swimming and boating',
+  ];
 
   return (
     <>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -458,7 +458,11 @@ function WaterbodyInfo({
                     if (value === 'Not Applicable') return null;
                     return (
                       <tr key={index}>
-                        <td>{useField.label}</td>
+                        <td>
+                          <GlossaryTerm term={useField.term}>
+                            {useField.label}
+                          </GlossaryTerm>
+                        </td>
                         <td>{value}</td>
                       </tr>
                     );

--- a/app/client/src/config/attainsToHmwMapping.js
+++ b/app/client/src/config/attainsToHmwMapping.js
@@ -2,12 +2,24 @@ import React from 'react';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 
 export const useFields = [
-  { value: 'drinkingwater_use', label: 'Drinking Water' },
-  { value: 'ecological_use', label: 'Aquatic Life' },
-  { value: 'fishconsumption_use', label: 'Fish and Shellfish Consumption' },
-  { value: 'recreation_use', label: 'Swimming and Boating' },
-  { value: 'cultural_use', label: 'Cultural' },
-  { value: 'other_use', label: 'Other' },
+  {
+    value: 'drinkingwater_use',
+    label: 'Drinking Water',
+    term: 'drinking water use',
+  },
+  { value: 'ecological_use', label: 'Aquatic Life', term: 'aquatic life' },
+  {
+    value: 'fishconsumption_use',
+    label: 'Fish and Shellfish Consumption',
+    term: 'fish and shellfish consumption',
+  },
+  {
+    value: 'recreation_use',
+    label: 'Swimming and Boating',
+    term: 'swimming and boating',
+  },
+  { value: 'cultural_use', label: 'Cultural', term: 'cultural use' },
+  { value: 'other_use', label: 'Other', term: 'other use' },
 ];
 
 export const impairmentFields = [

--- a/app/client/src/config/attainsToHmwMapping.js
+++ b/app/client/src/config/attainsToHmwMapping.js
@@ -5,21 +5,21 @@ export const useFields = [
   {
     value: 'drinkingwater_use',
     label: 'Drinking Water',
-    term: 'drinking water use',
+    term: 'Drinking Water Use',
   },
-  { value: 'ecological_use', label: 'Aquatic Life', term: 'aquatic life' },
+  { value: 'ecological_use', label: 'Aquatic Life', term: 'Aquatic Life' },
   {
     value: 'fishconsumption_use',
     label: 'Fish and Shellfish Consumption',
-    term: 'fish and shellfish consumption',
+    term: 'Fish and Shellfish Consumption',
   },
   {
     value: 'recreation_use',
     label: 'Swimming and Boating',
-    term: 'swimming and boating',
+    term: 'Swimming and Boating',
   },
-  { value: 'cultural_use', label: 'Cultural', term: 'cultural use' },
-  { value: 'other_use', label: 'Other', term: 'other use' },
+  { value: 'cultural_use', label: 'Cultural', term: 'Cultural Use' },
+  { value: 'other_use', label: 'Other', term: 'Other Use' },
 ];
 
 export const impairmentFields = [


### PR DESCRIPTION
## Related Issues:
* [HMW-292](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-292)

## Main Changes:
* Added links to the glossary terms of the corresponding water uses for the _Drinking Water_ and _Swimming_ tabs on the Community page.
* Added links to all of the uses listed in the `Waterbody` accordion items and map pop-ups.

## Steps To Test:
1. Navigate to Portland's (http://localhost:3000/community/portland) _Drinking Water_ and _Swimming_ tabs, and confirm that the glossary links in the shaded boxes _(There are X waterbodies assessed for \___)_ open the correct glossary terms (once they are populated)
2. Go to the _Waterbodies_ section of the _Overview_ tab, and expand an accordion item
3. Confirm that the labels in the left column, under "What is this water used for?", all have functional glossary links
4. Confirm that this is also reflected in the map pop-ups