### PR TITLE
Feature/429 update cyan services

### DIFF
--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -6,7 +6,7 @@ import React from 'react';
 export const echoError =
   'The permitted discharger information is temporarily unavailable, please try again later.';
 
-// qed.epa.gov
+// cyan.epa.gov
 export const cyanError =
   'CyAN data is temporarily unavailable, please try again later.';
 

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -55,11 +55,11 @@
   "sfdw": "https://ordspub.epa.gov/ords/sfdw/",
   "landCover": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2019_Land_Cover_L48/wms?service=WMS&request=GetCapabilities",
   "cyan": {
-    "application": "https://qed.epa.gov/cyanweb",
-    "cellConcentration": "https://qed.epa.gov/waterbody/data",
-    "dataDownload": "https://qed.epa.gov/waterbody/data_download",
-    "images": "https://qed.epa.gov/waterbody/image",
-    "properties": "https://qed.epa.gov/waterbody/properties",
+    "application": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
+    "cellConcentration": "https://cyan.epa.gov/waterbody/data",
+    "dataDownload": "https://cyan.epa.gov/waterbody/data_download",
+    "images": "https://cyan.epa.gov/waterbody/image",
+    "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
   "googleAnalyticsMapping": [

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -56,10 +56,10 @@
   "landCover": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2019_Land_Cover_L48/wms?service=WMS&request=GetCapabilities",
   "cyan": {
     "application": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
-    "cellConcentration": "https://qed.epa.gov/waterbody/data",
-    "dataDownload": "https://qed.epa.gov/waterbody/data_download",
-    "images": "https://qed.epa.gov/waterbody/image",
-    "properties": "https://qed.epa.gov/waterbody/properties",
+    "cellConcentration": "https://cyan.epa.gov/waterbody/data",
+    "dataDownload": "https://cyan.epa.gov/waterbody/data_download",
+    "images": "https://cyan.epa.gov/waterbody/image",
+    "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
   "googleAnalyticsMapping": [


### PR DESCRIPTION
## Related Issues:
* [HMW-429](https://jira.epa.gov/browse/HMW-429)

## Main Changes:
* Switched from `qed.epa.gov` to `cyan.epa.gov`.
* Updated the `services-attains.json` file.

## Steps To Test:
1. Verify that all instances of `qed.epa.gov` have been changed to `cyan.epa.gov`. Cyan still has cors errors, so we can't test the actual service yet.