### PR TITLE
Feature/444 add cyan to save output

### DIFF
--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -44,13 +44,7 @@ const tooltipCost =
 const tooltipFiltered = 'This layer will be saved with your selected filters.';
 const tooltipNotLoaded = 'This layer may not have been loaded yet.';
 
-const layersToIgnore = [
-  'nonprofitsLayer',
-  'protectedAreasHighlightLayer',
-
-  // TODO layers that still need to be added
-  'cyanLayer',
-];
+const layersToIgnore = ['nonprofitsLayer', 'protectedAreasHighlightLayer'];
 
 const layerTypesToIgnore = ['wcs', 'wfs'];
 
@@ -191,7 +185,8 @@ function SavePanel({ visible }: Props) {
     setSaveLayersList,
     widgetLayers,
   } = useAddSaveDataWidgetState();
-  const mapView = useContext(LocationSearchContext).mapView as __esri.MapView | null;
+  const mapView = useContext(LocationSearchContext)
+    .mapView as __esri.MapView | null;
   const upstreamWatershedResponse = useContext(LocationSearchContext)
     .upstreamWatershedResponse as {
     status: Status;
@@ -221,7 +216,9 @@ function SavePanel({ visible }: Props) {
   }, [setOAuthInfo, oAuthInfo]);
 
   // Watch for when layers are added to the map
-  const [mapLayerCount, setMapLayerCount] = useState(mapView?.map.layers.length);
+  const [mapLayerCount, setMapLayerCount] = useState(
+    mapView?.map.layers.length,
+  );
   const [layerWatcher, setLayerWatcher] = useState<IHandle | null>(null);
   useEffect(() => {
     if (!mapView || layerWatcher) return;

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -726,6 +726,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           attributes: { OBJECTID: 1 },
         }),
       ],
+      title: 'CyAN Waterbodies'
     });
 
     const cyanImages = new MediaLayer({
@@ -734,6 +735,10 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       effect: 'saturate(150%) contrast(150%)',
       id: 'cyanImages',
       opacity: 1,
+      spatialReference: {
+        wkid: 102100,
+      },
+      title: 'CyAN Images',
     });
 
     const newCyanLayer = new GroupLayer({

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1,6 +1,8 @@
+import ControlPointsGeoreference from '@arcgis/core/layers/support/ControlPointsGeoreference';
 import Extent from '@arcgis/core/geometry/Extent';
-import ExtentAndRotationGeoreference from '@arcgis/core/layers/support/ExtentAndRotationGeoreference';
 import ImageElement from '@arcgis/core/layers/support/ImageElement';
+import Point from '@arcgis/core/geometry/Point';
+import * as webMercatorUtils from '@arcgis/core/geometry/support/webMercatorUtils';
 import { css, FlattenSimpleInterpolation } from 'styled-components/macro';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import SpatialReference from '@arcgis/core/geometry/SpatialReference';
@@ -1480,7 +1482,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
     });
 
     // workaround for needing to proxy cyan from localhost
-    const fetcher = window.location.hostname === 'localhost' ? proxyFetch : fetchCheck;
+    const fetcher =
+      window.location.hostname === 'localhost' ? proxyFetch : fetchCheck;
 
     fetcher(dataUrl, abortSignal)
       .then((res: { data: { [date: string]: number[] } }) => {
@@ -1578,28 +1581,88 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
     setImageStatus('pending');
 
     // workaround for needing to proxy cyan from localhost
-    const fetcher = window.location.hostname === 'localhost' ? proxyFetch : fetchCheck;
+    const fetcher =
+      window.location.hostname === 'localhost' ? proxyFetch : fetchCheck;
 
-    const imagePromise = fetcher(imageUrl, abortController.signal, undefined, 'blob');
+    const imagePromise = fetcher(
+      imageUrl,
+      abortController.signal,
+      undefined,
+      'blob',
+    );
     const propsPromise = fetcher(propertiesUrl, abortController.signal);
     Promise.all([imagePromise, propsPromise])
       .then(([blob, propsRes]) => {
-        const image = new Image();
-        image.src = URL.createObjectURL(blob);
-        image.onload = () => setImageStatus('success');
-        const imageElement = new ImageElement({
-          image,
-          georeference: new ExtentAndRotationGeoreference({
-            extent: new Extent({
+        // read the image blob to convert it to base64
+        const reader = new FileReader();
+        reader.readAsDataURL(blob);
+        reader.onloadend = function () {
+          // convert the image to a base64 string
+          const base64String = reader.result;
+          const image = new Image();
+          image.src = base64String?.toString() || '';
+
+          image.onload = () => {
+            setImageStatus('success');
+
+            // create an extent and convert to web mercator for AGO support
+            const geographicExtent = new Extent({
               spatialReference: SpatialReference.WGS84,
               xmin: propsRes.properties.x_min,
               xmax: propsRes.properties.x_max,
               ymin: propsRes.properties.y_min,
               ymax: propsRes.properties.y_max,
-            }),
-          }),
-        });
-        cyanImageLayer.source.elements.add(imageElement);
+            });
+            const webMercatorExtent = webMercatorUtils.geographicToWebMercator(
+              geographicExtent,
+            ) as __esri.Extent;
+
+            // convert the extent to control points for AGO support
+            const swCorner = {
+              sourcePoint: { x: 0, y: image.height },
+              mapPoint: new Point({
+                x: webMercatorExtent.xmin,
+                y: webMercatorExtent.ymin,
+                spatialReference: webMercatorExtent.spatialReference,
+              }),
+            };
+            const nwCorner = {
+              sourcePoint: { x: 0, y: 0 },
+              mapPoint: new Point({
+                x: webMercatorExtent.xmin,
+                y: webMercatorExtent.ymax,
+                spatialReference: webMercatorExtent.spatialReference,
+              }),
+            };
+            const neCorner = {
+              sourcePoint: { x: image.width, y: 0 },
+              mapPoint: new Point({
+                x: webMercatorExtent.xmax,
+                y: webMercatorExtent.ymax,
+                spatialReference: webMercatorExtent.spatialReference,
+              }),
+            };
+            const seCorner = {
+              sourcePoint: { x: image.width, y: image.height },
+              mapPoint: new Point({
+                x: webMercatorExtent.xmax,
+                y: webMercatorExtent.ymin,
+                spatialReference: webMercatorExtent.spatialReference,
+              }),
+            };
+
+            const geo = new ControlPointsGeoreference({
+              controlPoints: [swCorner, nwCorner, neCorner, seCorner],
+              width: image.width,
+              height: image.height,
+            });
+            const imageElement = new ImageElement({
+              image,
+              georeference: geo,
+            });
+            cyanImageLayer.source.elements.add(imageElement);
+          };
+        };
       })
       .catch((err) => {
         setImageStatus('failure');
@@ -2429,7 +2492,11 @@ function MonitoringLocationsContent({
       {(!onMonitoringReportPage ||
         layer.id === 'monitoringLocationsLayer-surrounding') && (
         <p css={paragraphStyles}>
-          <a rel="noopener noreferrer" target="_blank" href={locationUrlPartial}>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href={locationUrlPartial}
+          >
             <i
               css={iconStyles}
               className="fas fa-info-circle"

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -1,8 +1,11 @@
+import SpatialReference from '@arcgis/core/geometry/SpatialReference';
+import { v4 as uuid } from 'uuid';
 // components
 import mapPin from 'images/pin.png';
 // utils
 import {
   fetchCheck,
+  fetchPostFile,
   fetchPostForm,
   getEnvironmentString,
 } from 'utils/fetchUtils';
@@ -493,6 +496,21 @@ export async function createFeatureLayers(
         });
 
         continue;
+      } else if (layer.layer.id === 'cyanLayer') {
+        const groupLayer = layer.layer as __esri.GroupLayer;
+        const waterbodiesLayer = groupLayer.findLayerById(
+          'cyanWaterbodies',
+        ) as __esri.FeatureLayer;
+
+        layerIds.push(groupLayer.id);
+        addSubLayer({
+          layer: waterbodiesLayer,
+          layersParams,
+          layerProps,
+          properties,
+        });
+
+        continue;
       } else if (layer.layer.id === 'waterbodyLayer') {
         const groupLayer = layer.layer as __esri.GroupLayer;
         const subLayers = groupLayer.layers.toArray() as __esri.FeatureLayer[];
@@ -661,6 +679,7 @@ async function applyEdits({
         // filter features down to just areas, lines, or points
         // depending on which geometry layer we are adding to
         graphicsLayer.graphics.forEach((g) => {
+          if (!g.geometry) return;
           if (
             (layerRes.name === `${layer.label} Areas` &&
               g.geometry.type === 'polygon') ||
@@ -675,6 +694,13 @@ async function applyEdits({
             });
           }
         });
+      } else if (layer.id === 'cyanLayer') {
+        const groupLayer = layer.layer as __esri.GroupLayer;
+        const subLayer = groupLayer.findLayerById(
+          'cyanWaterbodies',
+        ) as __esri.FeatureLayer;
+
+        if (subLayer) await processLayerFeatures(subLayer, adds);
       } else if (
         [
           'dischargersLayer',
@@ -871,7 +897,7 @@ function getLayerUrl(services: any, layer: LayerType): string {
  * @param layersResponse The response from creating layers
  * @returns A promise that resolves to the successfully saved web map
  */
-export function addWebMap({
+export async function addWebMap({
   portal,
   mapView,
   service,
@@ -913,6 +939,7 @@ export function addWebMap({
   }
 
   const operationalLayers: ILayerExtendedType[] = [];
+  const resourcesParams: any[] = [];
   layers.forEach((l) => {
     const layerType = getAgoLayerType(l) as string;
     const url = getLayerUrl(services, l);
@@ -935,8 +962,8 @@ export function addWebMap({
           widgetLayerFile.rawLayer.layerDefinition?.globalIdField,
           widgetLayerFile.fields,
         );
-      } else if (l.id === 'issuesLayer') {
-        // don't do anything for issuesLayer, it will be handeled below
+      } else if (['cyanLayer', 'issuesLayer'].includes(l.id)) {
+        // don't do anything for these layers, they will be handeled below
       } else {
         // handle boundaries and providers
         let properties = layerProps.data.layerSpecificSettings[l.layer.id];
@@ -955,7 +982,94 @@ export function addWebMap({
       }
 
       const lResponses = layersRes.layers.filter((r) => r.layerId === l.id);
-      if (lResponses.length === 1) {
+      if (l.id === 'cyanLayer' && lResponses.length > 0) {
+        const lRes = lResponses[0];
+
+        const groupLayer = mapView.map.layers.find(
+          (sl) => sl.id === 'cyanLayer',
+        ) as __esri.GroupLayer;
+        const waterbodiesLayer = groupLayer.findLayerById(
+          'cyanWaterbodies',
+        ) as __esri.FeatureLayer;
+        const imagesLayer = groupLayer.findLayerById(
+          'cyanImages',
+        ) as __esri.MediaLayer;
+
+        const layers: any[] = [];
+
+        // build fields here
+        let popupFields: IFieldInfo[] = [];
+        if (waterbodiesLayer) {
+          popupFields = buildPopupFieldsList(
+            waterbodiesLayer.objectIdField,
+            waterbodiesLayer.globalIdField,
+            waterbodiesLayer.fields,
+          );
+        }
+
+        layers.push({
+          title: lRes.name,
+          url: `${baseUrl}/${lRes.id}`,
+          itemId,
+          layerType: 'ArcGISFeatureLayer',
+          disablePopup: false,
+          popupInfo: {
+            popupElements: [
+              {
+                type: 'fields',
+                description: '',
+                fieldInfos: popupFields,
+                title: '',
+              },
+            ],
+            fieldInfos: popupFields,
+            title: `${lRes.name}: {orgName}`,
+          },
+        });
+
+        if (imagesLayer.source.elements.length > 0) {
+          const element = imagesLayer.source.elements.getItemAt(0);
+          const georeference =
+            element.georeference as __esri.ControlPointsGeoreference;
+
+          // get the extension from the base64 image and generate a unique filename
+          const extension = element.content.src.split(';')[0].split('/')[1];
+          const fileName = `${uuid()}.${extension}`;
+
+          layers.push({
+            id: imagesLayer.id,
+            title: imagesLayer.title,
+            layerType: 'MediaLayer',
+            mediaType: element.type,
+            url: `./resources/media/${fileName}`,
+            georeference: {
+              controlPoints: georeference.controlPoints.map((p) => {
+                return {
+                  x: p.mapPoint?.x,
+                  y: p.mapPoint?.y,
+                };
+              }),
+              spatialReference: SpatialReference.WebMercator.toJSON(),
+              coefficients: (georeference as any).transform,
+              height: element.content.height,
+              width: element.content.width,
+            },
+          });
+
+          resourcesParams.push({
+            resourcesPrefix: 'media',
+            fileName,
+            file: element.content.src,
+          });
+        }
+
+        operationalLayers.push({
+          id: l.layer.id,
+          title: l.layer.title,
+          layerType: 'GroupLayer',
+          layers: layers,
+        });
+      } else if (lResponses.length === 1) {
         lResponses.forEach((lRes) => {
           operationalLayers.push({
             title: lRes.name,
@@ -1104,7 +1218,34 @@ export function addWebMap({
   };
   appendEnvironmentObjectParam(data);
 
-  return fetchPostForm(`${portal.user.userContentUrl}/addItem`, data);
+  const webMapRes = await fetchPostForm(
+    `${portal.user.userContentUrl}/addItem`,
+    data,
+  );
+
+  const resourcesPromises: Promise<any>[] = [];
+  for (const p of resourcesParams) {
+    // convert file from base64 to blob
+    const base64Response = await fetch(p.file);
+    const fileBlob = await base64Response.blob();
+
+    resourcesPromises.push(
+      fetchPostFile(
+        `${portal.user.userContentUrl}/items/${webMapRes.id}/addResources`,
+        {
+          f: 'json',
+          token: portal.credential.token,
+          resourcesPrefix: p.resourcesPrefix,
+          fileName: p.fileName,
+        },
+        fileBlob,
+        p.fileName,
+      ),
+    );
+  }
+  await Promise.all(resourcesPromises);
+
+  return webMapRes;
 }
 
 /**

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -145,6 +145,7 @@ export function fetchPostFile(
   apiUrl: string,
   data: object,
   file: any,
+  fileName: string = undefined,
   timeout: number = defaultTimeout,
 ) {
   const startTime = performance.now();
@@ -160,7 +161,7 @@ export function fetchPostFile(
 
     body.append(key, valueToAdd);
   }
-  body.append('file', file);
+  body.append('file', file, fileName);
 
   return timeoutPromise(
     timeout,

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -1,5 +1,4 @@
 import { render } from 'react-dom';
-import { renderToStaticMarkup } from 'react-dom/server';
 import { css } from 'styled-components/macro';
 import Color from '@arcgis/core/Color';
 import Graphic from '@arcgis/core/Graphic';
@@ -9,7 +8,6 @@ import SimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import SimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 // components
 import { MapPopup } from 'components/shared/WaterbodyInfo';
-import WaterbodyIcon from 'components/shared/WaterbodyIcon';
 // utilities
 import { getSelectedCommunityTab } from 'utils/utils';
 // types
@@ -257,27 +255,6 @@ export function createUniqueValueInfosRestore(
   ];
 }
 
-// utility function to create an ESRI MarkerSymbol for a Waterbody
-export function createWaterbodySymbolSvg({
-  condition,
-  selected,
-}: {
-  condition: 'good' | 'polluted' | 'unassessed';
-  selected: boolean;
-}) {
-  const markup = renderToStaticMarkup(
-    <WaterbodyIcon condition={condition} selected={selected} />,
-  );
-
-  return {
-    type: 'picture-marker', // autocasts as new PictureMarkerSymbol()
-    url: `data:image/svg+xml;base64,${encode(markup)}`,
-    width: '26px',
-    height: '26px',
-    condition: condition,
-  };
-}
-
 export function createWaterbodySymbol({
   condition,
   selected,
@@ -367,10 +344,6 @@ export function createWaterbodySymbol({
       outline: polyOutline,
     });
   }
-}
-
-function encode(str: string): string {
-  return Buffer.from(str, 'binary').toString('base64');
 }
 
 // Functions used for narrowing types

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -29,7 +29,9 @@
         }
       }
     },
-    "cyanLayer": {},
+    "cyanLayer": {
+      "description": ""
+    },
     "dischargersLayer": {
       "geometryType": "esriGeometryPoint",
       "description": "",


### PR DESCRIPTION
## Related Issues:
* [HMW-444](https://jira.epa.gov/browse/HMW-444)

## Main Changes:
* Added ability to save CyAN data.
  * I had to switch to using from `ExtentAndRotationGeoreference` to `ControlPointsGeoreference`, which unfortunately makes the code a little more complex. This was done because the `addItem` REST service only supports control points for the georeference. Hopefully, they will update the service to allow extents in the future.
* Removed the `encode` and `createWaterbodySymbolSvg` functions, since they aren't being used anymore.

## Steps To Test:
1. Navigate to http://localhost:3000/community/030901011703/monitoring
2. Expand one of the CyAN waterbodies
3. Verify it places satelite imagery on the map (if it doesn't choose a different date or CyAN waterbody)
4. Once you have satelite imagery on the screen, attempt to save the layer
5. Open it in AGO and verify both of the CyAN layers are there
6. Collapse all of the CyAN waterbodies (all satellite imagery should be removed)
7. Save the CyAN layer with a different name
8. Open it in AGO and verify only the CyAN Waterbodies layer is there


