### PR TITLE
Feature/331 add surr monitoring to other pages

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -52,7 +52,14 @@ import resizeIcon from 'images/resize.png';
 // types
 import type { CSSProperties, Dispatch, SetStateAction } from 'react';
 import type { Container } from 'react-dom';
-import type { ExtendedLayer, Feature, FetchState, ScaledLayer, ServicesState, MonitoringLocationsData } from 'types';
+import type {
+  ExtendedLayer,
+  Feature,
+  FetchState,
+  ScaledLayer,
+  ServicesState,
+  MonitoringLocationsData,
+} from 'types';
 
 const layersToAllowPopups = ['restore', 'protect'];
 
@@ -1148,11 +1155,7 @@ function MapWidgets({
     if (!surroundingMonitoringLocationsWidget) return;
 
     const pathname = window.location.pathname;
-    if (
-      !pathname.includes('/community') &&
-      !pathname.includes('/tribe') &&
-      !pathname.includes('/waterbody-report')
-    ) {
+    if (pathname.includes('/state')) {
       // hide widget on other pages
       surroundingMonitoringLocationsWidget.style.display = 'none';
       surroundingMonitoringLocationsLayer.visible = false;
@@ -1160,9 +1163,8 @@ function MapWidgets({
     }
 
     if (
-      !pathname.includes('/tribe') &&
-      !pathname.includes('/waterbody-report') &&
-      (!huc12 || pathname === '/community')
+      pathname === '/community' ||
+      (!huc12 && pathname.includes('/community/'))
     ) {
       // disable widget on community home or invalid searches
       setSurroundingMonitoringLocationsWidgetDisabled(true);
@@ -1191,12 +1193,7 @@ function MapWidgets({
   // disable the all waterbodies widget if on the community home page
   useEffect(() => {
     const pathname = window.location.pathname;
-    if (
-      !surroundingMonitoringLocationsWidget ||
-      (!pathname.includes('/community') &&
-        !pathname.includes('/tribe') &&
-        !pathname.includes('/waterbody-report'))
-    ) {
+    if (!surroundingMonitoringLocationsWidget || pathname.includes('/state')) {
       return;
     }
 
@@ -1231,7 +1228,9 @@ function MapWidgets({
         services={services}
         setDisabled={setSurroundingMonitoringLocationsWidgetDisabled}
         setVisible={setSurroundingMonitoringLocationsLayerVisible}
-        surroundingMonitoringLocationsLayer={surroundingMonitoringLocationsLayer}
+        surroundingMonitoringLocationsLayer={
+          surroundingMonitoringLocationsLayer
+        }
       />,
       node,
     );
@@ -1703,7 +1702,9 @@ function ShowSurroundingMonitoringLocations({
     >
       <span
         className={
-          surroundingMonitoringLocations.status === 'fetching' && !widgetDisabled && layer?.visible
+          surroundingMonitoringLocations.status === 'fetching' &&
+          !widgetDisabled &&
+          layer?.visible
             ? 'esri-icon-loading-indicator esri-rotating'
             : 'esri-icon-experimental'
         }

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -44,6 +44,8 @@ import {
   stateNoGisDataError,
 } from 'config/errorMessages';
 
+let selectedGraphicGlobal = null;
+
 const mapPadding = 20;
 
 const containerStyles = css`
@@ -226,6 +228,11 @@ function StateMap({
 
   const [lastFilter, setLastFilter] = useState('');
 
+  // keep the selectedGraphicGlobal variable up to date
+  useEffect(() => {
+    selectedGraphicGlobal = selectedGraphic;
+  }, [selectedGraphic]);
+
   // cDU
   // detect when user changes their search
   const [homeWidgetSet, setHomeWidgetSet] = useState(false);
@@ -266,7 +273,7 @@ function StateMap({
               reactiveUtils
                 .whenOnce(() => !layerView.updating)
                 .then(() => {
-                  resolve(layerView.queryExtent());
+                  resolve(layer.queryExtent());
                 })
                 .catch((err) => reject(err));
             })
@@ -304,7 +311,7 @@ function StateMap({
                   if (fullExtent) {
                     let zoomParams = fullExtent;
                     let homeParams = { targetGeometry: fullExtent };
-                    if (!selectedGraphic) {
+                    if (!selectedGraphicGlobal) {
                       if (numberOfRecords === 1 && pointsExtent.count === 1) {
                         zoomParams = { target: fullExtent, zoom: 15 };
                         homeParams = {
@@ -353,7 +360,6 @@ function StateMap({
     mapView,
     numberOfRecords,
     pointsLayer,
-    selectedGraphic,
     stateMapLoadError,
     waterbodyLayer,
   ]);

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -908,7 +908,7 @@ function WaterbodyInfo({
   if (type === 'Past Water Conditions') {
     content = (
       <MonitoringLocationsContent
-        attributes={feature.attributes}
+        feature={feature}
         services={services ?? null}
       />
     );
@@ -1168,12 +1168,12 @@ function checkIfGroupInMapping(groupName: string): boolean {
 }
 
 type MonitoringLocationsContentProps = {
-  attributes: MonitoringLocationAttributes;
+  feature: __esri.Graphic;
   services: ServicesState | null;
 };
 
 function MonitoringLocationsContent({
-  attributes,
+  feature,
   services,
 }: MonitoringLocationsContentProps) {
   const [charGroupFilters, setCharGroupFilters] = useState('');
@@ -1184,6 +1184,8 @@ function MonitoringLocationsContent({
 
   const structuredProps = ['stationTotalsByGroup', 'timeframe'];
 
+  const attributes: MonitoringLocationAttributes = feature.attributes;
+  const layer = feature.layer;
   const parsed = parseAttributes<MonitoringLocationAttributes>(
     structuredProps,
     attributes,
@@ -1397,7 +1399,8 @@ function MonitoringLocationsContent({
         />
       </div>
 
-      {!onMonitoringReportPage && (
+      {(!onMonitoringReportPage ||
+        layer.id === 'surroundingMonitoringLocationsLayer') && (
         <p>
           <a rel="noopener noreferrer" target="_blank" href={locationUrl}>
             <i


### PR DESCRIPTION
## Related Issues:
* [HMW-331](https://jira.epa.gov/browse/HMW-331)
* [HMW-328](https://jira.epa.gov/browse/HMW-328)

## Main Changes:
* Added the surrounding past water conditions layer to the monitoring report and plan summary pages
* Fixed an issue with a weird zooming behavior on the state advanced search page

## Steps To Test Surrounding Past Water Conditions widget:
1. Verify the "Surrounding Past Water Conditions" widget is visible and works on the following pages:
    * http://localhost:3000/community/dc/overview
    * http://localhost:3000/waterbody-report/DOEE/DCANA00E_01/2020
    * http://localhost:3000/plan-summary/DOEE/40594
    * http://localhost:3000/tribe/DELAWARENATION
2. Verify the "Surrounding Past Water Conditions" widget is not visible on the following pages:
    * http://localhost:3000/state/AL/advanced-search
3. Verify the "Surrounding Past Water Conditions" widget is visible but disabled on the following pages:
    * http://localhost:3000/community
4. Navigate to http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-THR02/
5. Click on the monitoring location and verify it does not have the `View Monitoring Report` link
6. Verify the "Surrounding Past Water Conditions" widget is visible and works
7. Click on one of the surrounding monitoring locations and verify it does have the `View Monitoring Report` link

## Steps To Test Advanced Search Page Bugs:
1. Navigate to http://localhost:3000/state/AL/advanced-search
8. Click Search without any filters
9. Verify the map zooms in to Alabama
    * Currently this zooms to Alabama and west Africa on the dev site 
10. Switch to the list view
11. Click "View On Map" for one of the waterbodies
12. Verify the map zooms to the individual waterbody
