### PR TITLE
feature/251_cloudgov-log-fixes

### DIFF
--- a/app/server/app/server/routes/proxy.js
+++ b/app/server/app/server/routes/proxy.js
@@ -68,6 +68,10 @@ module.exports = function (app) {
       function deleteTSHeaders(response) {
         if (!response) return;
 
+        /* This is a workaround for an issue where service responses don't 
+          include headers. */
+        if (!response.headers) response.headers = {};
+
         /* The EPA Terminology Services (TS) exposes sensitive 
           information about its underlying technology. While we 
           notified the TS Team about this, they have not had time 


### PR DESCRIPTION
## Related Issues:
* https://jira.epa.gov/browse/HMW-251

## Main Changes:
* Fixed an issue with the proxy code attempting to delete headers from a response that has no headers.

## Steps To Test:
Not really much to test here. Just run the app and verify service calls still work (i.e., glossary loads, community page search works, etc.). 

