### PR TITLE
Bugfix/317 Characteristic chart capitalization

### DIFF
--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -50,7 +50,7 @@ import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { fetchCheck, fetchPost } from 'utils/fetchUtils';
 import { useSharedLayers } from 'utils/hooks';
 import { getPopupContent, getPopupTitle } from 'utils/mapFunctions';
-import { parseAttributes, titleCaseWithExceptions } from 'utils/utils';
+import { parseAttributes } from 'utils/utils';
 // styles
 import {
   boxStyles,
@@ -1230,10 +1230,8 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
     <div css={modifiedBoxStyles}>
       <h2 css={infoBoxHeadingStyles}>
         Chart of Results for{' '}
-        {!charcName
-          ? 'Selected Characteristic'
-          : titleCaseWithExceptions(charcName)}
-        <HelpTooltip label="Adjust the slider handles to filter the data displayed on the chart by the selected year range, and use the drop-down inputs to filter  the data by the corresponding fields" />
+        {!charcName ? 'Selected Characteristic' : charcName}
+        <HelpTooltip label="Adjust the slider handles to filter the data displayed on the chart by the selected year range, and use the drop-down inputs to filter the data by the corresponding fields" />
       </h2>
       <StatusContent
         empty={


### PR DESCRIPTION
## Related Issues:
* [HMW-317](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-317)

## Main Changes:
* Instead of passing characteristic names through the `titleCaseWithExceptions` function on the _Monitoring Report_ page, the characteristic names are used as-is for the chart title.

## Steps To Test:
1. Go to [http://localhost:3000/monitoring-report/STORET/21SCSANT/21SCSANT-SC-034/](http://localhost:3000/monitoring-report/STORET/21SCSANT/21SCSANT-SC-034/)
2. Select a characteristic from the chart with an element symbol or acronym in the name, such as **Alkalinity, Carbonate as CaCO3**
3. Confirm that the chart title is properly capitalized, i.e. "Chart of Results for Alkalinity, Carbonate as CaCO3"
