### PR TITLE
Feature/316 tribal upstream watershed

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalIntro.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalIntro.js
@@ -37,22 +37,26 @@ function StateTribalIntro() {
         <header css={headerStyles}>
           <i className="fas fa-tint" aria-hidden="true" />
           <h2 css={introHeadingStyles}>
-            States Play a Primary Role in Protecting Water Quality
+            States and Tribes Play a Primary Role in Protecting Water Quality
           </h2>
         </header>
         <p css={introTextStyles}>
           States have primary responsibility to implement the Clean Water Act to
-          protect waters in their state. This includes setting standards,
-          monitoring and assessing water quality, and developing goals to
-          safeguard and restore those water resources.
+          protect waters in their state and Native American Tribes and Nations
+          have the opportunity to take on Clean Water Act authority for their
+          tribal lands. This includes setting standards, monitoring and
+          assessing water quality, and developing goals to safeguard and restore
+          those water resources.
         </p>
         <br />
         <p css={introTextStyles}>
           The Safe Drinking Water Act (SDWA) requires EPA to establish and
           enforce standards that public drinking water systems must follow. EPA
           delegates primary enforcement responsibility (also called primacy) for
-          public water systems to states and Indian Tribes if they meet certain
-          requirements.
+          public water systems to states and Tribes if they meet certain
+          requirements. The information shown on the tribal pages is inclusive
+          of assessments performed against tribal thresholds, tribally adopted
+          water quality standards, and EPA approved water quality standards.
         </p>
       </div>
     </>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -413,7 +413,7 @@ function StateTribal() {
             <label css={promptStyles} htmlFor="hmw-state-select-input">
               <strong>Let’s get started!</strong>&nbsp;&nbsp;
               <em>
-                Select your state, tribe, or territory from the drop down to
+                Select your state, tribe or territory from the drop down to
                 begin exploring water quality.
               </em>
             </label>
@@ -508,7 +508,7 @@ function StateTribal() {
                   classNamePrefix="Select"
                   placeholder={
                     selectedSource === 'All'
-                      ? 'Select a state, tribe, or territory...'
+                      ? 'Select a state, tribe or territory...'
                       : selectedSource === 'State'
                       ? 'Select a state or territory...'
                       : 'Select a tribe...'

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -413,8 +413,8 @@ function StateTribal() {
             <label css={promptStyles} htmlFor="hmw-state-select-input">
               <strong>Let’s get started!</strong>&nbsp;&nbsp;
               <em>
-                Select your state or territory from the drop down to begin
-                exploring water quality.
+                Select your state, tribe, or territory from the drop down to
+                begin exploring water quality.
               </em>
             </label>
 
@@ -508,9 +508,9 @@ function StateTribal() {
                   classNamePrefix="Select"
                   placeholder={
                     selectedSource === 'All'
-                      ? 'Select a state or tribe...'
+                      ? 'Select a state, tribe, or territory...'
                       : selectedSource === 'State'
-                      ? 'Select a state...'
+                      ? 'Select a state or territory...'
                       : 'Select a tribe...'
                   }
                   options={selectOptions}

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { css } from 'styled-components/macro';
 import EsriMap from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
@@ -58,11 +58,18 @@ function Map({ layers = null, startingExtent = null }: Props) {
     setMapView,
   ]);
 
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+
   return (
-    <div id="hmw-map-container" css={mapContainerStyles}>
+    <div id="hmw-map-container" css={mapContainerStyles} ref={mapContainerRef}>
       {map && mapView && (
         <>
-          <MapWidgets map={map} view={mapView} layers={layers} />
+          <MapWidgets
+            map={map}
+            mapRef={mapContainerRef}
+            view={mapView}
+            layers={layers}
+          />
           <MapMouseEvents map={map} view={mapView} />
         </>
       )}

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -1891,7 +1891,7 @@ type ShowUpstreamWatershedProps = {
   getUpstreamLayer: () => (__esri.GraphicsLayer & { error?: boolean }) | '';
   getUpstreamWidgetDisabled: () => boolean;
   onClick: React.MouseEventHandler<HTMLDivElement>;
-  selectionEnabled?: boolean;
+  selectionActive?: boolean;
   upstreamLoading: boolean;
 };
 
@@ -1899,7 +1899,7 @@ function ShowUpstreamWatershed({
   getUpstreamLayer,
   getUpstreamWidgetDisabled,
   onClick,
-  selectionEnabled = false,
+  selectionActive = false,
   upstreamLoading,
 }: ShowUpstreamWatershedProps) {
   const [hover, setHover] = useState(false);
@@ -1911,11 +1911,11 @@ function ShowUpstreamWatershed({
   let title = 'View Upstream Watershed';
   if (upstreamWidgetDisabled) title = 'Upstream Widget Not Available';
   else if (upstreamLayer.visible) title = 'Hide Upstream Watershed';
-  else if (selectionEnabled) title = 'Cancel Watershed Selection';
+  else if (selectionActive) title = 'Cancel Watershed Selection';
 
   let iconClass = 'esri-icon esri-icon-overview-arrow-top-left';
   if (upstreamLoading) iconClass = 'esri-icon-loading-indicator esri-rotating';
-  else if (selectionEnabled) iconClass = 'esri-icon-locate';
+  else if (selectionActive) iconClass = 'esri-icon-locate';
 
   return (
     <div
@@ -2012,11 +2012,11 @@ function ShowSelectedUpstreamWatershed({
     newWatershedsLayer && setWatershedsVisible(newWatershedsLayer.visible);
   }, [map]);
 
-  const [selectionEnabled, setSelectionEnabled] = useState(false);
+  const [selectionActive, setSelectionActive] = useState(false);
 
   useEffect(() => {
     if (!view) return;
-    if (selectionEnabled) {
+    if (selectionActive) {
       view.popup.viewModel.includeDefaultActions = false;
       view.popup.visibleElements.closeButton = false;
       view.popup.dockOptions.buttonEnabled = false;
@@ -2026,7 +2026,7 @@ function ShowSelectedUpstreamWatershed({
       view.popup.dockOptions.buttonEnabled = true;
       view.popup.close();
     }
-  }, [selectionEnabled, view]);
+  }, [selectionActive, view]);
 
   const [upstreamLoading, setUpstreamLoading] = useState(false);
 
@@ -2034,7 +2034,7 @@ function ShowSelectedUpstreamWatershed({
   // its upstream watershed, and draw it
   const handleHucSelection = useCallback(
     (ev) => {
-      setSelectionEnabled(false);
+      setSelectionActive(false);
 
       if (!view) return;
       if (services.status !== 'success') return;
@@ -2080,20 +2080,20 @@ function ShowSelectedUpstreamWatershed({
   useEffect(() => {
     if (!view) return;
     const mapClickHandler = view.on('click', (ev) => {
-      if (!selectionEnabled) return;
+      if (!selectionActive) return;
       handleHucSelection(ev);
     });
 
     return function cleanup() {
       mapClickHandler.remove();
     };
-  }, [handleHucSelection, selectionEnabled, view]);
+  }, [handleHucSelection, selectionActive, view]);
 
   // Disable "selection mode" and restore the
   // initial visibility of the watersheds layer
   const cancelSelection = useCallback(() => {
     if (watershedsLayer) watershedsLayer.visible = watershedsVisible;
-    setSelectionEnabled(false);
+    setSelectionActive(false);
   }, [watershedsLayer, watershedsVisible]);
 
   // Create a global click listener to stop "selection mode"
@@ -2133,7 +2133,7 @@ function ShowSelectedUpstreamWatershed({
       watershedsLayer.visible = true;
     }
 
-    setSelectionEnabled(true);
+    setSelectionActive(true);
   }, [
     getCurrentExtent,
     getUpstreamLayer,
@@ -2161,7 +2161,7 @@ function ShowSelectedUpstreamWatershed({
     );
 
     const mouseMoveHandler = view.on('pointer-move', (ev) => {
-      if (!selectionEnabled || !mapRef.current) return;
+      if (!selectionActive || !mapRef.current) return;
       let content = `<p style="padding: 0.4em;font-weight:bold">
           Click within a watershed boundary to view its upstream watershed.
         </p>`;
@@ -2187,14 +2187,14 @@ function ShowSelectedUpstreamWatershed({
     return function cleanup() {
       mouseMoveHandler.remove();
     };
-  }, [mapRef, selectionEnabled, view, watershedsLayer]);
+  }, [mapRef, selectionActive, view, watershedsLayer]);
 
   return (
     <ShowUpstreamWatershed
       getUpstreamLayer={getUpstreamLayer}
       getUpstreamWidgetDisabled={getUpstreamWidgetDisabled}
-      onClick={selectionEnabled ? cancelSelection : selectUpstream}
-      selectionEnabled={selectionEnabled}
+      onClick={selectionActive ? cancelSelection : selectUpstream}
+      selectionActive={selectionActive}
       upstreamLoading={upstreamLoading}
     />
   );

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -1833,6 +1833,7 @@ function retrieveUpstreamWatershed(
 
   // already encountered an error for this location - don't retry
   if (upstreamLayer.error === true) {
+    setError?.(true);
     return;
   }
 
@@ -2133,7 +2134,6 @@ function ShowSelectedUpstreamWatershed({
 
   // Show/hide instruction dialogue when watershed selection activity changes
   useEffect(() => {
-    if (selectionActive) setError(false);
     setInstructionsVisible(selectionActive);
     upstreamWidget.style.filter = selectionActive
       ? 'invert(0.8) brightness(1.5) contrast(1.5)'
@@ -2182,7 +2182,10 @@ function ShowSelectedUpstreamWatershed({
       query
         .executeQueryJSON(services.data.wbd, queryParams)
         .then((boundaries) => {
-          if (boundaries.features.length === 0) return;
+          if (boundaries.features.length === 0) {
+            cancelSelection();
+            return;
+          }
 
           setCurrentExtent(view.extent);
 
@@ -2217,6 +2220,7 @@ function ShowSelectedUpstreamWatershed({
     },
     [
       abortSignal,
+      cancelSelection,
       getCurrentExtent,
       getHuc12,
       getTemplate,
@@ -2291,6 +2295,7 @@ function ShowSelectedUpstreamWatershed({
         watershedsLayer.visible = true;
       }
 
+      setError(false);
       setSelectionActive(true);
     },
     [

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -69,9 +69,10 @@ import type {
 
 const instructionContainerStyles = (isVisible: boolean) => css`
   display: ${isVisible ? 'flex' : 'none'};
-  justify-content: center;
+  justify-content: flex-end;
   position: absolute;
-  top: 15px;
+  right: 62px;
+  top: 99px;
   width: 100%;
   z-index: 1;
 `;

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -2140,9 +2140,16 @@ function ShowSelectedUpstreamWatershed({
       : 'none';
   }, [selectionActive, upstreamWidget]);
 
+  // Disable "selection mode" and restore the
+  // initial visibility of the watersheds layer
+  const cancelSelection = useCallback(() => {
+    if (watershedsLayer) watershedsLayer.visible = watershedsVisible;
+    setSelectionActive(false);
+  }, [watershedsLayer, watershedsVisible]);
+
   useEffect(() => {
-    if (error) setSelectionActive(false);
-  }, [error]);
+    if (error) cancelSelection();
+  }, [cancelSelection, error]);
 
   // Get the selected watershed, search for
   // its upstream watershed, and draw it
@@ -2243,22 +2250,12 @@ function ShowSelectedUpstreamWatershed({
     };
   }, [handleHucSelection, selectionActive, view]);
 
-  // Disable "selection mode" and restore the
-  // initial visibility of the watersheds layer
-  const cancelSelection = useCallback(
-    (_ev) => {
-      if (watershedsLayer) watershedsLayer.visible = watershedsVisible;
-      setSelectionActive(false);
-    },
-    [watershedsLayer, watershedsVisible],
-  );
-
   // Create a global click listener to stop "selection mode"
   // clicks if the user clicks away from the map
   useEffect(() => {
     const handleClick = (ev: MouseEvent) => {
       if (selectionActive && !mapRef.current?.contains(ev.target as Node)) {
-        cancelSelection(ev);
+        cancelSelection();
       }
     };
     window.addEventListener('click', handleClick);

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -170,6 +170,7 @@ function TribalMapList({
   );
   const {
     areasLayer,
+    errorMessage,
     linesLayer,
     mapView,
     setMonitoringGroups,
@@ -509,6 +510,12 @@ function TribalMapList({
               </>
             )}
           </div>
+        </div>
+      )}
+
+      {errorMessage && (
+        <div css={modifiedErrorBoxStyles}>
+          <p>{errorMessage}</p>
         </div>
       )}
 

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -656,6 +656,7 @@ function TribalMap({
     setVisibleLayers,
     waterbodyLayer,
     setWaterbodyLayer,
+    setUpstreamLayer,
   } = useContext(LocationSearchContext);
 
   const navigate = useNavigate();
@@ -836,11 +837,21 @@ function TribalMap({
     });
     setMonitoringLocationsLayer(monitoringLocationsLayer);
 
+    const upstreamLayer = new GraphicsLayer({
+      id: 'upstreamWatershed',
+      title: 'Upstream Watershed',
+      listMode: 'hide',
+      visible: false,
+    });
+
+    setUpstreamLayer(upstreamLayer);
+
     // add the shared layers to the map
     const sharedLayers = getSharedLayers();
 
     setLayers([
       ...sharedLayers,
+      upstreamLayer,
       selectedTribeLayer,
       monitoringLocationsLayer,
       waterbodyLayer,
@@ -859,6 +870,7 @@ function TribalMap({
     setLinesLayer,
     setMonitoringLocationsLayer,
     setPointsLayer,
+    setUpstreamLayer,
     setVisibleLayers,
     setWaterbodyLayer,
   ]);

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -70,7 +70,7 @@
 }
 
 .esri-popup__content {
-  margin: 0;
+  margin: 0 0 12px 0;
 }
 
 /* small screens (redfin style) docked to the bottom */

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -70,7 +70,7 @@
 }
 
 .esri-popup__content {
-  margin: 0 0 12px 0;
+  margin: 0;
 }
 
 /* small screens (redfin style) docked to the bottom */

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -198,6 +198,7 @@ interface ServicesData {
     userInterface: string;
     monitoringLocation: string;
   };
+  wbd: string;
 }
 
 export type ServicesState =

--- a/app/cypress/e2e/state.cy.ts
+++ b/app/cypress/e2e/state.cy.ts
@@ -106,7 +106,7 @@ describe('State page routes', () => {
     cy.visit('/state/%3Cscript%3Evar%20j%20=%201;%3C/script%3E');
 
     cy.findByText(
-      'States Play a Primary Role in Protecting Water Quality',
+      'States and Tribes Play a Primary Role in Protecting Water Quality',
     ).should('exist');
 
     cy.url().should('include', `${window.location.origin}/state`);


### PR DESCRIPTION
## Related Issues:
* [HMW-316](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-316)

## Main Changes:
* Added the _Upstream Watershed_ widget to the **Tribe** page.
* Altered the widget behavior to allow the user to select a watershed to view its upstream.
* Included an instruction box for the widget.
* Changed text on the main **State & Tribal** page.

## Steps To Test:
1. Visit the Red Lake Band of Chippewa Indians page, i.e. [http://localhost:3000/tribe/REDLAKE](http://localhost:3000/tribe/REDLAKE).
2. Click the _Upstream Watershed_ widget.
3. Check that a close-able instruction box appears and that the widget icon indicates activity.
4. Zoom in until watershed boundary lines appear, and confirm that the instructions update.
5. Click inside a watershed and confirm that the upstream watershed is shown and positioned correctly.
6. Click the widget again, and confirm that the extent returns to its previous location and the upstream watershed disappears.
7. Activate the widget, then click outside the map; the widget should exit "selection mode". Alternatively, click the widget again to deactivate.
8. Activate the widget, then click an area in one of the great lakes to verify errors are handled properly.
9. Verify that the proper text has been changed on the **State & Tribal** page.