### PR TITLE
Feature/306 wfs layer support

### DIFF
--- a/app/client/src/components/pages/Swimming.js
+++ b/app/client/src/components/pages/Swimming.js
@@ -55,7 +55,7 @@ function Swimming() {
           Learn whether your local waters have been deemed safe for swimming and
           other recreational activities. Find out about what impairments exist
           in your local waterbodies. Water quality can change on very short
-          notice. When deciding if it is safe to swim in a water body, refer to
+          notice. When deciding if it is safe to swim in a waterbody, refer to
           any local or state advisories. If available, refer to local or state
           real-time water quality reports.
         </p>

--- a/app/client/src/components/shared/AddDataWidget.URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget.URLPanel.js
@@ -13,6 +13,8 @@ import CSVLayer from '@arcgis/core/layers/CSVLayer';
 import GeoRSSLayer from '@arcgis/core/layers/GeoRSSLayer';
 import KMLLayer from '@arcgis/core/layers/KMLLayer';
 import Layer from '@arcgis/core/layers/Layer';
+import WCSLayer from '@arcgis/core/layers/WCSLayer';
+import WFSLayer from '@arcgis/core/layers/WFSLayer';
 import WMSLayer from '@arcgis/core/layers/WMSLayer';
 // components
 import { linkButtonStyles } from 'components/shared/LinkButton';
@@ -136,13 +138,15 @@ function URLPanel() {
         });
       return;
     }
+    if (type === 'WCS') {
+      newLayer = new WCSLayer({ url });
+    }
+    if (type === 'WFS') {
+      newLayer = new WFSLayer({ url });
+    }
     if (type === 'WMS') {
       newLayer = new WMSLayer({ url });
     }
-    /* // not supported in 4.x js api
-        if(type === 'WFS') {
-          layer = new WFSLayer({ url });
-        } */
     if (type === 'KML') {
       newLayer = new KMLLayer({ url });
     }
@@ -184,8 +188,9 @@ function URLPanel() {
         }}
         options={[
           { value: 'ArcGIS', label: 'An ArcGIS Server Web Service' },
+          { value: 'WCS', label: 'A WCS OGC Web Service' },
           { value: 'WMS', label: 'A WMS OGC Web Service' },
-          // {value: 'WFS', label: 'A WFS OGC Web Service'}, // not supported in 4.x yet
+          { value: 'WFS', label: 'A WFS OGC Web Service' },
           { value: 'KML', label: 'A KML File' },
           { value: 'GeoRSS', label: 'A GeoRSS File' },
           { value: 'CSV', label: 'A CSV File' },
@@ -239,8 +244,13 @@ function URLPanel() {
               <p>
                 http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Cities/FeatureServer/0
               </p>
+              <p>https://giswebservices.massgis.state.ma.us/geoserver/wfs</p>
+            </div>
+          )}
+          {urlType.value === 'WCS' && (
+            <div>
               <p>
-                http://services.arcgisonline.com/ArcGIS/rest/services/Demographics/USA_Tapestry/MapServer
+                https://sampleserver6.arcgisonline.com/arcgis/services/ScientificData/SeaTemperature/ImageServer/WCSServer
               </p>
             </div>
           )}
@@ -251,13 +261,14 @@ function URLPanel() {
               </p>
             </div>
           )}
-          {/* Not supported in 4.x JS API
           {urlType.value === 'WFS' && (
             <div>
-              <p>https://dservices.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/services/JapanPrefectures2018/WFSServer</p>
+              <p>https://giswebservices.massgis.state.ma.us/geoserver/wfs</p>
+              <p>
+                https://dservices.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/services/JapanPrefectures2018/WFSServer
+              </p>
             </div>
-          )} 
-          */}
+          )}
           {urlType.value === 'KML' && (
             <div>
               <p>

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -75,7 +75,7 @@ function SwimmingUpper() {
         <ShowLessMore
           charLimit={0}
           text=" Water quality can change on very short notice. When deciding if
-            it is safe to swim in a water body, refer to any local or state
+            it is safe to swim in a waterbody, refer to any local or state
             advisories. If available, refer to local or state real-time water
             quality reports."
         />


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-306
* https://jira.epa.gov/browse/HMW-303

## Main Changes:
* Added WCS and WFS layer support to the add data widget.
* Update the sample url options, since some layers have been deleted and no longer work.
* Updated text from "water body" to "waterbody". I did a search across the app and found two places (swimming page and swimming panel on the community page).

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the add data widget and click on the URL tab
3. Select `A WCS OGC Web Service` in the `Type` dropdown
4. Click `SAMPLE URL(S)`
5. Copy/paste the url into the `URL` input and click `Add`
6. Verify the layer shows up on the map 
7. Select `A WFS OGC Web Service` in the `Type` dropdown
8. Repeat steps 5 and 6
9. Navigate to http://localhost:3000/swimming
10. Verify the page says "waterbody" instead of "water body"
11. Navigate to http://localhost:3000/community/dc/swimming
12. Verify the page says "waterbody" instead of "water body"

