### PR TITLE
Feature/329 Impairments glossary links

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -146,10 +146,7 @@ function IdentifiedIssues() {
   }, [dischargersLayer, showDischargersLayer, violatingFacilities, navigate]);
 
   // translate scientific parameter names
-  const getMappedParameterName = (
-    parameterFields: Object,
-    parameter: string,
-  ) => {
+  const getMappedParameter = (parameterFields: Object, parameter: string) => {
     const filteredFields = parameterFields.filter(
       (field) => parameter === field.parameterGroup,
     )[0];
@@ -386,13 +383,13 @@ function IdentifiedIssues() {
 
     // get a list of all parameters displayed in table and push them to array
     cipSummaryData.items[0].summaryByParameterImpairments.forEach((param) => {
-      const mappedParameterName = getMappedParameterName(
+      const mappedParameter = getMappedParameter(
         impairmentFields,
         param['parameterGroupName'],
       );
 
-      if (mappedParameterName) {
-        parameters.push(mappedParameterName.label);
+      if (mappedParameter) {
+        parameters.push(mappedParameter.label);
       }
     });
 
@@ -745,37 +742,34 @@ function IdentifiedIssues() {
                                     ),
                                   );
 
-                                  const mappedParameterName =
-                                    getMappedParameterName(
-                                      impairmentFields,
-                                      param['parameterGroupName'],
-                                    );
+                                  const mappedParameter = getMappedParameter(
+                                    impairmentFields,
+                                    param['parameterGroupName'],
+                                  );
                                   // if service contains a parameter we have no mapping for
-                                  if (!mappedParameterName) return false;
+                                  if (!mappedParameter) return false;
 
                                   return (
-                                    <tr key={mappedParameterName.label}>
+                                    <tr key={mappedParameter.label}>
                                       <td>
                                         <div css={toggleStyles}>
                                           <Switch
-                                            ariaLabel={
-                                              mappedParameterName.label
-                                            }
+                                            ariaLabel={mappedParameter.label}
                                             checked={
                                               parameterToggleObject[
-                                                mappedParameterName.label
+                                                mappedParameter.label
                                               ]
                                             }
                                             onChange={(ev) => {
                                               toggleSwitch(
-                                                mappedParameterName.label,
+                                                mappedParameter.label,
                                               );
                                             }}
                                           />
                                           <GlossaryTerm
-                                            term={mappedParameterName.term}
+                                            term={mappedParameter.term}
                                           >
-                                            {mappedParameterName.label}
+                                            {mappedParameter.label}
                                           </GlossaryTerm>
                                         </div>
                                       </td>

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -157,7 +157,7 @@ function IdentifiedIssues() {
       return null;
     }
 
-    return filteredFields.label;
+    return filteredFields;
   };
 
   const checkWaterbodiesToDisplay = useCallback(() => {
@@ -392,7 +392,7 @@ function IdentifiedIssues() {
       );
 
       if (mappedParameterName) {
-        parameters.push(mappedParameterName);
+        parameters.push(mappedParameterName.label);
       }
     });
 
@@ -754,21 +754,29 @@ function IdentifiedIssues() {
                                   if (!mappedParameterName) return false;
 
                                   return (
-                                    <tr key={mappedParameterName}>
+                                    <tr key={mappedParameterName.label}>
                                       <td>
                                         <div css={toggleStyles}>
                                           <Switch
-                                            ariaLabel={mappedParameterName}
+                                            ariaLabel={
+                                              mappedParameterName.label
+                                            }
                                             checked={
                                               parameterToggleObject[
-                                                mappedParameterName
+                                                mappedParameterName.label
                                               ]
                                             }
                                             onChange={(ev) => {
-                                              toggleSwitch(mappedParameterName);
+                                              toggleSwitch(
+                                                mappedParameterName.label,
+                                              );
                                             }}
                                           />
-                                          <span>{mappedParameterName}</span>
+                                          <GlossaryTerm
+                                            term={mappedParameterName.term}
+                                          >
+                                            {mappedParameterName.label}
+                                          </GlossaryTerm>
                                         </div>
                                       </td>
                                       <td>


### PR DESCRIPTION
## Related Issues:
* [HMW-329](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-329)

## Main Changes:
* Added glossary links to the impairment names on the _Identified Issues_.

## Steps To Test:
1. Visit the _Identified Issues_ tab of a watershed on the Community page, e.g. [http://localhost:3000/community/dc/identified-issues](http://localhost:3000/community/dc/identified-issues)
2. Confirm that each of the identified issues listed has a glossary link, and that each links to the correct definition