### PR TITLE
Bugfix/380 cyan chart download

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -18,7 +18,7 @@
         "@visx/xychart": "2.16.0",
         "eslint-config-react-app": "7.0.1",
         "glossary-panel": "github:Eastern-Research-Group/glossary",
-        "highcharts": "10.3.1",
+        "highcharts": "9.3.3",
         "highcharts-react-official": "3.1.0",
         "papaparse": "5.3.2",
         "react": "17.0.2",
@@ -9764,9 +9764,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.1.tgz",
-      "integrity": "sha512-8UgVcLmgpiYwnsII0Ht76O+GRutfbrLslZFH3c53fXgl3aZ6NRB4mW5qsIyfsUExMny/n9JqYO/BFNejOKC6AA=="
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
+      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
     },
     "node_modules/highcharts-react-official": {
       "version": "3.1.0",
@@ -25845,9 +25845,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "highcharts": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.3.1.tgz",
-      "integrity": "sha512-8UgVcLmgpiYwnsII0Ht76O+GRutfbrLslZFH3c53fXgl3aZ6NRB4mW5qsIyfsUExMny/n9JqYO/BFNejOKC6AA=="
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.3.tgz",
+      "integrity": "sha512-QeOvm6cifeZYYdTLm4IxZsXcOE9c4xqfs0z0OJJ0z7hhA9WG0rmcVAyuIp5HBl/znjA/ayYHmpYjBYD/9PG4Fg=="
     },
     "highcharts-react-official": {
       "version": "3.1.0",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -65,7 +65,7 @@
     "@visx/xychart": "2.16.0",
     "eslint-config-react-app": "7.0.1",
     "glossary-panel": "github:Eastern-Research-Group/glossary",
-    "highcharts": "10.3.1",
+    "highcharts": "9.3.3",
     "highcharts-react-official": "3.1.0",
     "papaparse": "5.3.2",
     "react": "17.0.2",

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -3,22 +3,20 @@ import HighchartsReact from 'highcharts-react-official';
 import highchartsAccessibility from 'highcharts/modules/accessibility';
 import highchartsExporting from 'highcharts/modules/exporting';
 import highchartsHistogram from 'highcharts/modules/histogram-bellcurve';
-import highchartsOfflineExporting from 'highcharts/modules/offline-exporting';
 import { useMemo, useRef } from 'react';
 // styles
 import { fonts } from 'styles/index.js';
 // types
 import type { Options } from 'highcharts';
 
-// add accessibility features to highcharts
-highchartsAccessibility(Highcharts);
+// add histogram module to highcharts
+highchartsHistogram(Highcharts);
 
 // add exporting features to highcharts
 highchartsExporting(Highcharts);
-highchartsOfflineExporting(Highcharts);
 
-// add histogram module to highcharts
-highchartsHistogram(Highcharts);
+// add accessibility features to highcharts
+highchartsAccessibility(Highcharts);
 
 type Props = {
   categories: string[];
@@ -44,6 +42,20 @@ type Props = {
   yMin?: number;
 };
 
+// Workaround for the Download SVG not working with the accessibility module.
+Highcharts.addEvent(
+  Highcharts.Chart.prototype,
+  'afterA11yUpdate',
+  function (e: Event | Highcharts.Dictionary<any> | undefined) {
+    if (!e || !('accessibility' in e)) return;
+
+    const a11y = e.accessibility;
+    if ((this as any).renderer.forExport && a11y && a11y.proxyProvider) {
+      a11y.proxyProvider.destroy();
+    }
+  },
+);
+
 export default function Histogram({
   categories,
   height,
@@ -63,15 +75,18 @@ export default function Histogram({
         height: height ?? '300px',
         style: { fontFamily: fonts.primary },
         type: 'histogram',
-        zooming: {
-          type: 'x',
-        },
+        zoomType: 'x',
       },
       credits: { enabled: false },
       exporting: {
         buttons: {
           contextButton: {
-            menuItems: ['printChart'],
+            menuItems: [
+              'downloadPNG',
+              'downloadJPEG',
+              'downloadPDF',
+              'downloadSVG',
+            ],
             theme: {
               fill: 'rgba(0, 0, 0, 0)',
               states: {
@@ -86,28 +101,11 @@ export default function Histogram({
             },
           },
         },
-        menuItemDefinitions: {
-          printChart: {
-            onclick: function () {
-              const divToPrint = chartRef.current?.container.current;
-              if (!divToPrint) return;
-
-              const newWin = window.open();
-              if (!newWin) return;
-
-              newWin.document.write(divToPrint.innerHTML);
-              newWin.document.close();
-              newWin.focus();
-              newWin.print();
-              newWin.close();
-            },
-          },
-        },
       },
       legend: {
         enabled: false,
       },
-      series,
+      series: series as any, // workaround for an issue with the histogram type only accepting undefined for series
       subtitle: {
         text: subtitle,
       },

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -28,7 +28,7 @@ type Props = {
     };
     data: number[];
     name: string;
-    type: 'histogram';
+    type: 'column';
     zoneAxis?: 'x' | 'y';
     zones?: Array<{
       color: string;
@@ -74,7 +74,7 @@ export default function Histogram({
         backgroundColor: 'rgba(0, 0, 0, 0)',
         height: height ?? '300px',
         style: { fontFamily: fonts.primary },
-        type: 'histogram',
+        type: 'column',
         zoomType: 'x',
       },
       credits: { enabled: false },
@@ -105,7 +105,13 @@ export default function Histogram({
       legend: {
         enabled: false,
       },
-      series: series as any, // workaround for an issue with the histogram type only accepting undefined for series
+      plotOptions: {
+        column: {
+          groupPadding: 0,
+          pointPadding: 0,
+        },
+      },
+      series,
       subtitle: {
         text: subtitle,
       },

--- a/app/client/src/components/shared/Histogram.tsx
+++ b/app/client/src/components/shared/Histogram.tsx
@@ -50,7 +50,7 @@ Highcharts.addEvent(
     if (!e || !('accessibility' in e)) return;
 
     const a11y = e.accessibility;
-    if ((this as any).renderer.forExport && a11y && a11y.proxyProvider) {
+    if ((this.renderer as any).forExport && a11y && a11y.proxyProvider) {
       a11y.proxyProvider.destroy();
     }
   },

--- a/app/client/src/components/shared/StackedBarChart.tsx
+++ b/app/client/src/components/shared/StackedBarChart.tsx
@@ -2,19 +2,17 @@ import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import highchartsAccessibility from 'highcharts/modules/accessibility';
 import highchartsExporting from 'highcharts/modules/exporting';
-import highchartsOfflineExporting from 'highcharts/modules/offline-exporting';
 import { useMemo, useRef } from 'react';
 // styles
 import { fonts } from 'styles/index.js';
 // types
 import type { Options } from 'highcharts';
 
-// add accessibility features to highcharts
-highchartsAccessibility(Highcharts);
-
 // add exporting features to highcharts
 highchartsExporting(Highcharts);
-highchartsOfflineExporting(Highcharts);
+
+// add accessibility features to highcharts
+highchartsAccessibility(Highcharts);
 
 type Props = {
   caption?: string;
@@ -36,6 +34,20 @@ type Props = {
   yTitle?: string | null;
   yMin?: number;
 };
+
+// Workaround for the Download SVG not working with the accessibility module.
+Highcharts.addEvent(
+  Highcharts.Chart.prototype,
+  'afterA11yUpdate',
+  function (e: Event | Highcharts.Dictionary<any> | undefined) {
+    if (!e || !('accessibility' in e)) return;
+
+    const a11y = e.accessibility;
+    if ((this as any).renderer.forExport && a11y && a11y.proxyProvider) {
+      a11y.proxyProvider.destroy();
+    }
+  },
+);
 
 export default function StackedBarChart({
   caption,
@@ -67,7 +79,12 @@ export default function StackedBarChart({
       exporting: {
         buttons: {
           contextButton: {
-            menuItems: ['printChart'],
+            menuItems: [
+              'downloadPNG',
+              'downloadJPEG',
+              'downloadPDF',
+              'downloadSVG',
+            ],
             theme: {
               fill: 'rgba(0, 0, 0, 0)',
               states: {
@@ -88,23 +105,6 @@ export default function StackedBarChart({
               dataLabels: {
                 enabled: true,
               },
-            },
-          },
-        },
-        menuItemDefinitions: {
-          printChart: {
-            onclick: function () {
-              const divToPrint = chartRef.current?.container.current;
-              if (!divToPrint) return;
-
-              const newWin = window.open();
-              if (!newWin) return;
-
-              newWin.document.write(divToPrint.innerHTML);
-              newWin.document.close();
-              newWin.focus();
-              newWin.print();
-              newWin.close();
             },
           },
         },
@@ -136,7 +136,7 @@ export default function StackedBarChart({
         borderColor: '#000000',
         formatter: function () {
           return (
-            this.points?.reduce((s, point) => {
+            this.points?.reduce((s: any, point: any) => {
               return (
                 s +
                 `<tr>

--- a/app/client/src/components/shared/StackedBarChart.tsx
+++ b/app/client/src/components/shared/StackedBarChart.tsx
@@ -43,7 +43,7 @@ Highcharts.addEvent(
     if (!e || !('accessibility' in e)) return;
 
     const a11y = e.accessibility;
-    if ((this as any).renderer.forExport && a11y && a11y.proxyProvider) {
+    if ((this.renderer as any).forExport && a11y && a11y.proxyProvider) {
       a11y.proxyProvider.destroy();
     }
   },

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1247,7 +1247,7 @@ type CellConcentrationData = {
   [date: string]: number[];
 };
 
-type ChartData<T> = {
+type ChartData = {
   categories: string[];
   series: Array<{
     color?: string;
@@ -1256,7 +1256,7 @@ type ChartData<T> = {
     };
     data: number[];
     name: string;
-    type: T;
+    type: 'column';
     zoneAxis?: 'x' | 'y';
     zones?: Array<{
       color: string;
@@ -1360,8 +1360,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
   const [averageCc, setAverageCc] = useState<number | null>(null);
   const [stdDevCc, setStdDevCc] = useState<number | null>(null);
   const [countCc, setCountCc] = useState<number | null>(null);
-  const [histogramData, setHistogramData] =
-    useState<ChartData<'histogram'> | null>(null);
+  const [histogramData, setHistogramData] = useState<ChartData | null>(null);
 
   // Calculate statistics for the selected date and
   // set the data for the daily histogram
@@ -1391,7 +1390,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
         {
           name: 'Cell Concentration Counts',
           data: selectedData,
-          type: 'histogram',
+          type: 'column',
           zoneAxis: 'x',
           zones: [
             { color: '#3700eb', value: CcIdx.Medium },
@@ -1501,9 +1500,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
     };
   }, [mapView]);
 
-  const [barChartData, setBarChartData] = useState<ChartData<'column'> | null>(
-    null,
-  );
+  const [barChartData, setBarChartData] = useState<ChartData | null>(null);
 
   // Group the daily data by predetermined
   // thresholds for the weekly bar chart
@@ -1513,7 +1510,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
       return;
     }
 
-    const emptyBarChartData: ChartData<'column'> = {
+    const emptyBarChartData: ChartData = {
       categories: [],
       series: [
         {


### PR DESCRIPTION
## Related Issues:
* [HMW-380](https://jira.epa.gov/browse/HMW-380)
* PR #774

## Main Changes:
* Rolled back the highcharts version to v9.3.3 to fix downloading images. 
  * I noticed in the documentation that highcharts recommends using the accessibility module last. The documentation is showing CDN imports, but I figured it is probably safe to just reorder them anyways. https://www.highcharts.com/docs/accessibility/accessibility-module
  * The SVG download still didn't work so I added an additional workaround to fix that.
  * For the histogram I just set the type for `series` to `any` and left a comment indicating why.

## Steps To Test:
1. Navigate to http://localhost:3000/community/lake%20okechobee/monitoring
2. Verify all of the download buttons work for the bar chart and histogram chart
3. Verify the zooming x axis works for the histogram

## TODO:
- [ ] Continue looking into why download buttons in highcharts v10 don't work in HMW. This may get punted to a future release.
