### PR TITLE
Bugfix/361 wqp conus query

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -1793,7 +1793,6 @@ function ShowSurroundingMonitoringLocations({
         });
       });
   }, [
-    abortController,
     getDisabled,
     getMonitoringLocations,
     lastExtent,


### PR DESCRIPTION
## Related Issues:
* [HMW-361](https://jira.epa.gov/browse/HMW-361)

## Main Changes:
* Fixed a bug where the surrounding monitoring locations widget was querying the continental us on the community home page.

## Steps To Test:
1. Open the developer tools on the network tab and filter on www.waterqualitydata.us 
2. Navigate to http://localhost:3000/community
3. Verify no calls are made against www.waterqualitydata.us
4. Zoom in until the Surrounding Past Water Conditions widget is enable
5. Verify no calls are made against www.waterqualitydata.us
6. Click the Surrounding Past Water Conditions widget 
7. Verify a call is made against www.waterqualitydata.us and the data is displayed on the map

