### PR TITLE
Bugfix/340 adw url error

### DIFF
--- a/app/client/src/components/shared/AddDataWidget.URLPanel.js
+++ b/app/client/src/components/shared/AddDataWidget.URLPanel.js
@@ -30,6 +30,8 @@ import {
   urlLayerFailureMessage,
   urlLayerSuccessMessage,
 } from 'config/errorMessages';
+// styles
+import { colors } from 'styles/index.js';
 
 const MessageBoxStyles = `
   margin-bottom: 10px;
@@ -58,6 +60,18 @@ const addButtonStyles = css`
   min-width: 50%;
   font-weight: normal;
   font-size: 12px;
+  color: ${colors.white()};
+  background-color: ${colors.blue()};
+
+  &:not(.btn-danger):hover,
+  &:not(.btn-danger):focus {
+    color: ${colors.white()};
+    background-color: ${colors.navyBlue()};
+  }
+
+  &:disabled {
+    cursor: default;
+  }
 `;
 
 const urlInputStyles = css`
@@ -232,7 +246,13 @@ function URLPanel() {
         >
           SAMPLE URL(S)
         </button>
-        <button css={addButtonStyles} type="submit" onClick={handleAdd}>
+        <button
+          css={addButtonStyles}
+          className="btn"
+          disabled={!url.trim()}
+          type="submit"
+          onClick={handleAdd}
+        >
           ADD
         </button>
       </div>


### PR DESCRIPTION
## Related Issues:
* [HMW-340](https://jira.epa.gov/browse/HMW-340)

## Main Changes:
* Fixed a bug, on the URL tab of the Add Data Widget, where users could click the "ADD" button without entering a URL and then the app would display a success message.
    * To fix this I just set the ADD button to disabled if the URL input is empty. 

## Steps To Test:
1. Navigate to http://localhost:3000/community
2. Open the Add Data Widget and click on the URL tab
3. Verify the `ADD` button is disabled and clicking it does nothing
4. Enter a URL (you can copy one from the `SAMPLE URL(s)` on the URL tab)
5. Verify the `ADD` button is enabled and clicking it adds the layer to the map

