### PR TITLE
Feature/328 as infinite loading spinner

### DIFF
--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -67,9 +67,6 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
 
   const [layers, setLayers] = useState(null);
 
-  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [actionsMapLoadError, setActionsMapLoadError] = useState(false);
-
   const services = useServicesContext();
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
@@ -402,12 +399,8 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     setMapLoading(false);
   }, [fetchStatus, mapView, actionsLayer, homeWidget]);
 
-  // check for browser compatibility with map
-  if (!browserIsCompatibleWithArcGIS() && !actionsMapLoadError) {
-    setActionsMapLoadError(true);
-  }
-
-  if (actionsMapLoadError) {
+  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
+  if (!browserIsCompatibleWithArcGIS()) {
     return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
   }
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -608,9 +608,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setWaterbodyCountMismatch,
   ]);
 
-  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [communityMapLoadError, setCommunityMapLoadError] = useState(false);
-
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
@@ -2219,11 +2216,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setMapLoading(false);
   }, [waterbodyLayer, cipSummary, waterbodyFeatures]);
 
-  // check for browser compatibility with map
-  if (!browserIsCompatibleWithArcGIS() && !communityMapLoadError) {
-    setCommunityMapLoadError(true);
-  }
-
   // jsx
   const mapContent = (
     <>
@@ -2248,7 +2240,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     </>
   );
 
-  if (communityMapLoadError) {
+  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
+  if (!browserIsCompatibleWithArcGIS()) {
     return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
   }
 

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -98,11 +98,8 @@ function StateMap({
 
   const [layers, setLayers] = useState(null);
 
-  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  // and webservice errors
-  const [stateMapLoadError, setStateMapLoadError] = useState('');
-
   const [noGisDataAvailable, setNoGisDataAvailable] = useState(false);
+  const [stateMapLoadError, setStateMapLoadError] = useState(false);
 
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight(false);
@@ -244,8 +241,8 @@ function StateMap({
       numberOfRecords
     ) {
       setLastFilter(filter);
-      setStateMapLoadError('');
       setNoGisDataAvailable(false);
+      setStateMapLoadError(false);
 
       // change the where clause of the feature layers
       if (!filter) return;
@@ -323,17 +320,17 @@ function StateMap({
                 })
                 .catch((err) => {
                   console.error(err);
-                  setStateMapLoadError(huc12SummaryError);
+                  setStateMapLoadError(true);
                 });
             })
             .catch((err) => {
               console.error(err);
-              setStateMapLoadError(huc12SummaryError);
+              setStateMapLoadError(true);
             });
         })
         .catch((err) => {
           console.error(err);
-          setStateMapLoadError(huc12SummaryError);
+          setStateMapLoadError(true);
         });
     }
   }, [
@@ -391,11 +388,6 @@ function StateMap({
   const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
   const mapInputsHeight = mapInputs && mapInputs.getBoundingClientRect().height;
 
-  // check for browser compatibility with map
-  if (!browserIsCompatibleWithArcGIS() && !stateMapLoadError) {
-    setStateMapLoadError(esriMapLoadingFailure);
-  }
-
   // jsx
   const mapContent = (
     <div
@@ -441,8 +433,13 @@ function StateMap({
     </div>
   );
 
+  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
+  if (!browserIsCompatibleWithArcGIS()) {
+    return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
+  }
+
   if (stateMapLoadError) {
-    return <div css={errorBoxStyles}>{stateMapLoadError}</div>;
+    return <div css={errorBoxStyles}>{huc12SummaryError}</div>;
   }
 
   if (noGisDataAvailable) {

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -25,7 +25,7 @@ import {
 } from 'utils/mapFunctions';
 import MapErrorBoundary from 'components/shared/ErrorBoundary.MapErrorBoundary';
 // styled components
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 // contexts
 import { useFetchedDataDispatch } from 'contexts/FetchedData';
 import { LocationSearchContext } from 'contexts/locationSearch';
@@ -99,7 +99,10 @@ function StateMap({
   const [layers, setLayers] = useState(null);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
+  // and webservice errors
   const [stateMapLoadError, setStateMapLoadError] = useState('');
+
+  const [noGisDataAvailable, setNoGisDataAvailable] = useState(false);
 
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight(false);
@@ -242,6 +245,7 @@ function StateMap({
     ) {
       setLastFilter(filter);
       setStateMapLoadError('');
+      setNoGisDataAvailable(false);
 
       // change the where clause of the feature layers
       if (!filter) return;
@@ -314,9 +318,7 @@ function StateMap({
                     }
                   } else {
                     setMapLoading(false);
-                    setStateMapLoadError(
-                      stateNoGisDataError(activeState.label),
-                    );
+                    setNoGisDataAvailable(true);
                   }
                 })
                 .catch((err) => {
@@ -335,7 +337,6 @@ function StateMap({
         });
     }
   }, [
-    activeState.label,
     areasLayer,
     filter,
     homeWidget,
@@ -442,6 +443,12 @@ function StateMap({
 
   if (stateMapLoadError) {
     return <div css={errorBoxStyles}>{stateMapLoadError}</div>;
+  }
+
+  if (noGisDataAvailable) {
+    return (
+      <div css={infoBoxStyles}>{stateNoGisDataError(activeState.label)}</div>
+    );
   }
 
   if (layout === 'wide') {

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -186,9 +186,6 @@ function TribalMapList({
   const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
     useState(true);
 
-  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
-  const [tribeMapLoadError, setTribeMapLoadError] = useState(false);
-
   const reportStatusMapping = useReportStatusMappingContext();
   const services = useServicesContext();
 
@@ -382,12 +379,8 @@ function TribalMapList({
     setFooterHeight(node.getBoundingClientRect().height);
   }, []);
 
-  // check for browser compatibility with map
-  if (!browserIsCompatibleWithArcGIS() && !tribeMapLoadError) {
-    setTribeMapLoadError(true);
-  }
-
-  if (tribeMapLoadError) {
+  // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
+  if (!browserIsCompatibleWithArcGIS()) {
     return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
   }
 

--- a/app/client/src/components/shared/VirtualizedList.tsx
+++ b/app/client/src/components/shared/VirtualizedList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useWindowSize } from '@reach/window-size';
 import { VariableSizeList } from 'react-window';
 import throttle from 'lodash/throttle';
@@ -109,11 +109,11 @@ function VirtualizedListInner({ items, renderer }: Props) {
 // or jump around when the list is not immediatly visible
 // on the dom (i.e., the list is on the second tab).
 function VirtualizedList({ items, renderer }: Props) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const isVisible = useOnScreen(ref?.current);
+  const [ref, setRef] = useState<HTMLDivElement | null>(null);
+  const isVisible = useOnScreen(ref);
 
   return (
-    <div ref={ref}>
+    <div ref={newRef => setRef(newRef)}>
       {isVisible && <VirtualizedListInner items={items} renderer={renderer} />}
     </div>
   );

--- a/app/client/src/components/shared/WaterbodyListVirtualized.tsx
+++ b/app/client/src/components/shared/WaterbodyListVirtualized.tsx
@@ -160,6 +160,11 @@ function WaterbodyListVirtualized({ waterbodies, fieldName = null }: Props) {
             const auId = graphic.attributes.assessmentunitidentifier;
             const name = graphic.attributes.assessmentunitname;
 
+            const viewOnMapDisabled = 
+              graphic.attributes.area_count === 0 &&
+              graphic.attributes.line_count === 0 &&
+              graphic.attributes.point_count === 0;
+
             return (
               <AccordionItem
                 key={symbolType + orgId + auId}
@@ -187,7 +192,7 @@ function WaterbodyListVirtualized({ waterbodies, fieldName = null }: Props) {
                     type="Waterbody State Overview"
                     feature={graphic}
                   />
-                  <ViewOnMapButton feature={graphic} />
+                  <ViewOnMapButton feature={graphic} disabled={viewOnMapDisabled} />
                 </div>
               </AccordionItem>
             );

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -146,7 +146,10 @@ export const stateGeneralError = (source = 'State') =>
 
 // if an invalid state is entered
 export const stateNoDataError = (stateName) =>
-  `No data available ${stateName && 'for ' + stateName}.`; // conditionals in case state name is undefined or an empty string
+  `No data available${stateName && ' for ' + stateName}.`; // conditionals in case state name is undefined or an empty string
+
+export const stateNoGisDataError = (stateName) =>
+  `No map data available${stateName && ' for ' + stateName}.`; // conditionals in case state name is undefined or an empty string
 
 export const status303dError =
   'There was an issue looking up the 303(d) List Status code. Because of this, the status code may not look familiar.';
@@ -251,7 +254,7 @@ export const defaultErrorBoundaryMessage = (
 );
 
 // message displayed when the Esri map fails to load due to incompatible browsers and devices
-export const esriMapLoadingFailure = `The How's My Waterway Map is currently unavailable. Your web browser is
+export const esriMapLoadingFailure = `The How's My Waterway Map is unavailable. Your web browser is
 incompatible or outdated.`;
 
 export const educatorContentError =


### PR DESCRIPTION
## Related Issues:
* [HMW-328](https://jira.epa.gov/browse/HMW-328)

## Main Changes:
* Fixed an issue with an infinite loading spinner on the State Advanced Search page for American Samoa.
  * This issue is happening because we query the `Attribute Summary Table` which returns 88 records and then we query the GIS layers which return 0 records. The `Attribute Summary Table` is not guaranteed to have GIS data. I just added some better layer handling around this code.
* Fixed an issue with the list view, on the State Advanced Search page, not displaying when switching from map view to list view. Users could still get the data to display by clicking `Expand All` or sometimes by scrolling.
  * We were intending for the `useRef` to rerender the `VirtualizedList` component the ref is initially set. The problem is that `useRef` does not rerender components when the ref is updated. To fix this issue I switched from using `useRef` to `useState` for storing the ref. 
* Fixed an issue with the View On Map button, on the State Advanced Search page, being clickable for waterbodies that don't have GIS data.
  * This issue is happening because the State Advanced Search page queries the `Attribute Summary Table` which is not guaranteed to have GIS data. To fix this I just added code to disable the View On Map button if the `area_count`, `line_count`, and `point_count` fields are all 0. 

## Steps To Test:
1. Navigate to http://localhost:3000/state/AS/advanced-search
2. Click `Search`
3. Verify the `No map data available for American Samoa.` message is displayed
4. Click `List`
5. Verify the list is populated
6. Expand a few items and verify the `View On Map` button is disabled
7. Navigate to http://localhost:3000/state/AL/advanced-search
8. Click `Search`
9. Verify the map loads and displays data
10. Click `List`
11. Verify the list is populated
12. Expand a few items and verify the `View On Map` button is enabled and works

