### PR TITLE
Feature/404 319 documents not found

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -430,11 +430,6 @@
     </div>
 
     <header class="masthead clearfix" role="banner">
-      <img
-        alt=""
-        class="site-logo"
-        src="https://www.epa.gov/sites/all/themes/epa/logo.png"
-      />
       <div class="site-name-and-slogan">
         <h1 class="site-name">
           <a href="https://www.epa.gov/" rel="home" title="Go to the home page"

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@reach/tabs';
 import { css } from 'styled-components/macro';
 // components
@@ -11,7 +11,6 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { errorBoxStyles } from 'components/shared/MessageBoxes';
 import TabErrorBoundary from 'components/shared/ErrorBoundary.TabErrorBoundary';
-import DynamicExitDisclaimer from 'components/shared/DynamicExitDisclaimer';
 import {
   keyMetricsStyles,
   keyMetricStyles,
@@ -21,7 +20,7 @@ import {
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
-import { getUrlFromMarkup, getTitleFromMarkup } from 'components/shared/Regex';
+import { getUrlFromMarkup } from 'components/shared/Regex';
 import { useWaterbodyOnMap } from 'utils/hooks';
 // errors
 import {
@@ -207,49 +206,6 @@ function Restore() {
                         >
                           {sortedGrtsData.map((item, index) => {
                             const url = getUrlFromMarkup(item.project_link);
-                            const documents =
-                              item.watershed_plans &&
-                              // break string into pieces separated by commas and map over them
-                              item.watershed_plans.split(',').map((plan) => {
-                                const markup = plan.split('</a>')[0] + '</a>';
-                                const title = getTitleFromMarkup(markup);
-                                const planUrl = getUrlFromMarkup(markup);
-                                if (!title || !planUrl) return null;
-                                return { url: planUrl, title: title };
-                              });
-                            // remove any documents with missing titles or urls
-                            const filteredDocuments =
-                              documents &&
-                              documents.filter(
-                                (document) =>
-                                  document && document.url && document.title,
-                              );
-                            const documentLinks =
-                              filteredDocuments && filteredDocuments.length > 0
-                                ? filteredDocuments.map((document, index) => {
-                                    if (
-                                      document &&
-                                      document.url &&
-                                      document.title
-                                    ) {
-                                      return (
-                                        <div key={index}>
-                                          <a
-                                            href={document.url}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                          >
-                                            {document.title}
-                                          </a>
-                                          <DynamicExitDisclaimer
-                                            url={document.url}
-                                          />
-                                        </div>
-                                      );
-                                    }
-                                    return false;
-                                  })
-                                : 'Document not available';
 
                             return (
                               <AccordionItem
@@ -297,10 +253,6 @@ function Restore() {
                                           </small>
                                         </>
                                       ),
-                                    },
-                                    {
-                                      label: 'Documents',
-                                      value: documentLinks,
                                     },
                                   ]}
                                 />

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -1,190 +1,359 @@
 <!DOCTYPE html>
 <html class="js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="ImageToolbar" content="false" />
+    <meta http-equiv="cleartype" content="on" />
+    <meta name="HandheldFriendly" content="true" />
+    <link
+      rel="shortcut icon"
+      href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
+      type="image/vnd.microsoft.icon"
+    />
+    <meta name="MobileOptimized" content="width" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <!--googleon: all-->
+    <meta
+      name="DC.description"
+      content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language."
+    />
+    <meta
+      name="description"
+      content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language."
+    />
+    <meta name="DC.title" content="How's My Waterway?" />
+    <!--googleoff: snippet-->
+    <meta
+      name="keywords"
+      content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
+    />
+    <link rel="canonical" href="" />
+    <link rel="shortlink" href="" />
+    <meta name="DC.language" content="en" />
+    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
+    <meta name="DC.type" content="Data and Tools" />
+    <meta name="DC.creator" content="US EPA" />
+    <meta name="theme-color" content="#0071bc" />
+    <title>How’s My Waterway? | Page Not Found | US EPA</title>
+    <!--googleoff: all-->
+    <link
+      rel="stylesheet"
+      href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css"
+      media="all"
+    />
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-L8ZB');
+    </script>
+    <!-- End Google Tag Manager -->
+  </head>
 
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="ImageToolbar" content="false" />
-	<meta http-equiv="cleartype" content="on" />
-	<meta name="HandheldFriendly" content="true" />
-	<link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
-		type="image/vnd.microsoft.icon" />
-	<meta name="MobileOptimized" content="width" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-	<!--googleon: all-->
-	<meta name="DC.description"
-		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="description"
-		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="DC.title" content="How's My Waterway?" />
-	<!--googleoff: snippet-->
-	<meta name="keywords"
-		content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
-	<link rel="canonical" href="" />
-	<link rel="shortlink" href="" />
-	<meta name="DC.language" content="en" />
-	<meta name="DC.Subject.epachannel" content="Learn the Issues" />
-	<meta name="DC.type" content="Data and Tools" />
-	<meta name="DC.creator" content="US EPA" />
-	<meta name="theme-color" content="#0071bc">
-	<title>How’s My Waterway? | Page Not Found | US EPA</title>
-	<!--googleoff: all-->
-	<link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
-	<!-- Google Tag Manager -->
-	<script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != "dataLayer" ? "&l=" + l : ""; j.async = true; j.src = "//www.googletagmanager.com/gtm.js?id=" + i + dl; f.parentNode.insertBefore(j, f); })(window, document, "script", "dataLayer", "GTM-L8ZB");</script>
-	<!-- End Google Tag Manager -->
-</head>
-
-<body class="html">
-	<!-- Google Tag Manager -->
-	<noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0"
-			width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager -->
-	<div class="skip-links">
-		<a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
-	</div>
-	<header class="masthead clearfix" role="banner">
-		<img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png">
-		<div class="site-name-and-slogan">
-			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US
-						EPA</span></a></h1>
-			<div class="site-slogan">United States Environmental Protection Agency</div>
-		</div>
-		<div class="region-header">
-			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
-				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
-					<label class="element-hidden" for="search-box">Search</label>
-					<input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext"
-						placeholder="Search EPA.gov" value="">
-					<button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
-					<input name="areaname" type="hidden" value="">
-					<input name="areacontacts" type="hidden" value="">
-					<input name="areasearchurl" type="hidden" value="">
-					<input name="typeofsearch" type="hidden" value="epa">
-					<input name="result_template" type="hidden" value="2col.ftl">
-				</form>
-			</div>
-		</div>
-	</header>
-	<nav class="nav main-nav clearfix" role="navigation">
-		<div class="nav__inner">
-			<h2 class="element-invisible">Main menu</h2>
-			<ul class="menu" role="menu">
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/environmental-topics" role="menuitem"
-						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/laws-regulations" role="menuitem"
-						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
-						&amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
-						role="menuitem"
-						title="Learn more about our mission and what we do, how we are organized, and our history.">About
-						EPA</a></li>
-			</ul>
-		</div>
-	</nav>
-	<div class="mobile-nav" id="mobile-nav">
-		<div class="mobile-bar clearfix">
-			<label class="menu-button" for="mobile-nav-toggle">Menu</label>
-		</div>
-		<input checked id="mobile-nav-toggle" type="checkbox">
-		<div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
-			<ul class="mobile-menu">
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/environmental-topics" role="menuitem"
-						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/laws-regulations" role="menuitem"
-						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
-						&amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
-						role="menuitem"
-						title="Learn more about our mission and what we do, how we are organized, and our history.">About
-						EPA</a></li>
-			</ul>
-		</div>
-	</div>
-	<section class="main-content clearfix" id="main-content" lang="en" role="main" tabindex="-1">
-		<div class="main-column clearfix">
-			<!--googleon:all-->
-			<div style="margin: 2rem 0; text-align: center;">
-				<h1 class="page-title" style="margin-bottom: 0; font-size: 1.75rem; font-weight: 500;">Sorry, but this web page does not exist.</h1>
-				<p style="padding-bottom: 0;">Return to the <a href="./">homepage</a>.</p>
-			</div>
-		</div>
-	</section>
-	<footer class="main-footer clearfix" role="contentinfo">
-		<div class="main-footer__inner">
-			<div class="region-footer">
-				<div class="block-pane-epa-global-footer" id="block-pane-epa-global-footer">
-					<div class="row cols-3">
-						<div class="col size-1of3">
-							<div class="col__title">
-								Discover.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.epa.gov/accessibility">Accessibility</a></li>
-								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
-								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/grants">Grants</a>
-								</li>
-								<li><a href="https://www.epa.gov/home/wwwepagov-snapshots">EPA www Web Snapshots</a>
-								</li>
-								<li><a
-										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
-										FEAR Act Data</a></li>
-								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
-								<li><a href="https://www.epa.gov/privacy/privacy-and-security-notice">Privacy and Security Notice</a></li>
-							</ul>
-						</div>
-						<div class="col size-1of3">
-							<div class="col__title">
-								Connect.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.data.gov/">Data.gov</a></li>
-								<li><a
-										href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector
-										General</a></li>
-								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
-								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
-								<li><a href="https://www.regulations.gov/">Regulations.gov</a></li>
-								<li><a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a></li>
-								<li><a href="https://www.usa.gov/">USA.gov</a></li>
-								<li><a href="https://www.whitehouse.gov/">White House</a></li>
-							</ul>
-						</div>
-						<div class="col size-1of3">
-							<div class="col__title">
-								Ask.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.epa.gov/home/forms/contact-us">Contact Us</a></li>
-								<li><a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a></li>
-								<li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
-								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent
-										Questions</a></li>
-							</ul>
-							<div class="col__title">
-								Follow.
-							</div>
-							<ul class="social-menu">
-								<li><a class="menu-link social-facebook"
-										href="https://www.facebook.com/EPA">Facebook</a></li>
-								<li><a class="menu-link social-twitter" href="https://twitter.com/epa">Twitter</a></li>
-								<li><a class="menu-link social-youtube"
-										href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
-								<li><a class="menu-link social-flickr"
-										href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
-								<li><a class="menu-link social-instagram"
-										href="https://www.instagram.com/epagov">Instagram</a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</footer>
-</body>
-
+  <body class="html">
+    <!-- Google Tag Manager -->
+    <noscript
+      ><iframe
+        title="google tag manager"
+        src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager -->
+    <div class="skip-links">
+      <a
+        href="#main-content"
+        class="skip-link element-invisible element-focusable"
+        >Jump to main content</a
+      >
+    </div>
+    <header class="masthead clearfix" role="banner">
+      <div class="site-name-and-slogan">
+        <h1 class="site-name">
+          <a href="https://www.epa.gov/" rel="home" title="Go to the home page"
+            ><span>US EPA</span></a
+          >
+        </h1>
+        <div class="site-slogan">
+          United States Environmental Protection Agency
+        </div>
+      </div>
+      <div class="region-header">
+        <div
+          class="block-epa-core-gsa-epa-search"
+          id="block-epa-core-gsa-epa-search"
+        >
+          <form
+            action="https://search.epa.gov/epasearch"
+            class="epa-search"
+            method="get"
+          >
+            <label class="element-hidden" for="search-box">Search</label>
+            <input
+              class="form-text"
+              id="search-box"
+              aria-label="Search EPA.gov"
+              name="querytext"
+              placeholder="Search EPA.gov"
+              value=""
+            />
+            <button
+              class="epa-search-button"
+              id="search-button"
+              title="Search"
+              type="submit"
+            >
+              Search
+            </button>
+            <input name="areaname" type="hidden" value="" />
+            <input name="areacontacts" type="hidden" value="" />
+            <input name="areasearchurl" type="hidden" value="" />
+            <input name="typeofsearch" type="hidden" value="epa" />
+            <input name="result_template" type="hidden" value="2col.ftl" />
+          </form>
+        </div>
+      </div>
+    </header>
+    <nav class="nav main-nav clearfix" role="navigation">
+      <div class="nav__inner">
+        <h2 class="element-invisible">Main menu</h2>
+        <ul class="menu" role="menu">
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/environmental-topics"
+              role="menuitem"
+              title="Learn about Environmental Topics that EPA covers."
+              >Environmental Topics</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/laws-regulations"
+              role="menuitem"
+              title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws."
+              >Laws &amp; Regulations</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/aboutepa"
+              role="menuitem"
+              title="Learn more about our mission and what we do, how we are organized, and our history."
+              >About EPA</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <div class="mobile-nav" id="mobile-nav">
+      <div class="mobile-bar clearfix">
+        <label class="menu-button" for="mobile-nav-toggle">Menu</label>
+      </div>
+      <input checked id="mobile-nav-toggle" type="checkbox" />
+      <div
+        class="mobile-links element-hidden"
+        id="mobile-links"
+        style="height: 2404px"
+      >
+        <ul class="mobile-menu">
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/environmental-topics"
+              role="menuitem"
+              title="Learn about Environmental Topics that EPA covers."
+              >Environmental Topics</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/laws-regulations"
+              role="menuitem"
+              title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws."
+              >Laws &amp; Regulations</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/aboutepa"
+              role="menuitem"
+              title="Learn more about our mission and what we do, how we are organized, and our history."
+              >About EPA</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+    <section
+      class="main-content clearfix"
+      id="main-content"
+      lang="en"
+      role="main"
+      tabindex="-1"
+    >
+      <div class="main-column clearfix">
+        <!--googleon:all-->
+        <div style="margin: 2rem 0; text-align: center">
+          <h1
+            class="page-title"
+            style="margin-bottom: 0; font-size: 1.75rem; font-weight: 500"
+          >
+            Sorry, but this web page does not exist.
+          </h1>
+          <p style="padding-bottom: 0">
+            Return to the <a href="./">homepage</a>.
+          </p>
+        </div>
+      </div>
+    </section>
+    <footer class="main-footer clearfix" role="contentinfo">
+      <div class="main-footer__inner">
+        <div class="region-footer">
+          <div
+            class="block-pane-epa-global-footer"
+            id="block-pane-epa-global-footer"
+          >
+            <div class="row cols-3">
+              <div class="col size-1of3">
+                <div class="col__title">Discover.</div>
+                <ul class="menu">
+                  <li>
+                    <a href="https://www.epa.gov/accessibility"
+                      >Accessibility</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/planandbudget"
+                      >Budget &amp; Performance</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/contracts">Contracting</a>
+                  </li>
+                  <li><a href="https://www.epa.gov/grants">Grants</a></li>
+                  <li>
+                    <a href="https://www.epa.gov/home/wwwepagov-snapshots"
+                      >EPA www Web Snapshots</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees"
+                      >No FEAR Act Data</a
+                    >
+                  </li>
+                  <li><a href="https://www.epa.gov/privacy">Privacy</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/privacy/privacy-and-security-notice"
+                      >Privacy and Security Notice</a
+                    >
+                  </li>
+                </ul>
+              </div>
+              <div class="col size-1of3">
+                <div class="col__title">Connect.</div>
+                <ul class="menu">
+                  <li><a href="https://www.data.gov/">Data.gov</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general"
+                      >Inspector General</a
+                    >
+                  </li>
+                  <li><a href="https://www.epa.gov/careers">Jobs</a></li>
+                  <li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
+                  <li>
+                    <a href="https://www.regulations.gov/">Regulations.gov</a>
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/newsroom/email-subscriptions"
+                      >Subscribe</a
+                    >
+                  </li>
+                  <li><a href="https://www.usa.gov/">USA.gov</a></li>
+                  <li><a href="https://www.whitehouse.gov/">White House</a></li>
+                </ul>
+              </div>
+              <div class="col size-1of3">
+                <div class="col__title">Ask.</div>
+                <ul class="menu">
+                  <li>
+                    <a href="https://www.epa.gov/home/forms/contact-us"
+                      >Contact Us</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a>
+                  </li>
+                  <li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics"
+                      >Frequent Questions</a
+                    >
+                  </li>
+                </ul>
+                <div class="col__title">Follow.</div>
+                <ul class="social-menu">
+                  <li>
+                    <a
+                      class="menu-link social-facebook"
+                      href="https://www.facebook.com/EPA"
+                      >Facebook</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-twitter"
+                      href="https://twitter.com/epa"
+                      >Twitter</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-youtube"
+                      href="https://www.youtube.com/user/USEPAgov"
+                      >YouTube</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-flickr"
+                      href="https://www.flickr.com/photos/usepagov"
+                      >Flickr</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-instagram"
+                      href="https://www.instagram.com/epagov"
+                      >Instagram</a
+                    >
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -1,202 +1,380 @@
 <!DOCTYPE html>
 <html class="js" lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="ImageToolbar" content="false" />
+    <meta http-equiv="cleartype" content="on" />
+    <meta name="HandheldFriendly" content="true" />
+    <link
+      rel="shortcut icon"
+      href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
+      type="image/vnd.microsoft.icon"
+    />
+    <meta name="MobileOptimized" content="width" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <!--googleon: all-->
+    <meta
+      name="DC.description"
+      content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language."
+    />
+    <meta
+      name="description"
+      content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language."
+    />
+    <meta name="DC.title" content="How's My Waterway?" />
+    <!--googleoff: snippet-->
+    <meta
+      name="keywords"
+      content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
+    />
+    <link rel="canonical" href="" />
+    <link rel="shortlink" href="" />
+    <meta name="DC.language" content="en" />
+    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
+    <meta name="DC.type" content="Data and Tools" />
+    <meta name="DC.creator" content="US EPA" />
+    <meta name="theme-color" content="#0071bc" />
+    <title>How’s My Waterway? | Internal Server Error | US EPA</title>
+    <!--googleoff: all-->
+    <link
+      rel="stylesheet"
+      href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css"
+      media="all"
+    />
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = '//www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-L8ZB');
+    </script>
+    <!-- End Google Tag Manager -->
+  </head>
 
-<head>
-	<meta charset="utf-8" />
-	<meta http-equiv="ImageToolbar" content="false" />
-	<meta http-equiv="cleartype" content="on" />
-	<meta name="HandheldFriendly" content="true" />
-	<link rel="shortcut icon" href="https://www.epa.gov/sites/all/themes/epa/favicon.ico"
-		type="image/vnd.microsoft.icon" />
-	<meta name="MobileOptimized" content="width" />
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-	<!--googleon: all-->
-	<meta name="DC.description"
-		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="description"
-		content="An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language." />
-	<meta name="DC.title" content="How's My Waterway?" />
-	<!--googleoff: snippet-->
-	<meta name="keywords"
-		content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
-	<link rel="canonical" href="" />
-	<link rel="shortlink" href="" />
-	<meta name="DC.language" content="en" />
-	<meta name="DC.Subject.epachannel" content="Learn the Issues" />
-	<meta name="DC.type" content="Data and Tools" />
-	<meta name="DC.creator" content="US EPA" />
-	<meta name="theme-color" content="#0071bc">
-	<title>How’s My Waterway? | Internal Server Error | US EPA</title>
-	<!--googleoff: all-->
-	<link rel="stylesheet" href="https://www.epa.gov/sites/all/libraries/standalone/css/core/style.css" media="all" />
-	<!-- Google Tag Manager -->
-	<script>(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != "dataLayer" ? "&l=" + l : ""; j.async = true; j.src = "//www.googletagmanager.com/gtm.js?id=" + i + dl; f.parentNode.insertBefore(j, f); })(window, document, "script", "dataLayer", "GTM-L8ZB");</script>
-	<!-- End Google Tag Manager -->
-</head>
-
-<body class="html">
-	<!-- Google Tag Manager -->
-	<noscript><iframe title="google tag manager" src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB" height="0"
-			width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager -->
-	<div class="skip-links">
-		<a href="#main-content" class="skip-link element-invisible element-focusable">Jump to main content</a>
-	</div>
-	<header class="masthead clearfix" role="banner">
-		<img alt="" class="site-logo" src="https://www.epa.gov/sites/all/themes/epa/logo.png">
-		<div class="site-name-and-slogan">
-			<h1 class="site-name"><a href="https://www.epa.gov/" rel="home" title="Go to the home page"><span>US
-						EPA</span></a></h1>
-			<div class="site-slogan">United States Environmental Protection Agency</div>
-		</div>
-		<div class="region-header">
-			<div class="block-epa-core-gsa-epa-search" id="block-epa-core-gsa-epa-search">
-				<form action="https://search.epa.gov/epasearch" class="epa-search" method="get">
-					<label class="element-hidden" for="search-box">Search</label>
-					<input class="form-text" id="search-box" aria-label="Search EPA.gov" name="querytext"
-						placeholder="Search EPA.gov" value="">
-					<button class="epa-search-button" id="search-button" title="Search" type="submit">Search</button>
-					<input name="areaname" type="hidden" value="">
-					<input name="areacontacts" type="hidden" value="">
-					<input name="areasearchurl" type="hidden" value="">
-					<input name="typeofsearch" type="hidden" value="epa">
-					<input name="result_template" type="hidden" value="2col.ftl">
-				</form>
-			</div>
-		</div>
-	</header>
-	<nav class="nav main-nav clearfix" role="navigation">
-		<div class="nav__inner">
-			<h2 class="element-invisible">Main menu</h2>
-			<ul class="menu" role="menu">
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/environmental-topics" role="menuitem"
-						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/laws-regulations" role="menuitem"
-						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
-						&amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
-						role="menuitem"
-						title="Learn more about our mission and what we do, how we are organized, and our history.">About
-						EPA</a></li>
-			</ul>
-		</div>
-	</nav>
-	<div class="mobile-nav" id="mobile-nav">
-		<div class="mobile-bar clearfix">
-			<label class="menu-button" for="mobile-nav-toggle">Menu</label>
-		</div>
-		<input checked id="mobile-nav-toggle" type="checkbox">
-		<div class="mobile-links element-hidden" id="mobile-links" style="height:2404px;">
-			<ul class="mobile-menu">
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/environmental-topics" role="menuitem"
-						title="Learn about Environmental Topics that EPA covers.">Environmental Topics</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link"
-						href="https://www.epa.gov/laws-regulations" role="menuitem"
-						title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws.">Laws
-						&amp; Regulations</a></li>
-				<li class="menu-item" role="presentation"><a class="menu-link" href="https://www.epa.gov/aboutepa"
-						role="menuitem"
-						title="Learn more about our mission and what we do, how we are organized, and our history.">About
-						EPA</a></li>
-			</ul>
-		</div>
-	</div>
-	<section class="main-content clearfix" id="main-content" lang="en" role="main" tabindex="-1">
-		<div class="region-preface clearfix">
-			<div class="block block-pane block-pane-epa-web-area-connect" id="block-pane-epa-web-area-connect">
-				<ul class="menu utility-menu">
-					<li class="menu-item"><a class="menu-link" href="mailto:mywaterway@epa.gov">Contact Us</a></li>
-				</ul>
-			</div>
-		</div>
-		<div class="main-column clearfix">
-			<!--googleon:all-->
-			<h1 class="page-title">Unfortunately, this web application is not available at this time.</h1>
-			<div class="panel-pane pane-node-content">
-				<div class="pane-content">
-					<div class="node node-page clearfix view-mode-full">
-						<p><a href="https://www.epa.gov/waterdata/forms/contact-us-about-hows-my-waterway"
-								target="_blank" rel="noopener noreferrer">Contact Us</a> if the problem persists.</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</section>
-	<footer class="main-footer clearfix" role="contentinfo">
-		<div class="main-footer__inner">
-			<div class="region-footer">
-				<div class="block-pane-epa-global-footer" id="block-pane-epa-global-footer">
-					<div class="row cols-3">
-						<div class="col size-1of3">
-							<div class="col__title">
-								Discover.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.epa.gov/accessibility">Accessibility</a></li>
-								<li><a href="https://www.epa.gov/planandbudget">Budget &amp; Performance</a></li>
-								<li><a href="https://www.epa.gov/contracts">Contracting</a></li>
-								<li><a href="https://www.epa.gov/grants">Grants</a>
-								</li>
-								<li><a href="https://www.epa.gov/home/wwwepagov-snapshots">EPA www Web Snapshots</a>
-								</li>
-								<li><a
-										href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees">No
-										FEAR Act Data</a></li>
-								<li><a href="https://www.epa.gov/privacy">Privacy</a></li>
-								<li><a href="https://www.epa.gov/privacy/privacy-and-security-notice">Privacy and Security Notice</a></li>
-							</ul>
-						</div>
-						<div class="col size-1of3">
-							<div class="col__title">
-								Connect.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.data.gov/">Data.gov</a></li>
-								<li><a
-										href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general">Inspector
-										General</a></li>
-								<li><a href="https://www.epa.gov/careers">Jobs</a></li>
-								<li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
-								<li><a href="https://www.regulations.gov/">Regulations.gov</a></li>
-								<li><a href="https://www.epa.gov/newsroom/email-subscriptions">Subscribe</a></li>
-								<li><a href="https://www.usa.gov/">USA.gov</a></li>
-								<li><a href="https://www.whitehouse.gov/">White House</a></li>
-							</ul>
-						</div>
-						<div class="col size-1of3">
-							<div class="col__title">
-								Ask.
-							</div>
-							<ul class="menu">
-								<li><a href="https://www.epa.gov/home/forms/contact-us">Contact Us</a></li>
-								<li><a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a></li>
-								<li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
-								<li><a href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics">Frequent
-										Questions</a></li>
-							</ul>
-							<div class="col__title">
-								Follow.
-							</div>
-							<ul class="social-menu">
-								<li><a class="menu-link social-facebook"
-										href="https://www.facebook.com/EPA">Facebook</a></li>
-								<li><a class="menu-link social-twitter" href="https://twitter.com/epa">Twitter</a></li>
-								<li><a class="menu-link social-youtube"
-										href="https://www.youtube.com/user/USEPAgov">YouTube</a></li>
-								<li><a class="menu-link social-flickr"
-										href="https://www.flickr.com/photos/usepagov">Flickr</a></li>
-								<li><a class="menu-link social-instagram"
-										href="https://www.instagram.com/epagov">Instagram</a></li>
-							</ul>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</footer>
-</body>
-
+  <body class="html">
+    <!-- Google Tag Manager -->
+    <noscript
+      ><iframe
+        title="google tag manager"
+        src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager -->
+    <div class="skip-links">
+      <a
+        href="#main-content"
+        class="skip-link element-invisible element-focusable"
+        >Jump to main content</a
+      >
+    </div>
+    <header class="masthead clearfix" role="banner">
+      <div class="site-name-and-slogan">
+        <h1 class="site-name">
+          <a href="https://www.epa.gov/" rel="home" title="Go to the home page"
+            ><span>US EPA</span></a
+          >
+        </h1>
+        <div class="site-slogan">
+          United States Environmental Protection Agency
+        </div>
+      </div>
+      <div class="region-header">
+        <div
+          class="block-epa-core-gsa-epa-search"
+          id="block-epa-core-gsa-epa-search"
+        >
+          <form
+            action="https://search.epa.gov/epasearch"
+            class="epa-search"
+            method="get"
+          >
+            <label class="element-hidden" for="search-box">Search</label>
+            <input
+              class="form-text"
+              id="search-box"
+              aria-label="Search EPA.gov"
+              name="querytext"
+              placeholder="Search EPA.gov"
+              value=""
+            />
+            <button
+              class="epa-search-button"
+              id="search-button"
+              title="Search"
+              type="submit"
+            >
+              Search
+            </button>
+            <input name="areaname" type="hidden" value="" />
+            <input name="areacontacts" type="hidden" value="" />
+            <input name="areasearchurl" type="hidden" value="" />
+            <input name="typeofsearch" type="hidden" value="epa" />
+            <input name="result_template" type="hidden" value="2col.ftl" />
+          </form>
+        </div>
+      </div>
+    </header>
+    <nav class="nav main-nav clearfix" role="navigation">
+      <div class="nav__inner">
+        <h2 class="element-invisible">Main menu</h2>
+        <ul class="menu" role="menu">
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/environmental-topics"
+              role="menuitem"
+              title="Learn about Environmental Topics that EPA covers."
+              >Environmental Topics</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/laws-regulations"
+              role="menuitem"
+              title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws."
+              >Laws &amp; Regulations</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/aboutepa"
+              role="menuitem"
+              title="Learn more about our mission and what we do, how we are organized, and our history."
+              >About EPA</a
+            >
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <div class="mobile-nav" id="mobile-nav">
+      <div class="mobile-bar clearfix">
+        <label class="menu-button" for="mobile-nav-toggle">Menu</label>
+      </div>
+      <input checked id="mobile-nav-toggle" type="checkbox" />
+      <div
+        class="mobile-links element-hidden"
+        id="mobile-links"
+        style="height: 2404px"
+      >
+        <ul class="mobile-menu">
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/environmental-topics"
+              role="menuitem"
+              title="Learn about Environmental Topics that EPA covers."
+              >Environmental Topics</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/laws-regulations"
+              role="menuitem"
+              title="Laws written by Congress provide the authority for EPA to write regulations. Regulations explain the technical, operational, and legal details necessary to implement laws."
+              >Laws &amp; Regulations</a
+            >
+          </li>
+          <li class="menu-item" role="presentation">
+            <a
+              class="menu-link"
+              href="https://www.epa.gov/aboutepa"
+              role="menuitem"
+              title="Learn more about our mission and what we do, how we are organized, and our history."
+              >About EPA</a
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+    <section
+      class="main-content clearfix"
+      id="main-content"
+      lang="en"
+      role="main"
+      tabindex="-1"
+    >
+      <div class="region-preface clearfix">
+        <div
+          class="block block-pane block-pane-epa-web-area-connect"
+          id="block-pane-epa-web-area-connect"
+        >
+          <ul class="menu utility-menu">
+            <li class="menu-item">
+              <a class="menu-link" href="mailto:mywaterway@epa.gov"
+                >Contact Us</a
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="main-column clearfix">
+        <!--googleon:all-->
+        <h1 class="page-title">
+          Unfortunately, this web application is not available at this time.
+        </h1>
+        <div class="panel-pane pane-node-content">
+          <div class="pane-content">
+            <div class="node node-page clearfix view-mode-full">
+              <p>
+                <a
+                  href="https://www.epa.gov/waterdata/forms/contact-us-about-hows-my-waterway"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >Contact Us</a
+                >
+                if the problem persists.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <footer class="main-footer clearfix" role="contentinfo">
+      <div class="main-footer__inner">
+        <div class="region-footer">
+          <div
+            class="block-pane-epa-global-footer"
+            id="block-pane-epa-global-footer"
+          >
+            <div class="row cols-3">
+              <div class="col size-1of3">
+                <div class="col__title">Discover.</div>
+                <ul class="menu">
+                  <li>
+                    <a href="https://www.epa.gov/accessibility"
+                      >Accessibility</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/planandbudget"
+                      >Budget &amp; Performance</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/contracts">Contracting</a>
+                  </li>
+                  <li><a href="https://www.epa.gov/grants">Grants</a></li>
+                  <li>
+                    <a href="https://www.epa.gov/home/wwwepagov-snapshots"
+                      >EPA www Web Snapshots</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa-employees"
+                      >No FEAR Act Data</a
+                    >
+                  </li>
+                  <li><a href="https://www.epa.gov/privacy">Privacy</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/privacy/privacy-and-security-notice"
+                      >Privacy and Security Notice</a
+                    >
+                  </li>
+                </ul>
+              </div>
+              <div class="col size-1of3">
+                <div class="col__title">Connect.</div>
+                <ul class="menu">
+                  <li><a href="https://www.data.gov/">Data.gov</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/office-inspector-general/about-epas-office-inspector-general"
+                      >Inspector General</a
+                    >
+                  </li>
+                  <li><a href="https://www.epa.gov/careers">Jobs</a></li>
+                  <li><a href="https://www.epa.gov/newsroom">Newsroom</a></li>
+                  <li>
+                    <a href="https://www.regulations.gov/">Regulations.gov</a>
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/newsroom/email-subscriptions"
+                      >Subscribe</a
+                    >
+                  </li>
+                  <li><a href="https://www.usa.gov/">USA.gov</a></li>
+                  <li><a href="https://www.whitehouse.gov/">White House</a></li>
+                </ul>
+              </div>
+              <div class="col size-1of3">
+                <div class="col__title">Ask.</div>
+                <ul class="menu">
+                  <li>
+                    <a href="https://www.epa.gov/home/forms/contact-us"
+                      >Contact Us</a
+                    >
+                  </li>
+                  <li>
+                    <a href="https://www.epa.gov/home/epa-hotlines">Hotlines</a>
+                  </li>
+                  <li><a href="https://www.epa.gov/foia">FOIA Requests</a></li>
+                  <li>
+                    <a
+                      href="https://www.epa.gov/home/frequent-questions-specific-epa-programstopics"
+                      >Frequent Questions</a
+                    >
+                  </li>
+                </ul>
+                <div class="col__title">Follow.</div>
+                <ul class="social-menu">
+                  <li>
+                    <a
+                      class="menu-link social-facebook"
+                      href="https://www.facebook.com/EPA"
+                      >Facebook</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-twitter"
+                      href="https://twitter.com/epa"
+                      >Twitter</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-youtube"
+                      href="https://www.youtube.com/user/USEPAgov"
+                      >YouTube</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-flickr"
+                      href="https://www.flickr.com/photos/usepagov"
+                      >Flickr</a
+                    >
+                  </li>
+                  <li>
+                    <a
+                      class="menu-link social-instagram"
+                      href="https://www.instagram.com/epagov"
+                      >Instagram</a
+                    >
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  </body>
 </html>


### PR DESCRIPTION
## Related Issues:
* [HMW-404](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-404)

## Main Changes:
* Removed the "Documents" row from the items in the "Clean Water Act Section 319 Projects" sub-tab of the _Restore_ tab.
* Removed the loading of the `logo.png` image file in the static HTML files. It seems that the imported EPA scripts take care of loading the logo, now.
    * _Prettier_'s formatting made it look like a lot of changes were made to `400.html` and `500.html`, but the only change made to both is the single change made to `index.html`.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/restore, open a project item, and confirm that the _Documents_ row under _Project Details_ no longer exists.
2. Confirm that the EPA logo is still visible at the top of any page, and that it links to https://www.epa.gov.
3. Navigate to http://localhost:3000/communities, and verify the logo is intact and functional.
4. In `/server/app/server/routes/404.js`, change `400.html` to `500.html`, revisit http://localhost:3000/communities, and confirm the logo is still there.