### PR TITLE
Feature/353 otoe tribe fix

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1397,22 +1397,6 @@ function MonitoringLocationsContent({
         />
       </div>
 
-      {(!onMonitoringReportPage ||
-        layer.id === 'surroundingMonitoringLocationsLayer') && (
-        <p>
-          <a rel="noopener noreferrer" target="_blank" href={locationUrl}>
-            <i
-              css={iconStyles}
-              className="fas fa-info-circle"
-              aria-hidden="true"
-            />
-            View Monitoring Report
-          </a>
-          &nbsp;&nbsp;
-          <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>
-        </p>
-      )}
-
       {Object.keys(groups).length === 0 && (
         <p>No data available for this monitoring location.</p>
       )}
@@ -1533,6 +1517,22 @@ function MonitoringLocationsContent({
             </tr>
           </tfoot>
         </table>
+      )}
+
+      {(!onMonitoringReportPage ||
+        layer.id === 'surroundingMonitoringLocationsLayer') && (
+        <p css={paragraphStyles}>
+          <a rel="noopener noreferrer" target="_blank" href={locationUrl}>
+            <i
+              css={iconStyles}
+              className="fas fa-info-circle"
+              aria-hidden="true"
+            />
+            View Monitoring Report
+          </a>
+          &nbsp;&nbsp;
+          <small css={disclaimerStyles}>(opens new browser tab)</small>
+        </p>
       )}
     </>
   );

--- a/app/server/app/public/data/tribe/tribeMapping.json
+++ b/app/server/app/public/data/tribe/tribeMapping.json
@@ -120,11 +120,11 @@
     "epaRegion": 5
   },
   {
-    "name": "Miami Tribe of Oklahoma",
+    "name": "Otoe Missouria Tribe of Oklahoma",
     "attainsId": "O_MTRIBE",
-    "wqxIds": ["MIAMITRIBEOFOKLAHOMA"],
-    "biaTribeCode": "925",
-    "epaId": 100000158,
+    "wqxIds": ["O_MTRIBE_WQX"],
+    "biaTribeCode": "811",
+    "epaId": 100000187,
     "state": "OK",
     "stateList": ["OK"],
     "epaRegion": 6


### PR DESCRIPTION
## Related Issues:
* [HMW-351](https://jira.epa.gov/browse/HMW-351)
* [HMW-353](https://jira.epa.gov/browse/HMW-353)

## Main Changes:
* Fixed a bug where the `O_MTRIBE` org id was incorrectly tied to the `Miami Tribe of Oklahoma`. 
* Moved the "View Monitoring Report" link to the bottom of the monitoring popup.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/O_MTRIBE
2. Verify the tribe name being displayed is `Otoe Missouria Tribe of Oklahoma`
3. Verify the map zooms in to the tribe boundaries
4. Verify there are 6 waterbodies and 27 monitoring locations
5. Verify that `Miami Tribe of Oklahoma` does not show up in the dropdown list
6. Navigate to http://localhost:3000/community/dc/overview
7. Expand a Past Water Condition and or open a Past Water Condition popup
8. Verify the "View Monitoring Report" link is now at the bottom
