### PR TITLE
Bugfix/337 338 tribal bogus url issues

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -21,8 +21,13 @@ function StateTribalTabs() {
   const { stateCode, tabName } = useParams();
   const navigate = useNavigate();
 
-  const { activeState, setActiveState, activeTabIndex, setActiveTabIndex } =
-    useContext(StateTribalTabsContext);
+  const {
+    activeState,
+    activeTabIndex,
+    setActiveState,
+    setActiveTabIndex,
+    setErrorType,
+  } = useContext(StateTribalTabsContext);
 
   const { fullscreenActive } = useFullscreenState();
 
@@ -53,13 +58,14 @@ function StateTribalTabs() {
     );
 
     if (tabIndex === -1) {
+      setErrorType('invalid-page');
       navigate('/state-and-tribal', { replace: true });
     }
 
     if (activeTabIndex !== tabIndex) {
       setActiveTabIndex(tabIndex === -1 ? 0 : tabIndex);
     }
-  }, [navigate, activeTabIndex, setActiveTabIndex, stateCode]);
+  }, [activeTabIndex, navigate, setActiveTabIndex, setErrorType, stateCode]);
 
   // if user navigation directly to the url, activeState.value will be an empty
   // string, and if the back or forward buttons are used, `stateCode` won't match the
@@ -72,9 +78,25 @@ function StateTribalTabs() {
         return stateTribe.value === stateCode.toUpperCase();
       });
       if (match) setActiveState(match);
-      else navigate('/state-and-tribal', { replace: true });
+      else {
+        setErrorType('invalid-org-id');
+        navigate('/state-and-tribal', { replace: true });
+      }
     }
-  }, [activeState.value, navigate, setActiveState, stateCode, states, tribes]);
+  }, [
+    activeState.value,
+    navigate,
+    setActiveState,
+    setErrorType,
+    stateCode,
+    states,
+    tribes,
+  ]);
+
+  // reset the error after a successfull search
+  useEffect(() => {
+    if (activeState.value) setErrorType('');
+  }, [activeState.value, setErrorType]);
 
   const tabListRef = useRef();
 

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
@@ -186,7 +186,7 @@ function Documents({
   return (
     <div css={containerStyles}>
       <h3>Documents Related to Integrated Report</h3>
-      <em>Select a document below to download a copy of the report.</em>
+
       {(organizationData.status === 'fetching' ||
         documentOrder.status === 'fetching') && <LoadingSpinner />}
       {organizationData.status === 'failure' && (
@@ -227,6 +227,7 @@ function Documents({
               <DocumentsTable
                 activeState={activeState}
                 documents={surveyDocumentsSorted}
+                hideInfoMessage={assessmentDocumentsSorted.length > 0}
                 type="statewide statistical survey"
               />
             </>
@@ -241,10 +242,16 @@ function Documents({
 type DocumentsTableProps = {
   activeState: ActiveState,
   documents: Array<Object>,
+  hideInfoMessage?: boolean,
   type: string,
 };
 
-function DocumentsTable({ activeState, documents, type }: DocumentsTableProps) {
+function DocumentsTable({
+  activeState,
+  documents,
+  hideInfoMessage,
+  type,
+}: DocumentsTableProps) {
   if (documents.length === 0) {
     return (
       <p>
@@ -255,61 +262,69 @@ function DocumentsTable({ activeState, documents, type }: DocumentsTableProps) {
   }
 
   return (
-    <ReactTable
-      data={documents}
-      getColumns={(tableWidth) => {
-        let docNameWidth = 0;
+    <>
+      {!hideInfoMessage && (
+        <em>Select a document below to download a copy of the report.</em>
+      )}
 
-        // make the document name column take up the remaining widht of the table
-        // table width - document type width - agency code width - border
-        if (tableWidth > 425) docNameWidth = tableWidth - 300 - 125 - 3;
+      <ReactTable
+        data={documents}
+        getColumns={(tableWidth) => {
+          let docNameWidth = 0;
 
-        // ensure the document name column is atleast 372px wide
-        if (docNameWidth < 372) docNameWidth = 372;
+          // make the document name column take up the remaining widht of the table
+          // table width - document type width - agency code width - border
+          if (tableWidth > 425) docNameWidth = tableWidth - 300 - 125 - 3;
 
-        return [
-          {
-            accessor: 'documentTypeLabel',
-            Header: 'Document Types',
-            width: 300,
-          },
-          {
-            accessor: 'documentName',
-            Header: 'Document',
-            width: docNameWidth,
-            Render: (cell) => {
-              return (
-                <>
-                  <a
-                    href={cell.row.original.documentURL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {cell.value} (
-                    {getExtensionFromPath(
-                      cell.row.original.documentFileName,
-                      cell.row.original.documentURL,
-                    )}
-                    )
-                  </a>
-                  <DynamicExitDisclaimer url={cell.row.original.documentURL} />
-                </>
-              );
+          // ensure the document name column is atleast 372px wide
+          if (docNameWidth < 372) docNameWidth = 372;
+
+          return [
+            {
+              accessor: 'documentTypeLabel',
+              Header: 'Document Types',
+              width: 300,
             },
-          },
-          {
-            accessor: 'agencyCode',
-            Header: 'Agency Code',
-            width: 125,
-            Render: (cell) => {
-              if (cell.value === 'S') return 'State';
-              if (cell.value === 'E') return 'EPA';
-              return cell.value;
+            {
+              accessor: 'documentName',
+              Header: 'Document',
+              width: docNameWidth,
+              Render: (cell) => {
+                return (
+                  <>
+                    <a
+                      href={cell.row.original.documentURL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {cell.value} (
+                      {getExtensionFromPath(
+                        cell.row.original.documentFileName,
+                        cell.row.original.documentURL,
+                      )}
+                      )
+                    </a>
+                    <DynamicExitDisclaimer
+                      url={cell.row.original.documentURL}
+                    />
+                  </>
+                );
+              },
             },
-          },
-        ];
-      }}
-    />
+            {
+              accessor: 'agencyCode',
+              Header: 'Agency Code',
+              width: 125,
+              Render: (cell) => {
+                if (cell.value === 'S') return 'State';
+                if (cell.value === 'E') return 'EPA';
+                return cell.value;
+              },
+            },
+          ];
+        }}
+      />
+    </>
   );
 }
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -178,13 +178,24 @@ function StateTribal() {
   const services = useServicesContext();
   const tribeMapping = useTribeMappingContext();
 
+  const {
+    activeState,
+    errorType,
+    introText,
+    setActiveState,
+    setErrorCode,
+    setUsesStateSummaryServiceError,
+    usesStateSummaryServiceError,
+  } = useContext(StateTribalTabsContext);
+
   // redirect to '/stateandtribe' if the url is /state or /tribe
   useEffect(() => {
     const pathname = window.location.pathname.toLowerCase();
     if (['/state', '/state/', '/tribe', '/tribe/'].includes(pathname)) {
+      setErrorCode('');
       navigate('/state-and-tribal', { replace: true });
     }
-  }, [navigate]);
+  }, [navigate, setErrorCode]);
 
   // get tribes from the tribeMapping data
   const [tribes, setTribes] = useState({ status: 'success', data: [] });
@@ -243,14 +254,6 @@ function StateTribal() {
       })
       .catch((_err) => setStates({ status: 'failure', data: [] }));
   }, [services, statesInitialized]);
-
-  const {
-    activeState,
-    setActiveState,
-    introText,
-    usesStateSummaryServiceError,
-    setUsesStateSummaryServiceError,
-  } = useContext(StateTribalTabsContext);
 
   // reset active state if on state intro page
   useEffect(() => {
@@ -405,6 +408,24 @@ function StateTribal() {
         {tribes.status === 'failure' && (
           <div css={modifiedErrorBoxStyles}>
             <p>{stateListError('Tribe')}</p>
+          </div>
+        )}
+
+        {errorType === 'invalid-org-id' && (
+          <div css={modifiedErrorBoxStyles}>
+            <p>
+              Data is not available for this location. Please select a state,
+              territory or tribe from the dropdown below.
+            </p>
+          </div>
+        )}
+
+        {errorType === 'invalid-page' && (
+          <div css={modifiedErrorBoxStyles}>
+            <p>
+              Invalid URL path. Please select a state, territory or tribe from
+              the dropdown below.
+            </p>
           </div>
         )}
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -183,7 +183,7 @@ function StateTribal() {
     errorType,
     introText,
     setActiveState,
-    setErrorCode,
+    setErrorType,
     setUsesStateSummaryServiceError,
     usesStateSummaryServiceError,
   } = useContext(StateTribalTabsContext);
@@ -192,10 +192,10 @@ function StateTribal() {
   useEffect(() => {
     const pathname = window.location.pathname.toLowerCase();
     if (['/state', '/state/', '/tribe', '/tribe/'].includes(pathname)) {
-      setErrorCode('');
+      setErrorType('');
       navigate('/state-and-tribal', { replace: true });
     }
-  }, [navigate, setErrorCode]);
+  }, [navigate, setErrorType]);
 
   // get tribes from the tribeMapping data
   const [tribes, setTribes] = useState({ status: 'success', data: [] });

--- a/app/client/src/contexts/StateTribalTabs.js
+++ b/app/client/src/contexts/StateTribalTabs.js
@@ -11,6 +11,7 @@ export const StateTribalTabsContext: Object = createContext({
   activeState: { value: '', label: '', source: 'All' },
   introText: { status: 'fetching', data: {} },
   stateAndOrganizationId: null,
+  errorType: '',
 });
 
 type Props = {
@@ -28,6 +29,7 @@ type State = {
   },
   introText: object,
   stateAndOrganization: object,
+  errorType: '' | 'invalid-page' | 'invalid-org-id',
 };
 
 export class StateTribalTabsProvider extends Component<Props, State> {
@@ -48,6 +50,7 @@ export class StateTribalTabsProvider extends Component<Props, State> {
       data: {},
     },
     stateAndOrganization: null,
+    errorType: '',
     // in case ATTAINS usesStateSummary service returns invalid data or an internal error
     usesStateSummaryServiceError: false,
     setActiveTabIndex: (activeTabIndex: number) => {
@@ -79,6 +82,9 @@ export class StateTribalTabsProvider extends Component<Props, State> {
     },
     setStateAndOrganization: (stateAndOrganization: object) => {
       this.setState({ stateAndOrganization });
+    },
+    setErrorType: (errorType: string) => {
+      this.setState({ errorType });
     },
   };
 


### PR DESCRIPTION
## Related Issues:
* [HMW-337](https://jira.epa.gov/browse/HMW-337)
* [HMW-338](https://jira.epa.gov/browse/HMW-338)
* [HMW-339](https://jira.epa.gov/browse/HMW-339)

## Main Changes:
* Added an error message to the `state-and-tribal` page if a user includes a nonexistent state or tribe in the URL.
* Investigated an issue with the back button not working on the tribe page after navigating to a bad url.
    * I was unable to reproduce this locally. I'm hoping maybe the above change fixed this. If it doesn't 
* Removed an unnecessary sentece from the state/tribe page for when there are no documents.

## Steps To Test 337:
1. Navigate to http://localhost:3000/tribe/ABCDEF
2. Verify the `Data is not available for this location. Please select a state, territory or tribe from the dropdown below.` message is displayed
3. Select a state or tribe from the dropdown and click Go
4. Verify the message in step 2 is no longer displayed
5. Navigate to http://localhost:3000/state/ZZ/water-quality-overview
6. Repeat steps 2 - 4
7. Navigate to http://localhost:3000/state/AL/nonexistent-tab
8. Verify the `Invalid URL path. Please select a state, territory or tribe from the dropdown below.` message is displayed
9. Select a state from the dropdown and click Go
10. Verify the message in step 8 is no longer displayed

## Steps To Test 338:
1. Navigate to http://localhost:3000/tribe/DELAWARENATION
2. In the same tab navigate to http://localhost:3000/tribe/ABCDEF
3. Click the back button on the browser
4. Verify the url changes to http://localhost:3000/tribe/DELAWARENATION
5. Verify the data for `DELAWARENATION` is displayed

## Steps To Test 339:
1. Navigate to http://localhost:3000/tribe/DELAWARENATION
2. Expand the documents section
3. Verify the `Select a document below to download a copy of the report.` text is not visible
4. Navigate to http://localhost:3000/state/KS/water-quality-overview
5. Verify the `Select a document below to download a copy of the report.` text is visible, only above the `Documents Related to Integrated Report` section
