### PR TITLE
Feature/308 fix cultural tab not showing data

### DIFF
--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
@@ -67,6 +67,7 @@ function formatTopic(topic) {
   if (topic === 'swimming') return 'Recreation';
   if (topic === 'fishing') return 'Fish and Shellfish Consumption';
   if (topic === 'ecological') return 'Ecological Life';
+  if (topic === 'cultural') return 'Cultural';
   if (topic === 'other') return 'Other';
 }
 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-308

## Main Changes:
* Fixed issue of cultural data not showing up on the cultural tab.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/REDLAKE
2. Click on the `Cultural` tab
3. Verify that data now displays
