### PR TITLE
Feature/434 Remove XYChart log

### DIFF
--- a/app/client/src/components/shared/Sparkline.js
+++ b/app/client/src/components/shared/Sparkline.js
@@ -48,6 +48,7 @@ export function Sparkline({ data }: { data: Observation[] }) {
       <XYChart
         margin={{ top: 4, right: 4, bottom: 4, left: 4 }}
         height={32}
+        width={120}
         xScale={{ type: 'band', paddingInner: 0.875 }}
         yScale={{
           type: 'linear',


### PR DESCRIPTION
## Related Issues:
* [HMW-434](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-434)

## Main Changes:
* Added an explicit width to the `Sparkline` component to prevent XYChart from logging the error "XYChart has a zero width or height, bailing". This component is only used in one place, and it's inside a container with a static pixel width, so this isn't a problem. If we re-use the component in the future, we will want to parameterize the width.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/monitoring.
2. Open a "Current Water Conditions" panel item for a location with summary data for the week, e.g. **ANACOSTIA RIVER NR BUZZARD POINT AT WASHINGTON, DC**.
3. Confirm that the XYChart info log described above does not appear in the developer's console.
