### PR TITLE
Feature/304 sort dischargers by compliance

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -86,29 +86,6 @@ const toggleStyles = css`
   }
 `;
 
-const complianceRank = {
-  Significant: 0,
-  'Significant/Category I Noncompliance': 0,
-  'Violation Identified': 1,
-  Unknown: 2,
-  'No Violation Identified': 3,
-};
-
-function sortDischarchers(discharchers, sortBy) {
-  if (sortBy === 'CWPStatus') {
-    return discharchers.sort((a, b) => {
-      return (
-        (complianceRank[a.CWPStatus] ?? complianceRank.Unknown) -
-        (complianceRank[b.CWPStatus] ?? complianceRank.Unknown)
-      );
-    });
-  } else {
-    return discharchers.sort((a, b) => {
-      return a[sortBy].localeCompare(b[sortBy]);
-    });
-  }
-}
-
 function Overview() {
   const { usgsStreamgages } = useFetchedDataState();
 
@@ -811,6 +788,30 @@ function MonitoringAndSensorsTab({
   return null;
 }
 
+const complianceRank = {
+  Significant: 0,
+  'Significant/Category I Noncompliance': 0,
+  'Violation Identified': 1,
+  'No Violation': 2,
+  'No Violation Identified': 2,
+  Unknown: 3,
+};
+
+function sortDischarchers(discharchers, sortBy) {
+  if (sortBy === 'CWPStatus') {
+    return discharchers.sort((a, b) => {
+      return (
+        (complianceRank[a.CWPStatus] ?? complianceRank.Unknown) -
+        (complianceRank[b.CWPStatus] ?? complianceRank.Unknown)
+      );
+    });
+  } else {
+    return discharchers.sort((a, b) => {
+      return a[sortBy].localeCompare(b[sortBy]);
+    });
+  }
+}
+
 function PermittedDischargersTab({ totalPermittedDischargers }) {
   const navigate = useNavigate();
   const { permittedDischargers, dischargersLayer, watershed } = useContext(
@@ -888,6 +889,8 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
             {sortedPermittedDischargers.map((discharger, index) => {
               const id = discharger.SourceID;
               const name = discharger.CWPName;
+              const status = discharger.CWPStatus;
+
               const feature = {
                 geometry: {
                   type: 'point',
@@ -896,11 +899,18 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
                 },
                 attributes: discharger,
               };
+
               return (
                 <AccordionItem
                   key={index}
                   title={<strong>{name || 'Unknown'}</strong>}
-                  subTitle={<>NPDES ID: {id}</>}
+                  subTitle={
+                    <>
+                      NPDES ID: {id}
+                      <br />
+                      Compliance Status: {status}
+                    </>
+                  }
                   feature={feature}
                   idKey="CWPName"
                 >

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -86,6 +86,29 @@ const toggleStyles = css`
   }
 `;
 
+const complianceRank = {
+  Significant: 0,
+  'Significant/Category I Noncompliance': 0,
+  'Violation Identified': 1,
+  Unknown: 2,
+  'No Violation Identified': 3,
+};
+
+function sortDischarchers(discharchers, sortBy) {
+  if (sortBy === 'CWPStatus') {
+    return discharchers.sort((a, b) => {
+      return (
+        (complianceRank[a.CWPStatus] ?? complianceRank.Unknown) -
+        (complianceRank[b.CWPStatus] ?? complianceRank.Unknown)
+      );
+    });
+  } else {
+    return discharchers.sort((a, b) => {
+      return a[sortBy].localeCompare(b[sortBy]);
+    });
+  }
+}
+
 function Overview() {
   const { usgsStreamgages } = useFetchedDataState();
 
@@ -810,11 +833,7 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
 
   /* prettier-ignore */
   const sortedPermittedDischargers = permittedDischargers.data.Results?.Facilities
-    ? permittedDischargers.data.Results.Facilities.sort((a, b) => {
-        return a[permittedDischargersSortedBy].localeCompare(
-          b[permittedDischargersSortedBy],
-        );
-      })
+    ? sortDischarchers(permittedDischargers.data.Results.Facilities, permittedDischargersSortedBy)
     : [];
 
   if (permittedDischargers.status === 'fetching') {
@@ -859,6 +878,10 @@ function PermittedDischargersTab({ totalPermittedDischargers }) {
               {
                 value: 'SourceID',
                 label: 'NPDES ID',
+              },
+              {
+                value: 'CWPStatus',
+                label: 'Compliance Status',
               },
             ]}
           >


### PR DESCRIPTION
## Related Issues:
* [HMW-304](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-304)

## Main Changes:
* Added a sort option to the _Permitted Dischargers_ sub-tab of the _Overview_ tab to sort by CWA compliance status.
* Established a rank for each status to enable sorting.

## Steps To Test:
1. Visit a location where the dischargers express the full spectrum of compliance statuses, such as [Louisville, KY](http://localhost:3000/community/Louisville,%20KY,%20USA/overview)
2. While on the _Overview_ tab, click on the _Permitted Dischargers_ sub-tab
3. In the "Sort by" drop-down input, select "Compliance Status"
4. Accordion items should be sorted as **Significant/Category I Noncompliance -> Violation Identified -> No Violation Identified -> Unknown**

*NOTE* The status labels **Significant** and **No Violation** are included in the rankings and given the same values as the **Significant/Category I Noncompliance** and **No Violation Identified**, respectively, but these may not be necessary.

## TODO:
- [ ] Determine if more status labels need to be added to the rankings.
