### PR TITLE
HMW-330 Fixed issues with keyboard navigation on the community search…

### DIFF
--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -2,6 +2,7 @@
 
 import React, {
   Fragment,
+  useCallback,
   useContext,
   useEffect,
   useRef,
@@ -487,45 +488,52 @@ function LocationSearch({ route, label }: Props) {
     }
   }, [resultsCombined, upPress]);
 
+  // Performs the search operation
+  const formSubmit = useCallback(
+    (newSearchTerm, geometry = null) => {
+      setSuggestionsVisible(false);
+      setCursor(-1);
+
+      newSearchTerm = newSearchTerm.replace(/[\n\r\t/]/g, ' ');
+
+      if (containsScriptTag(newSearchTerm)) {
+        setErrorMessage(invalidSearchError);
+        return;
+      }
+
+      // get urlSearch parameter value
+      let urlSearch = null;
+      if (geometry) {
+        urlSearch = `${newSearchTerm.trim()}|${geometry.longitude}, ${
+          geometry.latitude
+        }`;
+      } else if (newSearchTerm) {
+        urlSearch = newSearchTerm.trim();
+      }
+
+      // navigate if the urlSearch value is available
+      if (urlSearch) {
+        setErrorMessage('');
+        setGeolocationError(false);
+
+        // only navigate if search box contains text
+        navigate(encodeURI(route.replace('{urlSearch}', urlSearch)));
+      }
+    },
+    [navigate, route],
+  );
+
   // Handle enter key press (search input)
   useEffect(() => {
-    if (resultsCombined.length === 0 || !enterPress) return;
-    if (cursor < 0 || cursor > resultsCombined.length) return;
-    if (resultsCombined[cursor].text)
+    if (!enterPress || cursor < -1 || cursor > resultsCombined.length) return;
+
+    if (cursor === -1 || resultsCombined.length === 0) {
+      formSubmit(inputText);
+    } else if (resultsCombined[cursor].text) {
       setInputText(resultsCombined[cursor].text);
-  }, [cursor, enterPress, resultsCombined]);
-
-  // Performs the search operation
-  function formSubmit(newSearchTerm, geometry = null) {
-    setSuggestionsVisible(false);
-    setCursor(-1);
-
-    newSearchTerm = newSearchTerm.replace(/[\n\r\t/]/g, ' ');
-
-    if (containsScriptTag(newSearchTerm)) {
-      setErrorMessage(invalidSearchError);
-      return;
+      formSubmit(resultsCombined[cursor].text);
     }
-
-    // get urlSearch parameter value
-    let urlSearch = null;
-    if (geometry) {
-      urlSearch = `${newSearchTerm.trim()}|${geometry.longitude}, ${
-        geometry.latitude
-      }`;
-    } else if (newSearchTerm) {
-      urlSearch = newSearchTerm.trim();
-    }
-
-    // navigate if the urlSearch value is available
-    if (urlSearch) {
-      setErrorMessage('');
-      setGeolocationError(false);
-
-      // only navigate if search box contains text
-      navigate(encodeURI(route.replace('{urlSearch}', urlSearch)));
-    }
-  }
+  }, [cursor, enterPress, formSubmit, inputText, resultsCombined]);
 
   // Splits the provided text by the searchString in a case insensitive way.
   function getHighlightParts(text, searchString) {
@@ -557,8 +565,8 @@ function LocationSearch({ route, label }: Props) {
     return parts;
   }
 
-  let index = -1;
-  function LayerSuggestions({ title, source }) {
+  function LayerSuggestions({ title, source, startIndex }) {
+    let index = 0;
     return (
       <>
         <div className="esri-menu__header">{title}</div>
@@ -566,8 +574,8 @@ function LocationSearch({ route, label }: Props) {
           role="presentation"
           className="esri-menu__list esri-search__suggestions-list"
         >
-          {source.results.map((result) => {
-            index = index + 1;
+          {source.results.map((result, idx) => {
+            index = startIndex + idx;
             return (
               <li
                 id={`search-suggestion-${index}`}
@@ -737,6 +745,8 @@ function LocationSearch({ route, label }: Props) {
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [suggestionsRef]);
+
+  let layerEndIndex = -1;
 
   return (
     <>
@@ -921,12 +931,15 @@ function LocationSearch({ route, label }: Props) {
                     }
                     if (source.results.length === 0) return null;
 
+                    layerEndIndex += source.results.length;
+
                     const title = findGroupName();
                     return (
                       <LayerSuggestions
                         key={`layer-suggestions-key-${suggestIndex}`}
                         title={title}
                         source={source}
+                        startIndex={layerEndIndex - (source.results.length - 1)}
                       />
                     );
                   })}


### PR DESCRIPTION
While I was testing one of the other PRs, I noticed that keyboard navigation isn't working on the community page search box (i.e., hitting enter should search, up/down arrows should scroll through suggestions, etc.). It's working on production and staging, so it is a new bug. I looked through our pull requests since the last release and didn't see anything that looked like it would cause this issue. I refactored the keyboard navigation code so it should be more resiliant now. 

## Related Issues:
* [HMW-330](https://jira.epa.gov/browse/HMW-330)

## Main Changes:
* Fixed issues with keyboard navigation on the community search box.

## Steps To Test:
1. Navigate to http://localhost:3000/
2. Start typing in the search box
3. Verify the up/down arrows navigate through the suggestions list
4. Verify the enter key selects the suggestion and searches for it
5. Start typing in the search box and hit the enter key without selecting any suggestions
6. Verify the app searches for the text you typed

