### PR TITLE
Feature/379 cyan panel edits

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -538,16 +538,17 @@ function Monitoring() {
           <TabPanels>
             <TabPanel>
               <p>
-                Click on each monitoring location on the map or in the list
-                below to find out about current water conditions. Water
-                conditions are measured in real-time using water quality sensors
-                deployed at each location.
+                Explore the map and information below to find out about current
+                water conditions. On this tab, we define current data as less
+                than one week old. The water condition information shown here is
+                estimated using satellite imagery and water quality sensors
+                deployed in the waterbody.
               </p>
 
               <div css={legendItemsStyles}>
                 <span>
                   {waterwayIcon({ color: '#6c95ce' })}
-                  &nbsp;CyAN Waterbodies&nbsp;
+                  &nbsp;CyAN Satellite Imagery&nbsp;
                 </span>
                 <span>
                   {squareIcon({ color: '#fffe00' })}
@@ -739,9 +740,9 @@ function CurrentConditionsTab({
                     cyanWaterbodies.status !== 'success' ||
                     cyanWaterbodies.data?.length === 0
                   }
-                  ariaLabel="CyAN Waterbodies"
+                  ariaLabel="CyAN Satellite Imagery"
                 />
-                <span>CyAN Waterbodies</span>
+                <span>CyAN Satellite Imagery</span>
               </div>
             </td>
             <td>{cyanWaterbodies.data?.length ?? 'N/A'}</td>

--- a/app/client/src/components/shared/BoxContent.tsx
+++ b/app/client/src/components/shared/BoxContent.tsx
@@ -128,7 +128,7 @@ export function BoxContent({ layout = 'grid', rows, styles }: BoxContentProps) {
     <section css={mergedStyles}>
       {keyedRows.map(
         (item) =>
-          item && (
+          item?.label && (
             <BoxRow
               key={item.key}
               label={item.label}

--- a/app/client/src/components/shared/BoxContent.tsx
+++ b/app/client/src/components/shared/BoxContent.tsx
@@ -157,8 +157,8 @@ export function ListContent({
 }
 
 interface RowProps {
-  label: ReactNode | string;
-  value: ReactNode | string;
+  label: NonNullable<ReactNode>;
+  value: ReactNode;
   status?: string;
 }
 

--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -6,7 +6,7 @@ import '@reach/tooltip/styles.css';
 import { colors } from 'styles';
 // types
 import type { Position } from '@reach/tooltip';
-import type { ReactElement, Ref } from 'react';
+import type { ReactElement, ReactNode, Ref } from 'react';
 
 /*
 ## Styles
@@ -55,7 +55,7 @@ const centered: Position = (triggerRect, tooltipRect) => {
  */
 type TooltipProps = {
   children: ReactElement;
-  label: string;
+  label: ReactNode;
   triggerRef: Ref<HTMLElement>;
 };
 
@@ -80,7 +80,7 @@ function Tooltip({ children, label, triggerRef }: TooltipProps) {
 type HelpTooltipProps = {
   description?: string;
   children?: ReactElement;
-  label: string;
+  label: ReactNode;
 };
 
 function HelpTooltip({ description, children, label }: HelpTooltipProps) {

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -2,6 +2,7 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import highchartsAccessibility from 'highcharts/modules/accessibility';
 import highchartsExporting from 'highcharts/modules/exporting';
+import highchartsHistogram from 'highcharts/modules/histogram-bellcurve';
 import highchartsOfflineExporting from 'highcharts/modules/offline-exporting';
 import { useMemo } from 'react';
 // styles
@@ -16,19 +17,24 @@ highchartsAccessibility(Highcharts);
 highchartsExporting(Highcharts);
 highchartsOfflineExporting(Highcharts);
 
+// add histogram module to highcharts
+highchartsHistogram(Highcharts);
+
 type Props = {
-  caption?: string;
   categories: string[];
-  height?: string;
   legendTitle?: string;
   series: Array<{
-    color?: string;
     custom?: {
       description?: string;
     };
     data: number[];
     name: string;
-    type: 'column';
+    type: 'histogram';
+    zoneAxis?: 'x' | 'y';
+    zones?: Array<{
+      color: string;
+      value?: number;
+    }>;
   }>;
   subtitle?: string;
   title?: string;
@@ -37,11 +43,8 @@ type Props = {
   yMin?: number;
 };
 
-export default function StackedBarChart({
-  caption,
+export default function Histogram({
   categories,
-  height,
-  legendTitle,
   series,
   subtitle,
   title,
@@ -51,15 +54,14 @@ export default function StackedBarChart({
 }: Props) {
   const options = useMemo<Options>(() => {
     return {
-      caption: {
-        text: caption,
-        useHTML: true,
-      },
       chart: {
         backgroundColor: 'rgba(0, 0, 0, 0)',
-        height: height ?? '500px',
+        height: '400px',
         style: { fontFamily: fonts.primary },
-        type: 'column',
+        type: 'histogram',
+        zooming: {
+          type: 'x',
+        },
       },
       credits: { enabled: false },
       exporting: {
@@ -85,31 +87,9 @@ export default function StackedBarChart({
             },
           },
         },
-        chartOptions: {
-          plotOptions: {
-            series: {
-              dataLabels: {
-                enabled: true,
-              },
-            },
-          },
-        },
       },
       legend: {
-        labelFormatter: function () {
-          if (this.options.custom?.description) {
-            return `${this.name}<br /><span style="fontWeight:normal">${this.options.custom.description}</span>`;
-          } else return this.name;
-        },
-        title: {
-          text: legendTitle,
-        },
-        verticalAlign: 'bottom',
-      },
-      plotOptions: {
-        column: {
-          stacking: 'normal',
-        },
+        enabled: false,
       },
       series,
       subtitle: {
@@ -119,24 +99,9 @@ export default function StackedBarChart({
         text: title,
       },
       tooltip: {
-        borderColor: '#000000',
         formatter: function () {
-          return (
-            this.points?.reduce((s, point) => {
-              return (
-                s +
-                `<tr>
-                <td style="color:${point.series.color};fontWeight:bold">
-                  ${point.series.name}: 
-                </td>
-                <td>${point.y?.toLocaleString()}</td>
-              </tr>`
-              );
-            }, `<b>${this.x}</b><table>`) + '</table>'
-          );
+          return `<b>${this.x} cells/mL:</b> ${this.y}`;
         },
-        shared: true,
-        useHTML: true,
       },
       xAxis: {
         categories,
@@ -151,18 +116,7 @@ export default function StackedBarChart({
         },
       },
     };
-  }, [
-    caption,
-    height,
-    legendTitle,
-    series,
-    subtitle,
-    title,
-    categories,
-    xTitle,
-    yMin,
-    yTitle,
-  ]);
+  }, [series, subtitle, title, categories, xTitle, yMin, yTitle]);
 
   return <HighchartsReact highcharts={Highcharts} options={options} />;
 }

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -22,6 +22,7 @@ highchartsHistogram(Highcharts);
 
 type Props = {
   categories: string[];
+  height?: string;
   legendTitle?: string;
   series: Array<{
     custom?: {
@@ -45,6 +46,7 @@ type Props = {
 
 export default function Histogram({
   categories,
+  height,
   series,
   subtitle,
   title,
@@ -56,7 +58,7 @@ export default function Histogram({
     return {
       chart: {
         backgroundColor: 'rgba(0, 0, 0, 0)',
-        height: '400px',
+        height: height ?? '300px',
         style: { fontFamily: fonts.primary },
         type: 'histogram',
         zooming: {
@@ -116,7 +118,7 @@ export default function Histogram({
         },
       },
     };
-  }, [series, subtitle, title, categories, xTitle, yMin, yTitle]);
+  }, [height, series, subtitle, title, categories, xTitle, yMin, yTitle]);
 
   return <HighchartsReact highcharts={Highcharts} options={options} />;
 }

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -101,6 +101,7 @@ export default function Histogram({
         text: title,
       },
       tooltip: {
+        borderColor: '#000000',
         formatter: function () {
           return `<b>${this.x} cells/mL:</b> ${this.y}`;
         },

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -813,7 +813,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         { name: 'monitoringType', type: 'string', defaultValue: 'CyAN' },
         { name: 'OBJECTID', type: 'oid' },
         { name: 'oid', type: 'integer' },
-        { name: 'orgName', type: 'string', defaultValue: 'CyAN, EPA' },
+        {
+          name: 'orgName',
+          type: 'string',
+          defaultValue: 'Cyanobacteria Assessment Network (CyAN)',
+        },
         { name: 'PERMANENT_', type: 'string' },
         { name: 'RESOLUTION', type: 'integer' },
         { name: 'x_max', type: 'double' },
@@ -1656,7 +1660,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
                 locationName: item.attributes.GNIS_NAME,
                 monitoringType: 'CyAN',
                 oid: item.attributes.OBJECTID,
-                orgName: 'CyAN, EPA',
+                orgName: 'Cyanobacteria Assessment Network (CyAN)',
               },
               geometry: new Polygon({
                 rings: item.geometry.rings,

--- a/app/client/src/components/shared/ShowLessMore.js
+++ b/app/client/src/components/shared/ShowLessMore.js
@@ -24,7 +24,7 @@ const linkButtonStyles = css`
 
 // --- components ---
 type Props = {
-  text: string | Node,
+  text: string | React.ReactNode,
   charLimit: number,
 };
 
@@ -32,8 +32,8 @@ function ShowLessMore({ text, charLimit }: Props) {
   const [truncated, setTruncated] = useState(true);
 
   if (typeof text === 'string') {
-    if (!text) return '';
-    if (text.length < charLimit) return text;
+    if (!text) return <></>;
+    if (text.length < charLimit) return <>text</>;
 
     return (
       <>

--- a/app/client/src/components/shared/ShowLessMore.js
+++ b/app/client/src/components/shared/ShowLessMore.js
@@ -2,6 +2,8 @@
 
 import React, { isValidElement, useState } from 'react';
 import { css } from 'styled-components/macro';
+// types
+import type { ReactNode } from 'react';
 
 const linkButtonStyles = css`
   display: inline;
@@ -24,7 +26,7 @@ const linkButtonStyles = css`
 
 // --- components ---
 type Props = {
-  text: string | React.ReactNode,
+  text: string | ReactNode,
   charLimit: number,
 };
 

--- a/app/client/src/components/shared/StackedBarChart.tsx
+++ b/app/client/src/components/shared/StackedBarChart.tsx
@@ -18,6 +18,7 @@ highchartsOfflineExporting(Highcharts);
 
 type Props = {
   categories: string[];
+  legendTitle?: string;
   series: Array<{
     color?: string;
     data: number[];
@@ -33,6 +34,7 @@ type Props = {
 
 export default function StackedBarChart({
   categories,
+  legendTitle,
   series,
   subtitle,
   title,
@@ -82,6 +84,10 @@ export default function StackedBarChart({
         },
       },
       legend: {
+        title: {
+          style: { display: 'flex', justifyContent: 'center' },
+          text: legendTitle,
+        },
         verticalAlign: 'top',
       },
       plotOptions: {
@@ -128,7 +134,7 @@ export default function StackedBarChart({
         },
       },
     };
-  }, [categories, series, subtitle, title, xLabel, yLabel, yMin]);
+  }, [categories, legendTitle, series, subtitle, title, xLabel, yLabel, yMin]);
 
   return (
     <div>

--- a/app/client/src/components/shared/StackedBarChart.tsx
+++ b/app/client/src/components/shared/StackedBarChart.tsx
@@ -21,14 +21,17 @@ type Props = {
   legendTitle?: string;
   series: Array<{
     color?: string;
+    custom?: {
+      description?: string;
+    };
     data: number[];
     name: string;
     type: 'column';
   }>;
   subtitle?: string;
   title?: string;
-  xLabel?: string | null;
-  yLabel?: string | null;
+  xTitle?: string | null;
+  yTitle?: string | null;
   yMin?: number;
 };
 
@@ -38,14 +41,15 @@ export default function StackedBarChart({
   series,
   subtitle,
   title,
-  xLabel = null,
-  yLabel = null,
+  xTitle = null,
+  yTitle = null,
   yMin = 0,
 }: Props) {
   const options = useMemo<Options>(() => {
     return {
       chart: {
         backgroundColor: 'rgba(0, 0, 0, 0)',
+        height: '500px',
         style: { fontFamily: fonts.primary },
         type: 'column',
       },
@@ -84,11 +88,15 @@ export default function StackedBarChart({
         },
       },
       legend: {
+        labelFormatter: function () {
+          if (this.options.custom?.description) {
+            return `${this.name}<br /><span style="fontWeight:normal">${this.options.custom.description}</span>`;
+          } else return this.name;
+        },
         title: {
-          style: { display: 'flex', justifyContent: 'center' },
           text: legendTitle,
         },
-        verticalAlign: 'top',
+        verticalAlign: 'bottom',
       },
       plotOptions: {
         column: {
@@ -124,17 +132,17 @@ export default function StackedBarChart({
       xAxis: {
         categories,
         title: {
-          text: xLabel,
+          text: xTitle,
         },
       },
       yAxis: {
         min: yMin,
         title: {
-          text: yLabel,
+          text: yTitle,
         },
       },
     };
-  }, [categories, legendTitle, series, subtitle, title, xLabel, yLabel, yMin]);
+  }, [categories, legendTitle, series, subtitle, title, xTitle, yTitle, yMin]);
 
   return (
     <div>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1770,18 +1770,19 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
       </>
 
       <div css={showLessMoreStyles}>
-        <h3>Data Accuracy</h3>
+        <h3>Data Accuracy:</h3>
         <ShowLessMore
           charLimit={0}
           text={
             <>
               <p>
-                Daily data are a snapshot of cyanobacteria (historically
-                referred to as blue-green algae) at the time of detection. These
-                are provisional satellite derived measures of cyanobacteria,
-                which may contain errors. Information can be used to identify
-                potential problems related to cyanobacteria in larger lakes and
-                reservoirs within the contiguous United States.
+                Daily data are a snapshot of{' '}
+                <GlossaryTerm term="Cyanobacteria">cyanobacteria</GlossaryTerm>{' '}
+                (historically referred to as blue-green algae) at the time of
+                detection. These are provisional satellite derived measures of
+                cyanobacteria, which may contain errors. Information can be used
+                to identify potential problems related to cyanobacteria in
+                larger lakes and reservoirs within the contiguous United States.
               </p>
 
               <h3>Data Issues include:</h3>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1253,7 +1253,10 @@ type CellConcentrationData = {
 type ChartData = {
   categories: string[];
   series: Array<{
-    color?: string;
+    color: string;
+    custom: {
+      description: string;
+    };
     data: number[];
     name: string;
     type: 'column';
@@ -1487,10 +1490,38 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
     const emptyChartData: ChartData = {
       categories: [],
       series: [
-        { name: 'very high', data: [], color: '#fa5300', type: 'column' },
-        { name: 'high', data: [], color: '#ffa200', type: 'column' },
-        { name: 'medium', data: [], color: '#00bf46', type: 'column' },
-        { name: 'low', data: [], color: '#3700eb', type: 'column' },
+        {
+          name: 'very high',
+          color: '#fa5300',
+          custom: {
+            description: `${String.fromCharCode(0x2265)} 1,000,000 cells/mL`,
+          },
+          data: [],
+          type: 'column',
+        },
+        {
+          name: 'high',
+          color: '#ffa200',
+          custom: { description: '300,000 - 1,000,000 cells/mL' },
+          data: [],
+          type: 'column',
+        },
+        {
+          name: 'medium',
+          color: '#00bf46',
+          custom: { description: '100,000 - 300,000 cells/mL' },
+          data: [],
+          type: 'column',
+        },
+        {
+          name: 'low',
+          color: '#3700eb',
+          custom: {
+            description: `${String.fromCharCode(0x2264)} 100,000 cells/mL`,
+          },
+          data: [],
+          type: 'column',
+        },
       ],
     };
 
@@ -1556,16 +1587,20 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
         {cellConcentration.status === 'success' && (
           <>
             {chartData && (
-              <div css={chartContainerStyles}>
-                <StackedBarChart
-                  categories={chartData.categories}
-                  legendTitle="Cyanobacteria Concentration Categories"
-                  series={chartData.series}
-                  title={`Daily Cyanobacteria Estimates for ${attributes.GNIS_NAME}`}
-                  yLabel="Measurement count / CC range"
-                  xLabel="Date"
-                />
-              </div>
+              <StackedBarChart
+                categories={chartData.categories}
+                legendTitle="Cyanobacteria Concentration Categories:"
+                series={chartData.series}
+                title={`Daily Cyanobacteria Estimates for ${attributes.GNIS_NAME}`}
+                yTitle="
+                    <p>
+                      Number of Image Pixels
+                      <br />
+                      (each pixel represents a 300x300 meter area)
+                    </p>
+                  "
+                xTitle="Date"
+              />
             )}
 
             {/* A null `selectedDate` means no date with data was found */}
@@ -1606,7 +1641,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                 )}
 
                 <p css={subheadingStyles}>
-                  <HelpTooltip label="Statistics are calculated based on only the detected values in the waterbody area (colored areas in map)" />
+                  <HelpTooltip label="Statistics are calculated based on only the detected values in the waterbody area (colored areas in map)." />
                   &nbsp;&nbsp; Cyanobacteria Concentration Statistics for{' '}
                   <b>
                     {new Date(selectedDate).toLocaleDateString('en-US', {
@@ -1695,14 +1730,14 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
               <h3>Data Issues include:</h3>
               <ul>
                 <li>
-                  <b>Near-shore response:</b> mixed land/water pixels may be
-                  reading land vegetation and/or shallow water bottom foliage.
-                  It is not possible to discount reported concentration
-                  entirely, as a response may be valid due to wind action on a
-                  bloom resulting in shoreline accumulation. Data values
-                  reported should be considered in context of the local
-                  conditions near and within the waterbody. Data reported should
-                  be validated in situ.
+                  <b id="near-shore-response">Near-shore response:</b> mixed
+                  land/water pixels may be reading land vegetation and/or
+                  shallow water bottom foliage. It is not possible to discount
+                  reported concentration entirely, as a response may be valid
+                  due to wind action on a bloom resulting in shoreline
+                  accumulation. Data values reported should be considered in
+                  context of the local conditions near and within the waterbody.
+                  Data reported should be validated in situ.
                 </li>
                 <li>
                   <b>Estuaries:</b> data have not been validated for brine/salt
@@ -1719,7 +1754,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                   waterbodies (i.e., those not having the minimum 900x900m size)
                   may be evident in the data, and their cyanobacteria responses
                   are suspect and open to interpretation. See{' '}
-                  <b>“Near-shore response”</b> above.
+                  <a href="#near-shore-response">“Near-shore response”</a>{' '}
+                  above.
                 </li>
               </ul>
             </>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import WaterbodyIcon from 'components/shared/WaterbodyIcon';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
+import ShowLessMore from 'components/shared/ShowLessMore';
 import { Sparkline } from 'components/shared/Sparkline';
 import StackedBarChart from 'components/shared/StackedBarChart';
 import TickSlider from 'components/shared/TickSlider';
@@ -43,6 +44,7 @@ import { cyanError, waterbodyReportError } from 'config/errorMessages';
 import {
   colors,
   disclaimerStyles,
+  fonts,
   iconStyles,
   modifiedTableStyles,
   tableStyles,
@@ -1124,6 +1126,31 @@ const marginBoxStyles = (styles: FlattenSimpleInterpolation) => css`
   margin: 1em;
 `;
 
+const showLessMoreStyles = css`
+  button {
+    margin-bottom: 1.5em;
+  }
+
+  h3 {
+    font-family: ${fonts.primary};
+    font-size: 1em;
+    font-weight: bold;
+
+    &:first-of-type {
+      display: inline-block;
+    }
+  }
+
+  li,
+  ul {
+    padding-bottom: 0.5em;
+  }
+
+  p {
+    padding-bottom: 0.5em;
+  }
+`;
+
 const sliderContainerStyles = css`
   margin: auto;
   width: 90%;
@@ -1509,27 +1536,13 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
         <ListContent
           rows={[
             {
-              label: 'Area',
+              label: 'Waterbody Area',
               value: attributes.AREASQKM
                 ? `${formatNumber(
                     attributes.AREASQKM,
                     2,
                   )} km${String.fromCodePoint(0x00b2)}`
                 : '',
-            },
-            {
-              label: 'Elevation',
-              value: attributes.ELEVATION
-                ? `${formatNumber(attributes.ELEVATION, 1)} m`
-                : '',
-            },
-            {
-              label: 'Centroid Latitude',
-              value: attributes.c_lat ? formatNumber(attributes.c_lat, 4) : '',
-            },
-            {
-              label: 'Centroid Longitude',
-              value: attributes.c_lng ? formatNumber(attributes.c_lng, 4) : '',
             },
           ]}
           styles={listContentStyles}
@@ -1546,8 +1559,9 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
               <div css={chartContainerStyles}>
                 <StackedBarChart
                   categories={chartData.categories}
+                  legendTitle="Cyanobacteria Concentration Categories"
                   series={chartData.series}
-                  title="Cell Concentration Counts"
+                  title={`Daily Cyanobacteria Estimates for ${attributes.GNIS_NAME}`}
                   yLabel="Measurement count / CC range"
                   xLabel="Date"
                 />
@@ -1558,7 +1572,17 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
             {selectedDate ? (
               <>
                 <p css={subheadingStyles}>
-                  <HelpTooltip label="Adjust the slider handle to view the day's CyAN satellite imagery on the map" />
+                  <HelpTooltip
+                    label={
+                      <>
+                        Adjust the slider handle to view the day's CyAN
+                        satellite imagery on the map.
+                        <br />
+                        Data for the previous day typically becomes available
+                        between 9 - 11am EST.
+                      </>
+                    }
+                  />
                   &nbsp;&nbsp;
                   <b>Date Selection:</b>
                 </p>
@@ -1582,7 +1606,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                 )}
 
                 <p css={subheadingStyles}>
-                  Cell Concentration Statistics for{' '}
+                  <HelpTooltip label="Statistics are calculated based on only the detected values in the waterbody area (colored areas in map)" />
+                  &nbsp;&nbsp; Cyanobacteria Concentration Statistics for{' '}
                   <b>
                     {new Date(selectedDate).toLocaleDateString('en-US', {
                       year: 'numeric',
@@ -1601,18 +1626,33 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                   <ListContent
                     rows={[
                       {
-                        label: 'Count',
-                        value: countCc !== null ? formatNumber(countCc) : 0,
-                      },
-                      {
-                        label: 'Min',
+                        label: (
+                          <>
+                            <HelpTooltip
+                              label={
+                                <>
+                                  Minimum detected value in the waterbody area.
+                                  <br />
+                                  Values under 6.5K cells/mL cannot be detected
+                                  by satellite.
+                                </>
+                              }
+                            />
+                            &nbsp;&nbsp; Minimum Value
+                          </>
+                        ),
                         value:
                           minCc !== null
                             ? `${formatNumber(minCc, 2)} cells/mL`
                             : 'N/A',
                       },
                       {
-                        label: 'Max',
+                        label: (
+                          <>
+                            <HelpTooltip label="Maximum detected value in the waterbody area." />
+                            &nbsp;&nbsp; Maximum Value
+                          </>
+                        ),
                         value:
                           maxCc !== null
                             ? `${formatNumber(maxCc, 2)} cells/mL`
@@ -1636,6 +1676,57 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
           </>
         )}
       </>
+
+      <div css={showLessMoreStyles}>
+        <h3>Data Accuracy</h3>
+        <ShowLessMore
+          charLimit={0}
+          text={
+            <>
+              <p>
+                Daily data are a snapshot of cyanobacteria (historically
+                referred to as blue-green algae) at the time of detection. These
+                are provisional satellite derived measures of cyanobacteria,
+                which may contain errors. Information can be used to identify
+                potential problems related to cyanobacteria in larger lakes and
+                reservoirs within the contiguous United States.
+              </p>
+
+              <h3>Data Issues include:</h3>
+              <ul>
+                <li>
+                  <b>Near-shore response:</b> mixed land/water pixels may be
+                  reading land vegetation and/or shallow water bottom foliage.
+                  It is not possible to discount reported concentration
+                  entirely, as a response may be valid due to wind action on a
+                  bloom resulting in shoreline accumulation. Data values
+                  reported should be considered in context of the local
+                  conditions near and within the waterbody. Data reported should
+                  be validated in situ.
+                </li>
+                <li>
+                  <b>Estuaries:</b> data have not been validated for brine/salt
+                  water.
+                </li>
+                <li>
+                  <b>Rivers:</b> large flowing waterways are not masked and can
+                  have a cyanobacteria response that is not validated.
+                </li>
+                <li>
+                  A resolvable waterbody is considered to have, at minimum, a
+                  3x3 raster cell matrix size (900x900m), with the center pixel
+                  being considered valid. Smaller or irregularly shaped
+                  waterbodies (i.e., those not having the minimum 900x900m size)
+                  may be evident in the data, and their cyanobacteria responses
+                  are suspect and open to interpretation. See{' '}
+                  <b>“Near-shore response”</b> above.
+                </li>
+              </ul>
+            </>
+          }
+        />
+      </div>
+
       {services?.status === 'success' && (
         <div css={linkSectionStyles}>
           <p>
@@ -1656,7 +1747,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                   aria-hidden="true"
                 />
               </HelpTooltip>
-              Download Cell Concentration Data
+              Download Cyanobacteria Data
             </a>
           </p>
           <p>
@@ -1667,10 +1758,10 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
             >
               <i
                 css={iconStyles}
-                className="fas fa-satellite"
+                className="fas fa-info-circle"
                 aria-hidden="true"
               />
-              CyAN Web Application
+              More Information
             </a>
             &nbsp;&nbsp;
             <small>(opens new browser tab)</small>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1787,7 +1787,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
               <h3>Data Issues include:</h3>
               <ul>
                 <li>
-                  <b id={`${attributes.FID}-near-shore-response`}>
+                  <b id={`near-shore-response-${attributes.FID}`}>
                     Near-shore response:
                   </b>{' '}
                   mixed land/water pixels may be reading land vegetation and/or
@@ -1813,7 +1813,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                   waterbodies (i.e., those not having the minimum 900x900m size)
                   may be evident in the data, and their cyanobacteria responses
                   are suspect and open to interpretation. See{' '}
-                  <a href={`#${attributes.FID}-near-shore-response`}>
+                  <a href={`#near-shore-response-${attributes.FID}`}>
                     “Near-shore response”
                   </a>{' '}
                   above.

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -55,7 +55,7 @@
   "sfdw": "https://ordspub.epa.gov/ords/sfdw/",
   "landCover": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2019_Land_Cover_L48/wms?service=WMS&request=GetCapabilities",
   "cyan": {
-    "application": "https://qed.epa.gov/cyanweb",
+    "application": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
     "cellConcentration": "https://qed.epa.gov/waterbody/data",
     "dataDownload": "https://qed.epa.gov/waterbody/data_download",
     "images": "https://qed.epa.gov/waterbody/image",


### PR DESCRIPTION
## Related Issues:
* [HMW-379](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-379)

## Main Changes:
* Removed the _Elevation_, _Centroid Latitude_, _Centroid Longitude_, and _Count_ rows from the CyAN panel.
* Added tooltips to several rows.
* Updated the _Current Water Conditions_ descriptive text.
* Added descriptive text to the CyAN panel.
* Added a histogram to to the CyAN panel to display daily cell concentration data.

## Steps To Test:
1. Navigate to the Lake Mattamuskeet watershed, i.e. http://localhost:3000/community/030201050101/monitoring, then expand the Lake Mattamuskeet accordion item.
2. Confirm that the appearance of the panel aligns with the edits requested (attached in the corresponding Jira ticket).