### PR TITLE
Feature/382 turn on monitoring layer

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -112,7 +112,7 @@ function IdentifiedIssues() {
 
   const [showIssuesLayer, setShowIssuesLayer] = useState(true);
 
-  const [showDischargersLayer, setShowDischargersLayer] = useState(true);
+  const [showDischargersLayer, setShowDischargersLayer] = useState(false);
 
   const setViolatingFacilities = useCallback(
     (data: Object) => {
@@ -615,7 +615,14 @@ function IdentifiedIssues() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs>
+        <Tabs
+          onChange={(index) => {
+            if (index === 0 && !toggleIssuesChecked)
+              toggleSwitch('Toggle Issues Layer');
+            if (index === 1 && !toggleDischargersChecked)
+              toggleSwitch('Toggle Dischargers Layer');
+          }}
+        >
           <TabList>
             <Tab>Impaired Assessed Waters</Tab>
             <Tab data-testid="hmw-dischargers">
@@ -646,11 +653,12 @@ function IdentifiedIssues() {
                     </p>
                   )}
 
-                  {cipSummary.data.items && cipSummary.data.items.length > 0 && (
-                    <>
-                      <p>
-                        {/* NOTE: removed until EPA determines correct value */}
-                        {/* {assessedPercent > 0 && (
+                  {cipSummary.data.items &&
+                    cipSummary.data.items.length > 0 && (
+                      <>
+                        <p>
+                          {/* NOTE: removed until EPA determines correct value */}
+                          {/* {assessedPercent > 0 && (
                           <span>
                             <strong>{assessedPercent}%</strong> of waters in
                             your watershed have been assessed.
@@ -666,128 +674,134 @@ function IdentifiedIssues() {
                         )}
                         <br /> */}
 
-                        <DisclaimerModal>
-                          <p>
-                            The condition of a waterbody is dynamic and can
-                            change at any time, and the information in How’s My
-                            Waterway should only be used for general reference.
-                            If available, refer to local or state real-time
-                            water quality reports.
-                          </p>
+                          <DisclaimerModal>
+                            <p>
+                              The condition of a waterbody is dynamic and can
+                              change at any time, and the information in How’s
+                              My Waterway should only be used for general
+                              reference. If available, refer to local or state
+                              real-time water quality reports.
+                            </p>
 
-                          <p>
-                            Furthermore, users of this application should not
-                            rely on information relating to environmental laws
-                            and regulations posted on this application.
-                            Application users are solely responsible for
-                            ensuring that they are in compliance with all
-                            relevant environmental laws and regulations. In
-                            addition, EPA cannot attest to the accuracy of data
-                            provided by organizations outside of the federal
-                            government.
-                          </p>
-                        </DisclaimerModal>
-                      </p>
-
-                      {emptyCategoriesWithPercent && (
-                        <p css={centeredTextStyles}>
-                          Impairment Summary information is temporarily
-                          unavailable for the {watershed} watershed. Please see
-                          the Overview tab for specific impairment information
-                          on these waters.
+                            <p>
+                              Furthermore, users of this application should not
+                              rely on information relating to environmental laws
+                              and regulations posted on this application.
+                              Application users are solely responsible for
+                              ensuring that they are in compliance with all
+                              relevant environmental laws and regulations. In
+                              addition, EPA cannot attest to the accuracy of
+                              data provided by organizations outside of the
+                              federal government.
+                            </p>
+                          </DisclaimerModal>
                         </p>
-                      )}
 
-                      {!emptyCategoriesWithPercent && zeroPollutedWaterbodies && (
-                        <p css={centeredTextStyles}>
-                          There are no impairment categories in the{' '}
-                          <em>{watershed}</em> watershed.
-                        </p>
-                      )}
-
-                      {!emptyCategoriesWithPercent && !zeroPollutedWaterbodies && (
-                        <>
-                          <p>
-                            Impairment categories in the {watershed} watershed.
+                        {emptyCategoriesWithPercent && (
+                          <p css={centeredTextStyles}>
+                            Impairment Summary information is temporarily
+                            unavailable for the {watershed} watershed. Please
+                            see the Overview tab for specific impairment
+                            information on these waters.
                           </p>
+                        )}
 
-                          <table css={toggleTableStyles} className="table">
-                            <thead>
-                              <tr>
-                                <th>
-                                  <div css={toggleStyles}>
-                                    <Switch
-                                      checked={showAllParameters}
-                                      onChange={(ev) => {
-                                        toggleSwitch('Toggle All');
-                                      }}
-                                      ariaLabel="Toggle all impairment categories"
-                                    />
-                                    <span>Identified Issues</span>
-                                  </div>
-                                </th>
-                                <th>% of Assessed Area</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              {cipSummary.data.items[0].summaryByParameterImpairments.map(
-                                (param) => {
-                                  const percent = formatNumber(
-                                    Math.min(
-                                      100,
-                                      (param['catchmentSizeSqMi'] /
-                                        cipSummary.data.items[0]
-                                          .assessedCatchmentAreaSqMi) *
-                                        100,
-                                    ),
-                                  );
+                        {!emptyCategoriesWithPercent &&
+                          zeroPollutedWaterbodies && (
+                            <p css={centeredTextStyles}>
+                              There are no impairment categories in the{' '}
+                              <em>{watershed}</em> watershed.
+                            </p>
+                          )}
 
-                                  const mappedParameter = getMappedParameter(
-                                    impairmentFields,
-                                    param['parameterGroupName'],
-                                  );
-                                  // if service contains a parameter we have no mapping for
-                                  if (!mappedParameter) return false;
+                        {!emptyCategoriesWithPercent &&
+                          !zeroPollutedWaterbodies && (
+                            <>
+                              <p>
+                                Impairment categories in the {watershed}{' '}
+                                watershed.
+                              </p>
 
-                                  return (
-                                    <tr key={mappedParameter.label}>
-                                      <td>
-                                        <div css={toggleStyles}>
-                                          <Switch
-                                            ariaLabel={mappedParameter.label}
-                                            checked={
-                                              parameterToggleObject[
-                                                mappedParameter.label
-                                              ]
-                                            }
-                                            onChange={(ev) => {
-                                              toggleSwitch(
-                                                mappedParameter.label,
-                                              );
-                                            }}
-                                          />
-                                          <GlossaryTerm
-                                            term={mappedParameter.term}
-                                          >
-                                            {mappedParameter.label}
-                                          </GlossaryTerm>
-                                        </div>
-                                      </td>
-                                      <td>
-                                        {nullPollutedWaterbodies === true
-                                          ? 'N/A'
-                                          : percent + '%'}
-                                      </td>
-                                    </tr>
-                                  );
-                                },
-                              )}
-                            </tbody>
-                          </table>
-                        </>
-                      )}
-                    </>
-                  )}
+                              <table css={toggleTableStyles} className="table">
+                                <thead>
+                                  <tr>
+                                    <th>
+                                      <div css={toggleStyles}>
+                                        <Switch
+                                          checked={showAllParameters}
+                                          onChange={(ev) => {
+                                            toggleSwitch('Toggle All');
+                                          }}
+                                          ariaLabel="Toggle all impairment categories"
+                                        />
+                                        <span>Identified Issues</span>
+                                      </div>
+                                    </th>
+                                    <th>% of Assessed Area</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {cipSummary.data.items[0].summaryByParameterImpairments.map(
+                                    (param) => {
+                                      const percent = formatNumber(
+                                        Math.min(
+                                          100,
+                                          (param['catchmentSizeSqMi'] /
+                                            cipSummary.data.items[0]
+                                              .assessedCatchmentAreaSqMi) *
+                                            100,
+                                        ),
+                                      );
+
+                                      const mappedParameter =
+                                        getMappedParameter(
+                                          impairmentFields,
+                                          param['parameterGroupName'],
+                                        );
+                                      // if service contains a parameter we have no mapping for
+                                      if (!mappedParameter) return false;
+
+                                      return (
+                                        <tr key={mappedParameter.label}>
+                                          <td>
+                                            <div css={toggleStyles}>
+                                              <Switch
+                                                ariaLabel={
+                                                  mappedParameter.label
+                                                }
+                                                checked={
+                                                  parameterToggleObject[
+                                                    mappedParameter.label
+                                                  ]
+                                                }
+                                                onChange={(ev) => {
+                                                  toggleSwitch(
+                                                    mappedParameter.label,
+                                                  );
+                                                }}
+                                              />
+                                              <GlossaryTerm
+                                                term={mappedParameter.term}
+                                              >
+                                                {mappedParameter.label}
+                                              </GlossaryTerm>
+                                            </div>
+                                          </td>
+                                          <td>
+                                            {nullPollutedWaterbodies === true
+                                              ? 'N/A'
+                                              : percent + '%'}
+                                          </td>
+                                        </tr>
+                                      );
+                                    },
+                                  )}
+                                </tbody>
+                              </table>
+                            </>
+                          )}
+                      </>
+                    )}
                 </>
               )}
             </TabPanel>

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -555,6 +555,13 @@ function IdentifiedIssues() {
     toggleDischargersChecked = false;
   }
 
+  const handleTabClick = (index) => {
+    if (index === 0 && !toggleIssuesChecked)
+      toggleSwitch('Toggle Issues Layer');
+    if (index === 1 && !toggleDischargersChecked)
+      toggleSwitch('Toggle Dischargers Layer');
+  };
+
   function getImpairedWatersPercent() {
     if (cipSummary.status === 'failure') return 'N/A';
     return nullPollutedWaterbodies ? 'N/A %' : `${pollutedPercent}%` || 0 + '%';
@@ -615,14 +622,7 @@ function IdentifiedIssues() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs
-          onChange={(index) => {
-            if (index === 0 && !toggleIssuesChecked)
-              toggleSwitch('Toggle Issues Layer');
-            if (index === 1 && !toggleDischargersChecked)
-              toggleSwitch('Toggle Dischargers Layer');
-          }}
-        >
+        <Tabs onChange={handleTabClick}>
           <TabList>
             <Tab>Impaired Assessed Waters</Tab>
             <Tab data-testid="hmw-dischargers">

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -555,12 +555,12 @@ function IdentifiedIssues() {
     toggleDischargersChecked = false;
   }
 
-  const handleTabClick = (index) => {
+  function handleTabClick(index) {
     if (index === 0 && !toggleIssuesChecked)
       toggleSwitch('Toggle Issues Layer');
     if (index === 1 && !toggleDischargersChecked)
       toggleSwitch('Toggle Dischargers Layer');
-  };
+  }
 
   function getImpairedWatersPercent() {
     if (cipSummary.status === 'failure') return 'N/A';

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -467,6 +467,14 @@ function Monitoring() {
     [monitoringLocationsLayer, setVisibleLayers, visibleLayers],
   );
 
+  const handleTabClick = useCallback(
+    (index) => {
+      if (index === 0) handleCurrentWaterConditionsToggle(true);
+      if (index === 1) handlePastWaterConditionsToggle(true);
+    },
+    [handleCurrentWaterConditionsToggle, handlePastWaterConditionsToggle],
+  );
+
   const totalCurrentWaterConditions =
     (usgsStreamgages.data.value?.length ?? 0) +
     (cyanWaterbodies.data?.length ?? 0);
@@ -529,12 +537,7 @@ function Monitoring() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs
-          onChange={(index) => {
-            if (index === 0) handleCurrentWaterConditionsToggle(true);
-            if (index === 1) handlePastWaterConditionsToggle(true);
-          }}
-        >
+        <Tabs onChange={handleTabClick}>
           <TabList>
             <Tab>Current Water Conditions</Tab>
             <Tab>Past Water Conditions</Tab>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -529,7 +529,12 @@ function Monitoring() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs>
+        <Tabs
+          onChange={(index) => {
+            if (index === 0) handleCurrentWaterConditionsToggle(true);
+            if (index === 1) handlePastWaterConditionsToggle(true);
+          }}
+        >
           <TabList>
             <Tab>Current Water Conditions</Tab>
             <Tab>Past Water Conditions</Tab>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -421,7 +421,13 @@ function Overview() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs>
+        <Tabs
+          onChange={(index) => {
+            if (index === 0) handleWaterbodiesToggle(true);
+            if (index === 1) handleMonitoringLocationsToggle(true);
+            if (index === 2) handlePermittedDischargersToggle(true);
+          }}
+        >
           <TabList>
             <Tab>Waterbodies</Tab>
             <Tab>Monitoring Locations</Tab>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -284,6 +284,19 @@ function Overview() {
     [dischargersLayer, updateVisibleLayers],
   );
 
+  const handleTabClick = useCallback(
+    (index) => {
+      if (index === 0) handleWaterbodiesToggle(true);
+      if (index === 1) handleMonitoringLocationsToggle(true);
+      if (index === 2) handlePermittedDischargersToggle(true);
+    },
+    [
+      handleMonitoringLocationsToggle,
+      handlePermittedDischargersToggle,
+      handleWaterbodiesToggle,
+    ],
+  );
+
   const waterbodies = useWaterbodyFeatures();
 
   const uniqueWaterbodies = waterbodies
@@ -421,13 +434,7 @@ function Overview() {
       </div>
 
       <div css={tabsStyles}>
-        <Tabs
-          onChange={(index) => {
-            if (index === 0) handleWaterbodiesToggle(true);
-            if (index === 1) handleMonitoringLocationsToggle(true);
-            if (index === 2) handlePermittedDischargersToggle(true);
-          }}
-        >
+        <Tabs onChange={handleTabClick}>
           <TabList>
             <Tab>Waterbodies</Tab>
             <Tab>Monitoring Locations</Tab>

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -386,7 +386,7 @@ const tabs = [
     lower: <IdentifiedIssues />,
     layers: {
       issuesLayer: true,
-      dischargersLayer: true,
+      dischargersLayer: false,
       monitoringLocationsLayer: false,
       usgsStreamgagesLayer: false,
     },


### PR DESCRIPTION
## Related Issues:
* [HMW-382](https://jira.epa.gov/browse/HMW-382)

## Main Changes:
* Updated the Overview, Monitoring, and Identified Issues panels such that clicking on a tab turns on the associated (

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Click on the `Monitoring Locations` tab
3. Verify the `USGS Sensors` and `Past Water Conditions` layers are turned on
4. Click on the `Permitted Dischargers` tab
5. Verify the `Permitted Dischargers` layer is turned on
6. Turn off the `Waterbodies` switch
7. Click on the `Waterbodies` tab
8. Verify the `Waterbodies` layer is turned on
9. Navigate to http://localhost:3000/community/dc/monitoring
10. Click on the `Past Water Conditions` tab
11. Verify the `Past Water Conditions` layer is turned on
12. Turn off the `Current Water Conditions` switch
13. Click on the `Current Water Conditions` tab
14. Verify the `USGS Sensors` layer is turned on
15. Navigate to http://localhost:3000/community/dc/identified-issues
16. Click on the `Dischargers with Significant Violations` tab
17. Verify the `Dischargers` layer is turned on
18. Turn off the `of Assessed Waters are impaired` switch
19. Click on the `Impaired Assessed Waters` tab
20. Verify the `Identified Issues` layer is turned on

