### PR TITLE
Feature/344 345 upstream popups

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -38,7 +38,6 @@ import { fetchCheck } from 'utils/fetchUtils';
 import {
   buildStations,
   hasSublayers,
-  isFeatureLayer,
   isGroupLayer,
   isInScale,
   isPolygon,
@@ -2161,7 +2160,7 @@ function ShowSelectedUpstreamWatershed({
       : 'none';
   }, [selectionActive, upstreamWidget]);
 
-  // Disable "selection mode" and restore the
+  // Disable "selection mode" and/or restore the
   // initial visibility of the watersheds layer
   const cancelSelection = useCallback(() => {
     if (watershedsLayer) watershedsLayer.visible = watershedsVisible;
@@ -2329,20 +2328,6 @@ function ShowSelectedUpstreamWatershed({
       watershedsVisible,
     ],
   );
-
-  const [currentScale, setCurrentScale] = useState<number | null>(null);
-  useEffect(() => {
-    if (!view) return;
-    const handle = reactiveUtils.watch(
-      () => view.scale,
-      () => setCurrentScale(view.scale),
-      { initial: true, sync: true },
-    );
-
-    return function cleanup() {
-      handle.remove();
-    };
-  }, [view]);
 
   return (
     <>

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -1915,6 +1915,11 @@ function retrieveUpstreamWatershed(
       const upstreamTitle = `Upstream Watershed for Currently Selected Location: ${watershed} (${currentHuc12})`;
 
       if (!res || !res.features || res.features.length === 0) {
+        upstreamLayer.error = true;
+        upstreamLayer.graphics.removeAll();
+        setUpstreamLayer(upstreamLayer);
+        canDisable && setUpstreamWidgetDisabled(true);
+        setUpstreamLayerVisible(false);
         setErrorMessage(
           `No upstream watershed data available for ${
             huc12 ? 'the selected' : 'this'
@@ -1977,6 +1982,7 @@ function retrieveUpstreamWatershed(
       upstreamLayer.graphics.removeAll();
       setUpstreamLayerVisible(false);
       setUpstreamLayer(upstreamLayer);
+      console.error(err);
       setErrorMessage(
         `Error fetching upstream watershed data for ${
           huc12 ? 'the selected' : 'this'
@@ -2233,6 +2239,9 @@ function ShowSelectedUpstreamWatershed({
         })
         .catch((err) => {
           console.error(err);
+          setErrorMessage(
+            'Error fetching watershed data for the selected location.',
+          );
         });
     },
     [

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -2358,15 +2358,8 @@ function ShowSelectedUpstreamWatershed({
               </header>
               <div>
                 <p>
-                  Click within a watershed boundary to view its upstream
-                  watershed.
+                  Click a location on the map to view its upstream watershed.
                 </p>
-                {currentScale &&
-                  watershedsLayer &&
-                  isFeatureLayer(watershedsLayer) &&
-                  currentScale > watershedsLayer.minScale && (
-                    <p>Zoom in to see watershed boundary lines.</p>
-                  )}
               </div>
             </div>
           </div>,

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1005,11 +1005,9 @@ function MapPopup({
   const huc12 = clickedHuc?.data?.huc12;
   const watershed = clickedHuc?.data?.watershed;
 
-  const onTribePage = window.location.pathname.startsWith('/tribe/');
-
   return (
     <div css={popupContainerStyles}>
-      {clickedHuc && !onTribePage && (
+      {clickedHuc && (
         <>
           {clickedHuc.status === 'no-data' && null}
           {clickedHuc.status === 'fetching' && <LoadingSpinner />}

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -974,10 +974,12 @@ function useDynamicPopup() {
       const mapView = getMapView();
       const location = mapView?.popup?.location;
       const fields = dynamicPopupFields;
+      const onTribePage = window.location.pathname.startsWith('/tribe/');
       // only look for huc boundaries if no graphics were clicked and the
       // user clicked outside of the selected huc boundaries
       if (
         !location ||
+        onTribePage ||
         (hucBoundaries &&
           hucBoundaries.features.length > 0 &&
           hucBoundaries.features[0].geometry.contains(location))


### PR DESCRIPTION
## Related Issues:
* [HMW-344](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-344)
* [HMW-345](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-345)

## Main Changes:
* Moved a check to a point deeper in the call stack to prevent an unnecessary service call.
* Rephrased the upstream selection instructions and removed their second line.
* Simplified some logic in the `ShowSelectedUpstreamWatershed` component.

## Steps To Test:
1. Visit a tribe page.
2. Click the _Upstream Watershed_ widget.
3. Verify that the instruction popup reads "Click a location on the map to view its upstream watershed."
4. Click the map so that an upstream watershed is retrieved and drawn. If a watershed without upstream data is selected, repeat from step 2.
5. Open the network tab of the browser's developer tools and clear the logs.
6. Click the upstream graphic to view its map popup, and check that no network requests are made to the URL "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/6".