### PR TITLE
Feature/367 count list mismatch

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -293,8 +293,8 @@ function Overview() {
           ) : (
             <>
               <span css={keyMetricNumberStyles}>
-                {Boolean(waterbodies?.length) && cipSummary.status === 'success'
-                  ? waterbodies.length.toLocaleString()
+                {Boolean(totalWaterbodies) && cipSummary.status === 'success'
+                  ? totalWaterbodies.toLocaleString()
                   : 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Waterbodies</p>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -447,6 +447,12 @@ function WaterbodiesTab() {
   const { watershed } = useContext(LocationSearchContext);
   const waterbodies = useWaterbodyFeatures();
 
+  const uniqueWaterbodies = waterbodies
+    ? getUniqueWaterbodies(waterbodies)
+    : [];
+
+  const totalWaterbodies = uniqueWaterbodies.length;
+
   // draw the waterbody on the map
   useWaterbodyOnMap();
 
@@ -457,8 +463,8 @@ function WaterbodiesTab() {
       title={
         <span data-testid="overview-waterbodies-accordion-title">
           Overall condition of{' '}
-          <strong>{waterbodies?.length.toLocaleString()}</strong>{' '}
-          {waterbodies?.length === 1 ? 'waterbody' : 'waterbodies'} in the{' '}
+          <strong>{totalWaterbodies.toLocaleString()}</strong>{' '}
+          {totalWaterbodies === 1 ? 'waterbody' : 'waterbodies'} in the{' '}
           <em>{watershed}</em> watershed.
         </span>
       }

--- a/app/client/src/utils/utils.ts
+++ b/app/client/src/utils/utils.ts
@@ -373,7 +373,9 @@ function summarizeAssessments(
       | 'Not Assessed'
       | 'Not Applicable'
       | 'X';
-    const { assessmentunitidentifier: id } = graphic.attributes;
+    const { assessmentunitidentifier, organizationidentifier } =
+      graphic.attributes;
+    const id = `${organizationidentifier}${assessmentunitidentifier}`;
 
     if (!field || field === 'X') {
       summary['Not Applicable']++;


### PR DESCRIPTION
## Related Issues:
* [HMW-367](https://jira.epa.gov/browse/HMW-367)

## Main Changes:
* Updated the count on the overview panel to use the same de-duplicating logic as the list view.
* Updated the `summarizeAssessments` function to work the similarly to the `getUniqueWaterbodies` function. 
  * We don't have any specific errors to warrant  this change. This is something that I noticed that could cause similar issues in the future. This is because attains allows the use of duplicate assessment unit ids as long as they are in different organizations. So `{orgId: 'ABC', auId: '1234'}, {orgId: 'DEF', auId: '1234'}` is valid within attains and would result in a count mismatch from the `summarizeAssessments` function. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/13671%20Emmerson%20Airline,%20Girard,%20IL%2062640/overview
2. Verfiy the waterbodies count is 3 and the list has 3 items
3. Click through the other tabs (i.e., Swimming, Eating Fish, Aquatic Life, etc.) and verify the counts match up with the list. Note: These other tabs DO NOT count `Condition Unknown` (or unassessed) waterbodies.
4. Navigate to http://localhost:3000/community/Lake%20Springfield,%20IL/overview
5. Verify the waterbodies count is 1 and the list has 1 item
6. Click through the other tabs (i.e., Swimming, Eating Fish, Aquatic Life, etc.) and verify the counts match up with the list. Note: These other tabs DO NOT count `Condition Unknown` (or unassessed) waterbodies.

