### PR TITLE
Feature/441 CyAN Overlapping Dates

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1277,7 +1277,9 @@ function getTotalNonLandPixels(
 }
 
 function getTzOffsetMsecs(previous: Date, current: Date) {
-  return previous.getTimezoneOffset() - current.getTimezoneOffset() * 60 * 1000;
+  return (
+    (previous.getTimezoneOffset() - current.getTimezoneOffset()) * 60 * 1000
+  );
 }
 
 function squareKmToSquareMi(km: number) {
@@ -1481,12 +1483,15 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
       .then((res: { data: { [date: string]: number[] } }) => {
         const newData: CellConcentrationData = {};
         let currentDate = startDate.getTime();
-        while (
-          currentDate <=
-          today.getTime() - oneDay + getTzOffsetMsecs(startDate, today)
-        ) {
+        const yesterdayRaw = today.getTime() - oneDay;
+        const yesterday =
+          yesterdayRaw + getTzOffsetMsecs(new Date(yesterdayRaw), today);
+        while (currentDate <= yesterday) {
           newData[currentDate] = null;
-          currentDate += oneDay;
+          const nextDate = currentDate + oneDay;
+          currentDate =
+            nextDate -
+            getTzOffsetMsecs(new Date(currentDate), new Date(nextDate));
         }
         Object.entries(res.data).forEach(([date, values]) => {
           if (values.length !== 256) return;

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1245,9 +1245,7 @@ function formatDate(epoch: number) {
 function getDayOfYear(day: Date) {
   const firstOfYear = new Date(day.getFullYear(), 0, 0);
   const diff =
-    day.getTime() -
-    firstOfYear.getTime() +
-    (firstOfYear.getTimezoneOffset() - day.getTimezoneOffset()) * 60 * 1000;
+    day.getTime() - firstOfYear.getTime() + getTzOffsetMsecs(firstOfYear, day);
   return Math.floor(diff / oneDay);
 }
 
@@ -1276,6 +1274,10 @@ function getTotalNonLandPixels(
 ) {
   const { belowDetection, measurements, noData } = data;
   return sum(belowDetection, noData, ...measurements);
+}
+
+function getTzOffsetMsecs(previous: Date, current: Date) {
+  return previous.getTimezoneOffset() - current.getTimezoneOffset() * 60 * 1000;
 }
 
 function squareKmToSquareMi(km: number) {
@@ -1459,7 +1461,10 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
   useEffect(() => {
     if (services?.status !== 'success') return;
 
-    const startDate = new Date(today.getTime() - 7 * oneDay);
+    const startDateRaw = new Date(today.getTime() - 7 * oneDay);
+    const startDate = new Date(
+      startDateRaw.getTime() + getTzOffsetMsecs(startDateRaw, today),
+    );
 
     const dataUrl = `${services.data.cyan.cellConcentration}/?OBJECTID=${
       attributes.oid ?? attributes.OBJECTID
@@ -1476,7 +1481,10 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
       .then((res: { data: { [date: string]: number[] } }) => {
         const newData: CellConcentrationData = {};
         let currentDate = startDate.getTime();
-        while (currentDate <= today.getTime() - oneDay) {
+        while (
+          currentDate <=
+          today.getTime() - oneDay + getTzOffsetMsecs(startDate, today)
+        ) {
           newData[currentDate] = null;
           currentDate += oneDay;
         }
@@ -1484,7 +1492,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
           if (values.length !== 256) return;
           const epochDate = cyanDateToEpoch(date);
           // Indices 0, 254, & 255 represent indetectable pixels
-          if (epochDate !== null) {
+          if (epochDate !== null && newData.hasOwnProperty(epochDate)) {
             const measurements = values.slice(1, 254);
             newData[epochDate] = {
               belowDetection: values[0],


### PR DESCRIPTION
## Related Issues:
* [HMW-441](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-441)

## Main Changes:
* Updated CyAN date range calculations to account for Daylight Savings Time. This involves checking if there is a difference in the time zone offsets of two dates. It might have been easier to use the day of the year until converting back to a date, but then the issue of leap years comes into play.

## Steps To Test:
1. CyAN's CORS settings do not allow access from `localhost`. I tested with mock data, but it's still necessary to check that the correct calculation is used in the initial service request. I attempted to switch to the `proxyFetch` function, but didn't have any luck, so may need to double-check after merging into develop.