### PR TITLE
Feature/394 formatting changes

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -110,6 +110,11 @@ const modifiedToggleTableStyles = css`
   }
 `;
 
+const showLessMoreStyles = css`
+  display: block;
+  padding-top: 1.5em;
+`;
+
 const sliderContainerStyles = css`
   align-items: flex-end;
   display: flex;
@@ -563,21 +568,22 @@ function Monitoring() {
                   charLimit={0}
                   text={
                     <>
-                      <br />
-                      <br />
-                      Areas highlighted light blue are the lakes, reservoirs,
-                      and other large waterbodies where CyAN satellite imagery
-                      data is available. Daily data are a snapshot of{' '}
-                      <GlossaryTerm term="Cyanobacteria">
-                        cyanobacteria
-                      </GlossaryTerm>{' '}
-                      (sometimes referred to as blue-green algae) at the time of
-                      detection.
-                      <br />
-                      <br />
-                      Click on each monitoring location on the map or in the
-                      list below to find out more about what was monitored at
-                      each location.
+                      <span css={showLessMoreStyles}>
+                        Areas highlighted light blue are the lakes, reservoirs,
+                        and other large waterbodies where CyAN satellite imagery
+                        data is available. Daily data are a snapshot of{' '}
+                        <GlossaryTerm term="Cyanobacteria">
+                          cyanobacteria
+                        </GlossaryTerm>{' '}
+                        (sometimes referred to as blue-green algae) at the time
+                        of detection.
+                      </span>
+
+                      <span css={showLessMoreStyles}>
+                        Click on each monitoring location on the map or in the
+                        list below to find out more about what was monitored at
+                        each location.
+                      </span>
                     </>
                   }
                 />
@@ -621,13 +627,11 @@ function Monitoring() {
                 anywhere in between, depending on the location.
                 <ShowLessMore
                   text={
-                    <>
-                      <br />
-                      <br />
+                    <span css={showLessMoreStyles}>
                       Click on each monitoring location on the map or in the
                       list below to find out more about what was monitored at
                       each location."
-                    </>
+                    </span>
                   }
                 />
               </p>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -110,10 +110,6 @@ const modifiedToggleTableStyles = css`
   }
 `;
 
-const sectionStyles = css`
-  padding-bottom: 1.5em;
-`;
-
 const sliderContainerStyles = css`
   align-items: flex-end;
   display: flex;
@@ -563,31 +559,29 @@ function Monitoring() {
                 that provide real time water quality measurements – such as
                 water level, water temperature, dissolved oxygen saturation, and
                 other water quality indicators.
-              </p>
-              <div css={sectionStyles}>
                 <ShowLessMore
                   charLimit={0}
                   text={
                     <>
-                      <p>
-                        Areas highlighted light blue are the lakes, reservoirs,
-                        and other large waterbodies where CyAN satellite imagery
-                        data is available. Daily data are a snapshot of{' '}
-                        <GlossaryTerm term="Cyanobacteria">
-                          cyanobacteria
-                        </GlossaryTerm>{' '}
-                        (sometimes referred to as blue-green algae) at the time
-                        of detection.
-                      </p>
-                      <p>
-                        Click on each monitoring location on the map or in the
-                        list below to find out more about what was monitored at
-                        each location.
-                      </p>
+                      <br />
+                      <br />
+                      Areas highlighted light blue are the lakes, reservoirs,
+                      and other large waterbodies where CyAN satellite imagery
+                      data is available. Daily data are a snapshot of{' '}
+                      <GlossaryTerm term="Cyanobacteria">
+                        cyanobacteria
+                      </GlossaryTerm>{' '}
+                      (sometimes referred to as blue-green algae) at the time of
+                      detection.
+                      <br />
+                      <br />
+                      Click on each monitoring location on the map or in the
+                      list below to find out more about what was monitored at
+                      each location.
                     </>
                   }
                 />
-              </div>
+              </p>
 
               <div css={legendItemsStyles}>
                 <span>
@@ -625,19 +619,18 @@ function Monitoring() {
                 available. These locations may have monitoring data available
                 from as recently as last week, to multiple decades old, or
                 anywhere in between, depending on the location.
-              </p>
-
-              <div css={sectionStyles}>
                 <ShowLessMore
                   text={
-                    <p>
+                    <>
+                      <br />
+                      <br />
                       Click on each monitoring location on the map or in the
                       list below to find out more about what was monitored at
                       each location."
-                    </p>
+                    </>
                   }
                 />
-              </div>
+              </p>
 
               <div css={legendItemsStyles}>
                 <span>

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -110,6 +110,14 @@ const disclaimerStyles = css`
   display: inline-block;
 `;
 
+const listStyles = css`
+  padding-bottom: 1em;
+
+  li {
+    margin: 0.5em 0;
+  }
+`;
+
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
   margin-bottom: 1em;
@@ -1483,7 +1491,7 @@ function Protect() {
                 </i>
               </h2>
 
-              <ul>
+              <ul css={listStyles}>
                 <li>
                   <a
                     href="https://www.epa.gov/system/files/documents/2021-12/ws-outdoor-water-smart-landscapes.pdf"
@@ -1591,7 +1599,7 @@ function Protect() {
                 </i>
               </h2>
 
-              <ul>
+              <ul css={listStyles}>
                 <li>
                   <a
                     href="https://www.epa.gov/hw/household-hazardous-waste-hhw"
@@ -1676,7 +1684,7 @@ function Protect() {
                 <i css={subTitleStyles}>Get involved in your local watershed</i>
               </h2>
 
-              <ul>
+              <ul css={listStyles}>
                 <li>
                   Volunteer at a{' '}
                   <a
@@ -1750,7 +1758,7 @@ function Protect() {
                 <i css={subTitleStyles}>School and Work</i>
               </h2>
 
-              <ul>
+              <ul css={listStyles}>
                 <li>
                   Host a campus clean-up to remove litter and trash around your
                   school.
@@ -1827,7 +1835,7 @@ function Protect() {
 
               <h2>For more information and tips, visit the following sites:</h2>
 
-              <ul>
+              <ul css={listStyles}>
                 <li>
                   Visit EPA’s{' '}
                   <a


### PR DESCRIPTION
## Related Issues:
* [HMW-394](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-394)

## Main Changes:
* Moved the "Show More" buttons on the **Monitoring** tab inline with the preceding paragraph. Previously, they were in a separate block.
* Added spacing between list items in the "Tips for Protecting Your Watershed" section of the **Protect** tab.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/monitoring.
2. In both the _Current Water Conditions_ and _Past Water Conditions_, verify that the "Show More" button is inline with the first paragraph, and that the enclosed text is formatted correctly.
3. Switch to the **Protect** tab, then click the "Tips for Protecting Your Watershed" sub-tab.
4. Check that there is consistent space between list items.
