### PR TITLE
Feature/396 data page s3 config file

### DIFF
--- a/app/client/src/components/shared/DataContent.js
+++ b/app/client/src/components/shared/DataContent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
 // components
@@ -210,7 +210,6 @@ function DataContent() {
                 Where do I find {shortName} data in How’s My Waterway?
               </h2>
               <p dangerouslySetInnerHTML={{ __html: siteLocation }} />
-              <br />
               {extraContent !== null && (
                 <div dangerouslySetInnerHTML={{ __html: extraContent }} />
               )}

--- a/app/client/src/components/shared/DataContent.js
+++ b/app/client/src/components/shared/DataContent.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect } from 'react';
 import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
 // components
@@ -50,16 +50,17 @@ const contentsTitleStyles = css`
   text-decoration: underline;
 `;
 
-const modifiedErrorBoxStyles = css`
-  ${errorBoxStyles}
-  margin-bottom: 1.25rem;
-`;
-
 const modifiedLinkButtonStyles = css`
   ${linkButtonStyles}
   font-size: 16px;
   font-weight: 400;
   text-align: left;
+`;
+
+const pageErrorBoxStyles = css`
+  ${errorBoxStyles};
+  margin: 1rem;
+  text-align: center;
 `;
 
 const titleStyles = css`
@@ -127,7 +128,7 @@ function DataContent() {
 
   const { data, status } = useDataSourcesContext();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (status !== 'success') return;
     const spans = Array.from(document.querySelectorAll('span'));
     spans.forEach((span) => {
@@ -150,11 +151,12 @@ function DataContent() {
 
   if (status === 'failure') {
     return (
-      <div css={modifiedErrorBoxStyles}>
+      <div css={pageErrorBoxStyles}>
         <p>{dataContentError}</p>
       </div>
     );
   }
+
   return (
     <div css={containerStyles} className="container">
       <p dangerouslySetInnerHTML={{ __html: data.intro }} />

--- a/app/client/src/components/shared/DataContent.js
+++ b/app/client/src/components/shared/DataContent.js
@@ -1,11 +1,18 @@
 // @flow
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
+import { render } from 'react-dom';
 import { css } from 'styled-components/macro';
 // components
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { linkButtonStyles } from 'components/shared/LinkButton';
+import LoadingSpinner from 'components/shared/LoadingSpinner';
+// config
+import { dataContentError } from 'config/errorMessages';
+// contexts
+import { useDataSourcesContext } from 'contexts/LookupFiles';
 // styles
+import { errorBoxStyles } from 'components/shared/MessageBoxes';
 import { fonts } from 'styles/index.js';
 
 function scrollToItem(id: string) {
@@ -41,6 +48,11 @@ const containerStyles = css`
 const contentsTitleStyles = css`
   padding-bottom: 16px !important;
   text-decoration: underline;
+`;
+
+const modifiedErrorBoxStyles = css`
+  ${errorBoxStyles}
+  margin-bottom: 1.25rem;
 `;
 
 const modifiedLinkButtonStyles = css`
@@ -90,7 +102,7 @@ function DataContent() {
     const href = window.location.href;
 
     // get the pathname without the leading /
-    const pathname = window.location.pathname.substr(1);
+    const pathname = window.location.pathname.slice(1);
 
     // build the url for the data page
     let newHref = '';
@@ -113,13 +125,39 @@ function DataContent() {
     };
   }, []);
 
+  const { data, status } = useDataSourcesContext();
+
+  useLayoutEffect(() => {
+    if (status !== 'success') return;
+    const spans = Array.from(document.querySelectorAll('span'));
+    spans.forEach((span) => {
+      if (
+        !span.dataset.hasOwnProperty('glossaryTerm') ||
+        !span.dataset.hasOwnProperty('term')
+      )
+        return;
+
+      const node = document.createElement('span');
+      render(
+        <GlossaryTerm term={span.dataset.term}>{span.innerText}</GlossaryTerm>,
+        node,
+      );
+      span.parentNode.replaceChild(node, span);
+    });
+  }, [status]);
+
+  if (status === 'fetching') return <LoadingSpinner />;
+
+  if (status === 'failure') {
+    return (
+      <div css={modifiedErrorBoxStyles}>
+        <p>{dataContentError}</p>
+      </div>
+    );
+  }
   return (
     <div css={containerStyles} className="container">
-      <p>
-        <em>How’s My Waterway</em> pulls data from multiple databases at EPA and
-        other federal agencies through web services. Below is a summary of data
-        included in <em>How’s My Waterway</em>.
-      </p>
+      <p dangerouslySetInnerHTML={{ __html: data.intro }} />
 
       <hr />
 
@@ -127,501 +165,62 @@ function DataContent() {
         <strong>Contents</strong>
       </p>
       <ul>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('attains')}
-          >
-            Assessment, Total Maximum Daily Load Tracking and Implementation
-            System (ATTAINS)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('cyan')}
-          >
-            Cyanobacteria Assessment Network (CyAN)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('echo')}
-          >
-            Enforcement and Compliance History Online (ECHO)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('grts')}
-          >
-            Grants Reporting and Tracking System (GRTS)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('protected-areas')}
-          >
-            Protected Areas
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('sdwis')}
-          >
-            Safe Drinking Water Information System (SDWIS)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('usgs-sensors')}
-          >
-            USGS Sensors (USGS Stream Gages)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('wqp')}
-          >
-            Water Quality Portal (WQP)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('waters')}
-          >
-            Watershed Assessment, Tracking &amp; Environmental Results System
-            (WATERS)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('wsio')}
-          >
-            Watershed Index Online (WSIO)
-          </button>
-        </li>
-        <li>
-          <button
-            css={modifiedLinkButtonStyles}
-            onClick={() => scrollToItem('wild-scenic-rivers')}
-          >
-            Wild and Scenic Rivers
-          </button>
-        </li>
+        {data.content.map(({ id, title }) => (
+          <li key={id}>
+            <button
+              css={modifiedLinkButtonStyles}
+              onClick={() => scrollToItem(id)}
+            >
+              {title}
+            </button>
+          </li>
+        ))}
       </ul>
 
       <hr />
 
       <em>Links below open in a new browser tab.</em>
 
-      <div css={itemStyles} id="attains">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>
-          Assessment, Total Maximum Daily Load Tracking and Implementation
-          System (ATTAINS)
-        </h2>
-        <p>
-          <a
-            href="https://www.epa.gov/waterdata/attains"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ATTAINS Data/System
-          </a>
-        </p>
-        <p>
-          ATTAINS contains information on water quality assessments, impaired
-          waters, and total maximum daily loads (TMDLs), through data submitted
-          by states under Clean Water Act sections{' '}
-          <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
-            303(d)
-          </GlossaryTerm>{' '}
-          and 305(b).
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find ATTAINS data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the following tabs; Overview ({' '}
-          <GlossaryTerm term="overall waterbody condition">
-            waterbody condition
-          </GlossaryTerm>{' '}
-          list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues
-          ( <GlossaryTerm term="impairment">impairments</GlossaryTerm> ),
-          Restore (
-          <GlossaryTerm term="restoration plan">restoration plans</GlossaryTerm>{' '}
-          ), Drinking Water (Which waters have been assessed for drinking water
-          use?). It can also be found on the state page under the State Water
-          Quality Overview and Advanced Search tabs.
-        </p>
-        <br />
-        <h2 css={questionStyles}>Impairment Category Filtering Tool:</h2>{' '}
-        <p>
-          <a href="attains" target="_blank" rel="noopener noreferrer">
-            How ATTAINS data are grouped in How’s My Waterway
-          </a>
-        </p>
-        <ScrollToTop />
-      </div>
+      {data.content.map(
+        (
+          {
+            description,
+            extraContent,
+            id,
+            linkHref,
+            linkLabel,
+            shortName,
+            siteLocation,
+            title,
+          },
+          i,
+        ) => (
+          <div key={id}>
+            <div css={itemStyles} id={id}>
+              <i className="fas fa-database" aria-hidden="true" />{' '}
+              <h2 css={titleStyles}>{title}</h2>
+              <p>
+                <a href={linkHref} target="_blank" rel="noopener noreferrer">
+                  {linkLabel}
+                </a>
+              </p>
+              <p dangerouslySetInnerHTML={{ __html: description }} />
+              <br />
+              <h2 css={questionStyles}>
+                Where do I find {shortName} data in How’s My Waterway?
+              </h2>
+              <p dangerouslySetInnerHTML={{ __html: siteLocation }} />
+              <br />
+              {extraContent !== null && (
+                <div dangerouslySetInnerHTML={{ __html: extraContent }} />
+              )}
+              <ScrollToTop />
+            </div>
 
-      <hr />
-
-      <div css={itemStyles} id="cyan">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Cyanobacteria Assessment Network (CyAN)</h2>
-        <p>
-          <a
-            href="https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            CyAN Data/System
-          </a>
-        </p>
-        <p>
-          The Cyanobacteria Assessment Network (CyAN) data provides access to{' '}
-          <GlossaryTerm term="cyanobacteria">cyanobacterial</GlossaryTerm> bloom
-          satellite data for over 2,000 of the largest lakes and reservoirs
-          across the United States.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find CyAN data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from CyAN can be found on the Community Page in the
-          Monitoring Tab under current water conditions, CyAN Satellite Imagery.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="echo">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>
-          Enforcement and Compliance History Online (ECHO)
-        </h2>
-        <p>
-          <a
-            href="https://echo.epa.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ECHO Data/System
-          </a>
-        </p>
-        <p>
-          ECHO allows users to search for facilities in their community to
-          assess their compliance with environmental regulations.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find ECHO data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the following tabs; Overview ({' '}
-          <GlossaryTerm term="dischargers">permitted dischargers</GlossaryTerm>{' '}
-          ) and Identified Issues ({' '}
-          <GlossaryTerm term="significant violations">
-            dischargers with significant effluent violations
-          </GlossaryTerm>{' '}
-          ).
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="grts">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Grants Reporting and Tracking System (GRTS)</h2>
-        <p>
-          <a
-            href="https://iaspub.epa.gov/apex/grts/f?p=grts:95"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            GRTS Data/System
-          </a>
-        </p>
-        <p>
-          GRTS is the primary tool for management and oversight of the EPA’s
-          Nonpoint Source (NPS) Pollution Control Program. Under Clean Water Act
-          Section 319(h), EPA awards grants for implementation of state NPS
-          management programs.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find GRTS data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the following tabs; Restore ({' '}
-          <GlossaryTerm term="Clean Water Act Section 319 Projects">
-            Clean Water Act Section 319 Projects
-          </GlossaryTerm>{' '}
-          ), Protect, Watershed Health and Protection (Protection Projects). On
-          the State page under Water Stories.{' '}
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="protected-areas">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Protected Areas</h2>
-        <p>
-          <a
-            href="https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Protected Areas Data/System
-          </a>
-        </p>
-        <p>
-          The Protected Areas Database (PAD-US) is America’s official national
-          inventory of U.S. terrestrial and marine protected areas that are
-          dedicated to the preservation of biological diversity and to other
-          natural, recreation and cultural uses, managed for these purposes
-          through legal or other effective means.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find Wild and Protected Areas data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the protect tab under Watershed Health and Protection, Protected
-          Areas.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="sdwis">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>
-          Safe Drinking Water Information System (SDWIS)
-        </h2>
-        <p>
-          <a
-            href="https://www.epa.gov/ground-water-and-drinking-water/safe-drinking-water-information-system-sdwis-federal-reporting"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            SDWIS Data/System
-          </a>
-        </p>
-        <p>
-          The Safe Drinking Water Information System (SDWIS) contains
-          information on public water systems, including monitoring,
-          enforcement, and violation data related to requirements established by
-          the Safe Drinking Water Act (SDWA).
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find SDWIS data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the following tabs; Drinking Water (Who provides the drinking water
-          here?, Who withdraws water for drinking here?). On the State page
-          under the Drinking Water topic (Drinking Water Information). On the
-          National page under the National Drinking Water tab.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="usgs-sensors">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>USGS Sensors (USGS Stream Gages)</h2>
-        <p>
-          <a
-            href="https://waterdata.usgs.gov/nwis/rt"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            USGS Stream Gages Data/System
-          </a>
-        </p>
-        <p>
-          Data and GIS files from the USGS current conditions can be found on
-          the{' '}
-          <a
-            href="https://waterdata.usgs.gov/nwis/sw"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            USGS website
-          </a>
-          .
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find USGS Stream Gage data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from the USGS databases can be found on the Community page
-          on the Overview tab under Monitoring Locations, Current Water
-          Conditions, USGS Sensors and in the Monitoring Tab under current water
-          conditions, USGS Sensors.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="wqp">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Water Quality Portal (WQP)</h2>
-        <p>
-          <a
-            href="https://www.waterqualitydata.us/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            WQP Data/System
-          </a>
-        </p>
-        <p>
-          The Water Quality Portal (WQP) is a cooperative service sponsored by
-          the United States Geological Survey (USGS), the Environmental
-          Protection Agency (EPA) and the National Water Quality Monitoring
-          Council (NWQMC) that integrates publicly available water quality
-          monitoring data.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find WQP data in How’s My Waterway?{' '}
-        </h2>
-        <p>
-          Information from this database can be found on the Community page
-          under the Overview tab under Monitoring Locations, Past Water
-          Conditions, and on the Monitoring tab under Past Water Conditions, as
-          well as on the Monitoring Report pages.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="waters">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>
-          Watershed Assessment, Tracking &amp; Environmental Results System
-          (WATERS)
-        </h2>
-        <p>
-          <a
-            href="https://www.epa.gov/waterdata/waters-watershed-assessment-tracking-environmental-results-system"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            WATERS Data/System
-          </a>
-        </p>
-        <p>
-          A suite of web services that provide comprehensive information about
-          the quality of the nation's surface water.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find WATERS data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from WATERS supports the display of Watershed boundaries
-          on the map display.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="wsio">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Watershed Index Online (WSIO)</h2>
-        <p>
-          <a
-            href="https://www.epa.gov/wsio"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            WSIO Data/System
-          </a>
-        </p>
-        <p>
-          The Watershed Index Online (WSIO) is a free, publicly available data
-          library of watershed indicators and a decision-support tool, developed
-          by EPA, to assist resource managers, citizens, and other users with
-          evaluating, comparing, and prioritizing watersheds for a user-defined
-          purpose.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find WSIO data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the protect tab under Watershed Health and Protection, Watershed
-          Health Scores.
-        </p>
-        <ScrollToTop />
-      </div>
-
-      <hr />
-
-      <div css={itemStyles} id="wild-scenic-rivers">
-        <i className="fas fa-database" aria-hidden="true" />{' '}
-        <h2 css={titleStyles}>Wild and Scenic Rivers</h2>
-        <p>
-          <a
-            href="https://www.rivers.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Wild and Scenic Rivers Data/System
-          </a>
-        </p>
-        <p>
-          Data and GIS files on wild and scenic rivers can be found on the{' '}
-          <a
-            href="https://www.rivers.gov/mapping-gis.php"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            National Wild and Scenic Rivers System
-          </a>{' '}
-          website.
-        </p>
-        <br />
-        <h2 css={questionStyles}>
-          Where do I find Wild and Scenic Rivers data in How’s My Waterway?
-        </h2>
-        <p>
-          Information from this database can be found on the Community page on
-          the protect tab under Watershed Health and Protection, Wild and Scenic
-          Rivers.
-        </p>
-        <ScrollToTop />
-      </div>
+            {i < data.content.length - 1 && <hr />}
+          </div>
+        ),
+      )}
     </div>
   );
 }
@@ -633,11 +232,7 @@ const scrollToTopContainerStyles = css`
 
 // --- components - ScrollToTop
 
-type ScrollToTopProps = {
-  id: string,
-};
-
-function ScrollToTop({ id }: ScrollToTopProps) {
+function ScrollToTop() {
   return (
     <div css={scrollToTopContainerStyles}>
       <div style={{ float: 'right' }}>

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -259,6 +259,13 @@ export const defaultErrorBoundaryMessage = (
   </p>
 );
 
+export const dataContentError = (
+  <>
+    Information about data used in <em>How's My Waterway</em> is temporarily
+    unavailable, please try again later.
+  </>
+);
+
 // message displayed when the Esri map fails to load due to incompatible browsers and devices
 export const esriMapLoadingFailure = `The How's My Waterway Map is unavailable. Your web browser is
 incompatible or outdated.`;

--- a/app/client/src/contexts/LookupFiles.js
+++ b/app/client/src/contexts/LookupFiles.js
@@ -25,6 +25,7 @@ type LookupFile = {
 };
 
 type LookupFiles = {
+  dataSources: LookupFile,
   documentOrder: LookupFile,
   setDocumentOrder: Function,
   educatorMaterials: LookupFile,
@@ -50,6 +51,8 @@ type LookupFiles = {
 };
 
 const LookupFilesContext: Object = createContext<LookupFiles>({
+  dataSources: { status: 'fetching', data: null },
+  setDataSources: () => {},
   documentOrder: { status: 'fetching', data: null },
   setDocumentOrder: () => {},
   educatorMaterials: { status: 'fetching', data: null },
@@ -79,6 +82,10 @@ type Props = {
 };
 
 function LookupFilesProvider({ children }: Props) {
+  const [dataSources, setDataSources] = useState({
+    status: 'fetching',
+    data: null,
+  });
   const [documentOrder, setDocumentOrder] = useState({
     status: 'fetching',
     data: {},
@@ -127,6 +134,8 @@ function LookupFilesProvider({ children }: Props) {
   return (
     <LookupFilesContext.Provider
       value={{
+        dataSources,
+        setDataSources,
         documentOrder,
         setDocumentOrder,
         educatorMaterials,
@@ -154,6 +163,20 @@ function LookupFilesProvider({ children }: Props) {
       {children}
     </LookupFilesContext.Provider>
   );
+}
+
+// Custom hook for the data.json file.
+let dataSourcesInitialized = false; // global var for ensuring fetch only happens once
+function useDataSourcesContext() {
+  const { dataSources, setDataSources } = useContext(LookupFilesContext);
+
+  // fetch the lookup file if necessary
+  if (!dataSourcesInitialized) {
+    dataSourcesInitialized = true;
+    getLookupFile('data.json', setDataSources);
+  }
+
+  return dataSources;
 }
 
 // Custom hook for the documentOrder.json lookup file.
@@ -371,6 +394,7 @@ function useWaterTypeOptionsContext() {
 export {
   LookupFilesContext,
   LookupFilesProvider,
+  useDataSourcesContext,
   useDocumentOrderContext,
   useEducatorMaterialsContext,
   useNarsContext,

--- a/app/client/src/contexts/LookupFiles.js
+++ b/app/client/src/contexts/LookupFiles.js
@@ -165,7 +165,7 @@ function LookupFilesProvider({ children }: Props) {
   );
 }
 
-// Custom hook for the data.json file.
+// Custom hook for the dataPage.json file.
 let dataSourcesInitialized = false; // global var for ensuring fetch only happens once
 function useDataSourcesContext() {
   const { dataSources, setDataSources } = useContext(LookupFilesContext);
@@ -173,7 +173,7 @@ function useDataSourcesContext() {
   // fetch the lookup file if necessary
   if (!dataSourcesInitialized) {
     dataSourcesInitialized = true;
-    getLookupFile('data.json', setDataSources);
+    getLookupFile('dataPage.json', setDataSources);
   }
 
   return dataSources;

--- a/app/server/app/public/data/data.json
+++ b/app/server/app/public/data/data.json
@@ -1,0 +1,115 @@
+{
+  "intro": "<em>How’s My Waterway</em> pulls data from multiple databases at EPA and other federal agencies through web services. Below is a summary of data included in <em>How’s My Waterway</em>.",
+  "content": [
+    {
+      "description": "ATTAINS contains information on water quality assessments, impaired waters, and total maximum daily loads (TMDLs), through data submitted by states under Clean Water Act sections <span data-glossary-term data-term='303(d) listed impaired waters (Category 5)'>303(d)</span> and 305(b).",
+      "extraContent": "<h2 style='display:block;margin-bottom:0.25rem;font-size:1.125em;line-height:1.125;font-family:Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;font-weight:bold;padding-bottom:0'>Impairment Category Filtering Tool:</h2><p><a href='attains' target='_blank' rel='noopener noreferrer'>How ATTAINS data are grouped in How’s My Waterway</a></p>",
+      "id": "attains",
+      "linkHref": "https://www.epa.gov/waterdata/attains",
+      "linkLabel": "ATTAINS Data/System",
+      "shortName": "ATTAINS",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='overall waterbody condition'>waterbody condition</span> list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues ( <span data-glossary-term data-term='impairment'>impairments</span> ), Restore ( <span data-glossary-term data-term='restoration plan'>restoration plans</span>), Drinking Water (Which waters have been assessed for drinking water use?). It can also be found on the state page under the State Water Quality Overview and Advanced Search tabs.",
+      "title": "Assessment, Total Maximum Daily Load Tracking and Implementation System (ATTAINS)"
+    },
+    {
+      "description": "The Cyanobacteria Assessment Network (CyAN) data provides access to <span data-glossary-term data-term='cyanobacteria'>cyanobacterial</span> bloom satellite data for over 2,000 of the largest lakes and reservoirs across the United States.",
+      "extraContent": null,
+      "id": "cyan",
+      "linkHref": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
+      "linkLabel": "CyAN Data/System",
+      "shortName": "CyAN",
+      "siteLocation": "Information from CyAN can be found on the Community Page in the Monitoring Tab under current water conditions, CyAN Satellite Imagery.",
+      "title": "Cyanobacteria Assessment Network (CyAN)"
+    },
+    {
+      "description": "ECHO allows users to search for facilities in their community to assess their compliance with environmental regulations.",
+      "extraContent": null,
+      "id": "echo",
+      "linkHref": "https://echo.epa.gov/",
+      "linkLabel": "ECHO Data/System",
+      "shortName": "ECHO",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term jkdata-term='dischargers'>permitted dischargers</span> ) and Identified Issues ( <span data-term='significant violations'> dischargers with significant effluent violations </span> ).",
+      "title": "Enforcement and Compliance History Online (ECHO)"
+    },
+    {
+      "description": "GRTS is the primary tool for management and oversight of the EPA’s Nonpoint Source (NPS) Pollution Control Program. Under Clean Water Act Section 319(h), EPA awards grants for implementation of state NPS management programs.",
+      "extraContent": null,
+      "id": "grts",
+      "linkHref": "https://iaspub.epa.gov/apex/grts/f?p=grts:95",
+      "linkLabel": "GRTS Data/System",
+      "shortName": "GRTS",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Restore ( <span data-glossary-term data-term='Clean Water Act Section 319 Projects'> Clean Water Act Section 319 Projects </span> ), Protect, Watershed Health and Protection (Protection Projects). On the State page under Water Stories.",
+      "title": "Grants Reporting and Tracking System (GRTS)"
+    },
+    {
+      "description": "The Protected Areas Database (PAD-US) is America’s official national inventory of U.S. terrestrial and marine protected areas that are dedicated to the preservation of biological diversity and to other natural, recreation and cultural uses, managed for these purposes through legal or other effective means.",
+      "extraContent": null,
+      "id": "protected-areas",
+      "linkHref": "https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas",
+      "linkLabel": "Protected Areas Data/System",
+      "shortName": "Wild and Protected Areas",
+      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Protected Areas.",
+      "title": "Protected Areas"
+    },
+    {
+      "description": "The Safe Drinking Water Information System (SDWIS) contains information on public water systems, including monitoring, enforcement, and violation data related to requirements established by the Safe Drinking Water Act (SDWA).",
+      "extraContent": null,
+      "id": "sdwis",
+      "linkHref": "https://www.epa.gov/ground-water-and-drinking-water/safe-drinking-water-information-system-sdwis-federal-reporting",
+      "linkLabel": "SDWIS Data/System",
+      "shortName": "SDWIS",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Drinking Water (Who provides the drinking water here?, Who withdraws water for drinking here?). On the State page under the Drinking Water topic (Drinking Water Information). On the National page under the National Drinking Water tab.",
+      "title": "Safe Drinking Water Information System (SDWIS)"
+    },
+    {
+      "description": "Data and GIS files from the USGS current conditions can be found on the <a href='https://waterdata.usgs.gov/nwis/sw' target='_blank' rel='noopener noreferrer'>USGS website</a>.",
+      "extraContent": null,
+      "id": "usgs-sensors",
+      "linkHref": "https://waterdata.usgs.gov/nwis/rt",
+      "linkLabel": "USGS Stream Gages Data/System",
+      "shortName": "USGS Stream Gage",
+      "siteLocation": "Information from the USGS databases can be found on the Community page on the Overview tab under Monitoring Locations, Current Water Conditions, USGS Sensors and in the Monitoring Tab under current water conditions, USGS Sensors.",
+      "title": "USGS Sensors (USGS Stream Gages)"
+    },
+    {
+      "description": "The Water Quality Portal (WQP) is a cooperative service sponsored by the United States Geological Survey (USGS), the Environmental Protection Agency (EPA) and the National Water Quality Monitoring Council (NWQMC) that integrates publicly available water quality monitoring data.",
+      "extraContent": null,
+      "id": "wqp",
+      "linkHref": "https://www.waterqualitydata.us/",
+      "linkLabel": "WQP Data/System",
+      "shortName": "WQP",
+      "siteLocation": "Information from this database can be found on the Community page under the Overview tab under Monitoring Locations, Past Water Conditions, and on the Monitoring tab under Past Water Conditions, as well as on the Monitoring Report pages.",
+      "title": "Water Quality Portal (WQP)"
+    },
+    {
+      "description": "A suite of web services that provide comprehensive information about the quality of the nation's surface water.",
+      "extraContent": null,
+      "id": "waters",
+      "linkHref": "https://www.epa.gov/waterdata/waters-watershed-assessment-tracking-environmental-results-system",
+      "linkLabel": "WATERS Data/System",
+      "shortName": "WATERS",
+      "siteLocation": "Information from WATERS supports the display of Watershed boundaries on the map display.",
+      "title": "Watershed Assessment, Tracking &amp; Environmental Results System (WATERS)"
+    },
+    {
+      "description": "The Watershed Index Online (WSIO) is a free, publicly available data library of watershed indicators and a decision-support tool, developed by EPA, to assist resource managers, citizens, and other users with evaluating, comparing, and prioritizing watersheds for a user-defined purpose.",
+      "extraContent": null,
+      "id": "wsio",
+      "linkHref": "https://www.epa.gov/wsio",
+      "linkLabel": "WSIO Data/System",
+      "shortName": "WSIO",
+      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Watershed Health Scores.",
+      "title": "Watershed Index Online (WSIO)"
+    },
+    {
+      "description": "Data and GIS files on wild and scenic rivers can be found on the <a href='https://www.rivers.gov/mapping-gis.php' target='_blank' rel='noopener noreferrer'>National Wild and Scenic Rivers System</a> website.",
+      "extraContent": null,
+      "id": "wild-scenic-rivers",
+      "linkHref": "https://www.rivers.gov/",
+      "linkLabel": "Wild and Scenic Rivers Data/System",
+      "shortName": "Wild and Scenic Rivers",
+      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Wild and Scenic Rivers.",
+      "title": "Wild and Scenic Rivers"
+    }
+  ]
+}

--- a/app/server/app/public/data/data.json
+++ b/app/server/app/public/data/data.json
@@ -28,7 +28,7 @@
       "linkHref": "https://echo.epa.gov/",
       "linkLabel": "ECHO Data/System",
       "shortName": "ECHO",
-      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term jkdata-term='dischargers'>permitted dischargers</span> ) and Identified Issues ( <span data-term='significant violations'> dischargers with significant effluent violations </span> ).",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='dischargers'>permitted dischargers</span> ) and Identified Issues ( <span data-glossary-term data-term='significant violations'> dischargers with significant effluent violations</span> ).",
       "title": "Enforcement and Compliance History Online (ECHO)"
     },
     {
@@ -89,7 +89,7 @@
       "linkLabel": "WATERS Data/System",
       "shortName": "WATERS",
       "siteLocation": "Information from WATERS supports the display of Watershed boundaries on the map display.",
-      "title": "Watershed Assessment, Tracking &amp; Environmental Results System (WATERS)"
+      "title": "Watershed Assessment, Tracking & Environmental Results System (WATERS)"
     },
     {
       "description": "The Watershed Index Online (WSIO) is a free, publicly available data library of watershed indicators and a decision-support tool, developed by EPA, to assist resource managers, citizens, and other users with evaluating, comparing, and prioritizing watersheds for a user-defined purpose.",

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -3,7 +3,7 @@
   "content": [
     {
       "description": "ATTAINS contains information on water quality assessments, impaired waters, and total maximum daily loads (TMDLs), through data submitted by states under Clean Water Act sections <span data-glossary-term data-term='303(d) listed impaired waters (Category 5)'>303(d)</span> and 305(b).",
-      "extraContent": "<h2 style='display:block;margin-bottom:0.25rem;font-size:1.125em;line-height:1.125;font-family:Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;font-weight:bold;padding-bottom:0'>Impairment Category Filtering Tool:</h2><p><a href='attains' target='_blank' rel='noopener noreferrer'>How ATTAINS data are grouped in How’s My Waterway</a></p>",
+      "extraContent": "<br /><h2 style='display:block;margin-bottom:0.25rem;font-size:1.125em;line-height:1.125;font-family:Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;font-weight:bold;padding-bottom:0'>Impairment Category Filtering Tool:</h2><p><a href='attains' target='_blank' rel='noopener noreferrer'>How ATTAINS data are grouped in How’s My Waterway</a></p>",
       "id": "attains",
       "linkHref": "https://www.epa.gov/waterdata/attains",
       "linkLabel": "ATTAINS Data/System",


### PR DESCRIPTION
## Related Issues:
* [HMW-396](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-396)

## Main Changes:
* Moved the content of the **Data** page into a JSON file that can be stored in an S3 bucket.

## Steps To Test:
1. Open http://localhost:3000/data and https://mywaterway.epa.gov/data in side-by-side tabs.
2. Verify that the content, style, glossary items, and links throughout the pages are identical.