### PR TITLE
Feature/360 protect tab surrounding layer

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -206,6 +206,7 @@ function Protect() {
     waterbodyLayer,
     cipSummary,
     allWaterbodiesLayer,
+    surroundingMonitoringLocationsLayer,
   } = useContext(LocationSearchContext);
 
   const { usgsStreamgages } = useFetchedDataState();
@@ -416,11 +417,16 @@ function Protect() {
   function onWsioToggle(newValue) {
     if (newValue) {
       if (allWaterbodiesLayer) allWaterbodiesLayer.visible = false;
+      if (surroundingMonitoringLocationsLayer)
+        surroundingMonitoringLocationsLayer.visible = false;
       if (monitoringLocationsLayer) monitoringLocationsLayer.visible = false;
       if (usgsStreamgagesLayer) usgsStreamgagesLayer.visible = false;
     } else {
       if (allWaterbodiesLayer)
         allWaterbodiesLayer.visible = initialAllWaterbodiesVisibility;
+      if (surroundingMonitoringLocationsLayer)
+        surroundingMonitoringLocationsLayer.visible =
+          initialSurroundingMonitoringVisibility;
       if (monitoringLocationsLayer)
         monitoringLocationsLayer.visible = initialMonitoringLocationsVisibility;
       if (usgsStreamgagesLayer)
@@ -491,6 +497,18 @@ function Protect() {
     setInitialAllWaterbodiesVisibility(allWaterbodiesLayer.visible);
   }, [allWaterbodiesLayer]);
 
+  const [
+    initialSurroundingMonitoringVisibility,
+    setInitialSurroundingMonitoringVisibility,
+  ] = useState(false);
+  useEffect(() => {
+    if (!surroundingMonitoringLocationsLayer) return;
+
+    setInitialSurroundingMonitoringVisibility(
+      surroundingMonitoringLocationsLayer.visible,
+    );
+  }, [surroundingMonitoringLocationsLayer]);
+
   const initialVisibility = tabs.find((tab) => tab.title === 'Protect')?.layers;
 
   const [
@@ -539,15 +557,19 @@ function Protect() {
       if (!componentWillUnmount?.current) return;
 
       allWaterbodiesLayer.visible = initialAllWaterbodiesVisibility;
+      surroundingMonitoringLocationsLayer.visible =
+        initialSurroundingMonitoringVisibility;
       monitoringLocationsLayer.visible = initialMonitoringLocationsVisibility;
       usgsStreamgagesLayer.visible = initialUsgsStreamgagesVisibility;
     };
   }, [
     allWaterbodiesLayer,
     initialAllWaterbodiesVisibility,
+    initialSurroundingMonitoringVisibility,
     initialMonitoringLocationsVisibility,
     initialUsgsStreamgagesVisibility,
     monitoringLocationsLayer,
+    surroundingMonitoringLocationsLayer,
     usgsStreamgagesLayer,
   ]);
 

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -416,6 +416,13 @@ function Protect() {
 
   function onWsioToggle(newValue) {
     if (newValue) {
+      setInitialAllWaterbodiesVisibility(allWaterbodiesLayer.visible);
+      setInitialSurroundingMonitoringVisibility(
+        surroundingMonitoringLocationsLayer.visible,
+      );
+      setInitialMonitoringLocationsVisibility(monitoringLocationsLayer.visible);
+      setInitialUsgsStreamgagesVisibility(usgsStreamgagesLayer.visible);
+
       if (allWaterbodiesLayer) allWaterbodiesLayer.visible = false;
       if (surroundingMonitoringLocationsLayer)
         surroundingMonitoringLocationsLayer.visible = false;


### PR DESCRIPTION
## Related Issues:
* [HMW-360](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-360)

## Main Changes:
* Added the _Surrounding Monitoring Locations_ layer to the list of layers that are toggled off when the _WSIO Health Index_ layer is toggled on.
    * The will return to its initial visibility state when the _WSIO Health Index_ layer is toggled off.
* Updated the logic to set the initial visibility of each layer each time the WSIO toggle is switched on.

## Steps To Test:
1. Visit [http://localhost:3000/community/dc/protect](http://localhost:3000/community/dc/protect).
2. In the Layer List, toggle on the "Surrounding Past Water Conditions" and the "Past Water Conditions" layers.
3. In the **Watershed Health and Protection** accordion list, toggle on the "Watershed Health Scores" item.
4. Verify the two layers are not visible.
5. Toggle the "Watershed Health Scores" item off.
6. Verify the two layers are visible. 