### PR TITLE
Feature/295 download link tooltips

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1020,7 +1020,15 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       &nbsp;&nbsp;
                       {displayedLocationsCount > 0 ? (
                         <a href={`${downloadUrl}&mimeType=xlsx`}>
-                          <i className="fas fa-file-excel" aria-hidden="true" />
+                          <HelpTooltip
+                            label="Download XLSX"
+                            description="Download selected data as an XLSX file."
+                          >
+                            <i
+                              className="fas fa-file-excel"
+                              aria-hidden="true"
+                            />
+                          </HelpTooltip>
                         </a>
                       ) : (
                         <i
@@ -1032,7 +1040,12 @@ function MonitoringTab({ monitoringDisplayed, setMonitoringDisplayed }) {
                       &nbsp;&nbsp;
                       {displayedLocationsCount > 0 ? (
                         <a href={`${downloadUrl}&mimeType=csv`}>
-                          <i className="fas fa-file-csv" aria-hidden="true" />
+                          <HelpTooltip
+                            label="Download CSV"
+                            description="Download selected data as a CSV file."
+                          >
+                            <i className="fas fa-file-csv" aria-hidden="true" />
+                          </HelpTooltip>
                         </a>
                       ) : (
                         <i

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -214,7 +214,6 @@ const iconStyles = css`
 const infoBoxHeadingStyles = css`
   ${boxHeadingStyles};
   display: flex;
-  align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 0;
 

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -1972,10 +1972,14 @@ function FileLink({ disabled, fileType, data, setError, url }) {
 
   return (
     <button css={fileLinkStyles} onClick={fetchFile}>
-      <i className={`fas fa-file-${fileType}`} aria-hidden="true" />
-      <span className="sr-only">
-        Download location data as a {fileType} file.
-      </span>
+      <HelpTooltip
+        label={`Download ${mimeTypes[fileType].toUpperCase()}`}
+        description={`Download selected data as ${
+          fileType === 'excel' ? 'an' : 'a'
+        } ${mimeTypes[fileType].toUpperCase()} file.`}
+      >
+        <i className={`fas fa-file-${fileType}`} aria-hidden="true" />
+      </HelpTooltip>
     </button>
   );
 }

--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -78,16 +78,12 @@ function Tooltip({ children, label, triggerRef }: TooltipProps) {
 }
 
 type HelpTooltipProps = {
-  description?: string | null;
+  description?: string;
   children?: ReactElement;
   label: string;
 };
 
-function HelpTooltip({
-  description = null,
-  children,
-  label,
-}: HelpTooltipProps) {
+function HelpTooltip({ description, children, label }: HelpTooltipProps) {
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   return (
     <Tooltip label={label} triggerRef={triggerRef}>
@@ -103,7 +99,7 @@ function HelpTooltip({
             <i css={helpIconStyles} className="fas fa-question-circle" />
           )}
         </span>
-        <span className="sr-only">{description ?? 'Information Tooltip'}</span>
+        <span className="sr-only">{description || 'Information Tooltip'}</span>
       </button>
     </Tooltip>
   );

--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -92,13 +92,15 @@ function HelpTooltip({ description, children, label }: HelpTooltipProps) {
         onClick={(_ev) => triggerRef.current?.focus()}
         ref={triggerRef}
       >
-        <span aria-hidden>
-          {children ? (
-            children
-          ) : (
-            <i css={helpIconStyles} className="fas fa-question-circle" />
-          )}
-        </span>
+        {children ? (
+          children
+        ) : (
+          <i
+            aria-hidden
+            css={helpIconStyles}
+            className="fas fa-question-circle"
+          />
+        )}
         <span className="sr-only">{description || 'Information Tooltip'}</span>
       </button>
     </Tooltip>

--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -1,15 +1,20 @@
-// @flow
-
 import React, { useRef } from 'react';
 import { TooltipPopup, useTooltip } from '@reach/tooltip';
 import { css } from 'styled-components/macro';
 // styles
 import '@reach/tooltip/styles.css';
 import { colors } from 'styles';
+// types
+import type { Position } from '@reach/tooltip';
+import type { ReactElement, Ref } from 'react';
 
 /*
  * Styles
  */
+const helpIconStyles = css`
+  cursor: help;
+`;
+
 const tooltipIconStyles = css`
   background: none;
   border: none;
@@ -18,10 +23,6 @@ const tooltipIconStyles = css`
   margin: 0;
   outline: inherit;
   padding: 0;
-
-  i {
-    cursor: help;
-  }
 `;
 
 const tooltipStyles = css`
@@ -29,16 +30,17 @@ const tooltipStyles = css`
   border: none;
   border-radius: 6px;
   color: white;
+  max-width: 320px;
   padding: 0.5em 1em;
   text-align: center;
   white-space: normal;
-  width: 320px;
 `;
 
 /*
  * Helpers
  */
-function centered(triggerRect, tooltipRect) {
+const centered: Position = (triggerRect, tooltipRect) => {
+  if (!triggerRect || !tooltipRect) return {};
   const triggerCenter = triggerRect.left + triggerRect.width / 2;
   const left = triggerCenter - tooltipRect.width / 2;
   const maxLeft = document.body.clientWidth - tooltipRect.width;
@@ -46,13 +48,18 @@ function centered(triggerRect, tooltipRect) {
     left: Math.min(Math.max(2, left), maxLeft) + window.scrollX,
     top: triggerRect.bottom + 8 + window.scrollY,
   };
-}
+};
 
 /*
  * Components
  */
+type TooltipProps = {
+  children: ReactElement;
+  label: string;
+  triggerRef: Ref<HTMLElement>;
+};
 
-function Tooltip({ children, label, triggerRef }) {
+function Tooltip({ children, label, triggerRef }: TooltipProps) {
   const [trigger, tooltip] = useTooltip({
     ref: triggerRef,
   });
@@ -70,8 +77,18 @@ function Tooltip({ children, label, triggerRef }) {
   );
 }
 
-function HelpTooltip({ label }) {
-  const triggerRef = useRef();
+type HelpTooltipProps = {
+  description?: string | null;
+  children?: ReactElement;
+  label: string;
+};
+
+function HelpTooltip({
+  description = null,
+  children,
+  label,
+}: HelpTooltipProps) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   return (
     <Tooltip label={label} triggerRef={triggerRef}>
       <button
@@ -80,9 +97,13 @@ function HelpTooltip({ label }) {
         ref={triggerRef}
       >
         <span aria-hidden>
-          <i className="fas fa-question-circle" />
+          {children ? (
+            children
+          ) : (
+            <i css={helpIconStyles} className="fas fa-question-circle" />
+          )}
         </span>
-        <span className="sr-only">Information Tooltip</span>
+        <span className="sr-only">{description ?? 'Information Tooltip'}</span>
       </button>
     </Tooltip>
   );

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { css } from 'styled-components/macro';
 // components
+import HelpTooltip from 'components/shared/HelpTooltip';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
@@ -1501,7 +1502,9 @@ function MonitoringLocationsContent({
                       downloadUrl ? `${downloadUrl}&mimeType=xlsx` : undefined
                     }
                   >
-                    <i className="fas fa-file-excel" aria-hidden="true" />
+                    <HelpTooltip label="Download XLSX" description="Download selected data as an XLSX file.">
+                      <i className="fas fa-file-excel" aria-hidden="true" />
+                    </HelpTooltip>
                   </a>
                   &nbsp;&nbsp;
                   <a
@@ -1509,7 +1512,9 @@ function MonitoringLocationsContent({
                       downloadUrl ? `${downloadUrl}&mimeType=csv` : undefined
                     }
                   >
-                    <i className="fas fa-file-csv" aria-hidden="true" />
+                    <HelpTooltip label="Download CSV" description="Download selected data as a CSV file.">
+                      <i className="fas fa-file-csv" aria-hidden="true" />
+                    </HelpTooltip>
                   </a>
                 </span>
               </td>


### PR DESCRIPTION
## Related Issues:
* [HMW-295](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-295)

## Main Changes:
* Added short hover tooltips to the Monitoring Location download icons.
* Adjusted some styles.
* Converted the `HelpTooltip` component to TypeScript.

## Steps To Test:
1. Check that the file download tooltips properly appear when hovering over file download icons in 3 locations across the application:
    a. Beneath the "All Monitoring Locations" toggle table on the _Monitoring_ tab
    b. Beneath the checkboxes for individual monitoring locations (_Community_ page accordions and map popups) 
    c. At the bottom of the Download Section on the _Monitoring Report_ page