### PR TITLE
Feature/hotfix 2 5

### DIFF
--- a/app/client/src/components/pages/Attains.js
+++ b/app/client/src/components/pages/Attains.js
@@ -24,9 +24,11 @@ function compareContextName(objA, objB) {
 }
 
 function getMatchingLabel(ATTAINSContext) {
-  return impairmentFields.filter((field) => {
-    return field.parameterGroup === ATTAINSContext;
-  })[0].label;
+  return (
+    impairmentFields.filter((field) => {
+      return field.parameterGroup === ATTAINSContext;
+    })[0]?.label ?? ATTAINSContext
+  );
 }
 
 const containerStyles = css`

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
@@ -231,17 +231,15 @@ function SiteSpecific({
         // match the param with an item in the attainsToHmwMapping file
         const match = impairmentFields.filter((field) => {
           return field.parameterGroup === param;
-        })[0];
+        })?.[0];
 
-        const sentence =
-          match && match.sentence ? (
-            <>{match.sentence}</>
-          ) : (
-            <>
-              contain{' '}
-              <GlossaryTerm term={match.term}>{match.label}</GlossaryTerm>
-            </>
-          );
+        const sentence = !match ? null : match.sentence ? (
+          <>{match.sentence}</>
+        ) : (
+          <>
+            contain <GlossaryTerm term={match.term}>{match.label}</GlossaryTerm>
+          </>
+        );
 
         return (
           <li key={index}>

--- a/app/client/src/config/attainsToHmwMapping.js
+++ b/app/client/src/config/attainsToHmwMapping.js
@@ -219,6 +219,13 @@ export const impairmentFields = [
     sentence: null,
   },
   {
+    value: 'pfas',
+    parameterGroup: 'PER- AND POLYFLUOROALKYL SUBSTANCES (PFAS)',
+    label: 'PFAS',
+    term: 'PFAS',
+    sentence: null,
+  },
+  {
     value: 'ph_acidity_caustic_conditions',
     parameterGroup: 'PH/ACIDITY/CAUSTIC CONDITIONS',
     label: 'Acidity',


### PR DESCRIPTION
## Related Issues:
* [HMW-410](https://jira.epa.gov/browse/HMW-410)

## Main Changes:
* Fixed an issue of the attains page not loading.
* Added additional safe guards to prevent this issue from happening again in the future.

## Steps To Test:
1. Navigate to http://localhost:3000/attains
2. Verify the page loads
3. Search for `PFAS` in the `Impairment Category` column and verify that `PFAS` shows up
4. In the `attainsToHmwMapping.js` file, comment out the entry for `PFAS`.
5. Reload the `attains` page 
6. Verify the page loads
7. Search for `PFAS` in the `Impairment Category` column and verify that `PER- AND POLYFLUOROALKYL SUBSTANCES (PFAS)` shows up, instead of `PFAS`
8. In the `attainsToHmwMapping.js` file, uncomment the entry for `PFAS` and comment out the entry for `Trash`.
9. Navigate to http://localhost:3000/state/CA/water-quality-overview
10. Verify the page doesn't crash
11. Expand the `Top Reasons for Impairment...` accordion
12. Verify that `Trash` shows up bold, without any glossary links

