### PR TITLE
Feature/305 Add monitoring layers to all Community tabs

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -34,6 +34,7 @@ import {
 } from 'components/shared/KeyMetrics';
 // contexts
 import { CommunityTabsContext } from 'contexts/CommunityTabs';
+import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { formatNumber } from 'utils/utils';
@@ -85,6 +86,7 @@ function IdentifiedIssues() {
   const {
     permittedDischargers,
     dischargersLayer,
+    monitoringLocations,
     issuesLayer,
     waterbodyLayer,
     showAllPolluted,
@@ -97,6 +99,8 @@ function IdentifiedIssues() {
     cipSummary,
     watershed,
   } = useContext(LocationSearchContext);
+
+  const { usgsStreamgages } = useFetchedDataState();
 
   const [permittedDischargersData, setPermittedDischargersData] = useState({});
 
@@ -322,6 +326,7 @@ function IdentifiedIssues() {
   const updateVisibleLayers = useCallback(
     ({ key = null, newValue = null, useCurrentValue = false }) => {
       const newVisibleLayers = {};
+
       if (cipSummary.status !== 'failure') {
         newVisibleLayers['issuesLayer'] =
           !issuesLayer || useCurrentValue
@@ -335,6 +340,16 @@ function IdentifiedIssues() {
             : showDischargersLayer;
       }
 
+      if (monitoringLocations.status !== 'failure') {
+        newVisibleLayers['monitoringLocationsLayer'] =
+          visibleLayers['monitoringLocationsLayer'];
+      }
+
+      if (usgsStreamgages.status !== 'failure') {
+        newVisibleLayers['usgsStreamgagesLayer'] =
+          visibleLayers['usgsStreamgagesLayer'];
+      }
+
       if (newVisibleLayers.hasOwnProperty(key)) {
         newVisibleLayers[key] = newValue;
       }
@@ -345,13 +360,15 @@ function IdentifiedIssues() {
       }
     },
     [
-      dischargersLayer,
-      showDischargersLayer,
+      cipSummary,
       permittedDischargers,
+      monitoringLocations,
+      usgsStreamgages,
+      visibleLayers,
       issuesLayer,
       showIssuesLayer,
-      cipSummary,
-      visibleLayers,
+      dischargersLayer,
+      showDischargersLayer,
       setVisibleLayers,
     ],
   );

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -23,6 +23,7 @@ import ShowLessMore from 'components/shared/ShowLessMore';
 import ViewOnMapButton from 'components/shared/ViewOnMapButton';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 // contexts
+import { useFetchedDataState } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { useMapHighlightState } from 'contexts/MapHighlight';
@@ -188,6 +189,7 @@ function Protect() {
     watershed,
     highlightOptions,
     huc12,
+    monitoringLocations,
     statesData,
     visibleLayers,
     setVisibleLayers,
@@ -202,6 +204,8 @@ function Protect() {
     cipSummary,
     allWaterbodiesLayer,
   } = useContext(LocationSearchContext);
+
+  const { usgsStreamgages } = useFetchedDataState();
 
   const { infoToggleChecked } = useContext(CommunityTabsContext);
 
@@ -315,6 +319,16 @@ function Protect() {
             : false;
       }
 
+      if (monitoringLocations.status !== 'failure') {
+        newVisibleLayers['monitoringLocationsLayer'] =
+          visibleLayers['monitoringLocationsLayer'];
+      }
+
+      if (usgsStreamgages.status !== 'failure') {
+        newVisibleLayers['usgsStreamgagesLayer'] =
+          visibleLayers['usgsStreamgagesLayer'];
+      }
+
       if (newVisibleLayers.hasOwnProperty(key)) {
         newVisibleLayers[key] = newValue;
       }
@@ -326,6 +340,8 @@ function Protect() {
     },
     [
       healthScoresDisplayed,
+      monitoringLocations,
+      usgsStreamgages,
       wsioHealthIndexLayer,
       wsioHealthIndexData,
       protectedAreasDisplayed,

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -308,10 +308,10 @@ const tabs = [
     upper: <OverviewUpper />,
     lower: <Overview />,
     layers: {
-      waterbodyLayer: true,
+      dischargersLayer: false,
       monitoringLocationsLayer: false,
       usgsStreamgagesLayer: false,
-      dischargersLayer: false,
+      waterbodyLayer: true,
     },
   },
   {
@@ -321,6 +321,8 @@ const tabs = [
     upper: <SwimmingUpper />,
     lower: <Swimming />,
     layers: {
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       waterbodyLayer: true,
     },
   },
@@ -331,6 +333,8 @@ const tabs = [
     upper: <EatingFishUpper />,
     lower: <EatingFish />,
     layers: {
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       waterbodyLayer: true,
     },
   },
@@ -341,6 +345,8 @@ const tabs = [
     upper: <AquaticLifeUpper />,
     lower: <AquaticLife />,
     layers: {
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       waterbodyLayer: true,
     },
   },
@@ -352,6 +358,8 @@ const tabs = [
     lower: <DrinkingWater />,
     layers: {
       boundariesLayer: false,
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       waterbodyLayer: false,
       providersLayer: true,
     },
@@ -378,6 +386,8 @@ const tabs = [
     layers: {
       issuesLayer: true,
       dischargersLayer: true,
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
     },
   },
   {
@@ -387,6 +397,8 @@ const tabs = [
     upper: <RestoreUpper />,
     lower: <Restore />,
     layers: {
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       waterbodyLayer: false,
     },
   },
@@ -397,6 +409,8 @@ const tabs = [
     upper: <ProtectUpper />,
     lower: <Protect />,
     layers: {
+      monitoringLocationsLayer: false,
+      usgsStreamgagesLayer: false,
       wsioHealthIndexLayer: false,
       wildScenicRiversLayer: false,
       protectedAreasLayer: false,


### PR DESCRIPTION
## Related Issues:
* [HMW-305](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-305)

## Main Changes:
* Added the _Current Water Conditions_ and _Past Water Conditions_ layers to the layer list on all tabs on the Community page.

## Steps To Test:
1. Confirm that the layers appear in the layer on all tabs
2. The layers should not initially be visible, except on the Monitoring sub-tab