### PR TITLE
Feature/413 440 Report and data page links

### DIFF
--- a/app/client/src/components/shared/DataContent.js
+++ b/app/client/src/components/shared/DataContent.js
@@ -12,13 +12,19 @@ import { dataContentError } from 'config/errorMessages';
 // contexts
 import { useDataSourcesContext } from 'contexts/LookupFiles';
 // styles
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, textBoxStyles } from 'components/shared/MessageBoxes';
 import { fonts } from 'styles/index.js';
 
 function scrollToItem(id: string) {
   const item = document.getElementById(id);
   if (item) item.scrollIntoView();
 }
+
+const marginBoxStyles = (styles) => css`
+  ${styles}
+  margin: 0.5em 0;
+  width: fit-content;
+`;
 
 const containerStyles = css`
   padding: 1rem;
@@ -201,11 +207,11 @@ function DataContent() {
             <div css={itemStyles} id={id}>
               <i className="fas fa-database" aria-hidden="true" />{' '}
               <h2 css={titleStyles}>{title}</h2>
-              <p>
+              <div css={marginBoxStyles(textBoxStyles)}>
                 <a href={linkHref} target="_blank" rel="noopener noreferrer">
                   {linkLabel}
                 </a>
-              </p>
+              </div>
               <p dangerouslySetInnerHTML={{ __html: description }} />
               <br />
               <h2 css={questionStyles}>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -407,7 +407,7 @@ function WaterbodyInfo({
 
   const waterbodyReportLink =
     onWaterbodyReportPage ? null : attributes.organizationid ? (
-      <p css={paragraphStyles}>
+      <div css={paddedMarginBoxStyles(textBoxStyles)}>
         <a
           rel="noopener noreferrer"
           target="_blank"
@@ -422,8 +422,8 @@ function WaterbodyInfo({
           View Waterbody Report
         </a>
         &nbsp;&nbsp;
-        <small css={disclaimerStyles}>(opens new browser tab)</small>
-      </p>
+        <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>
+      </div>
     ) : (
       <p css={paragraphStyles}>
         Unable to find a waterbody report for this waterbody.
@@ -1150,7 +1150,13 @@ const cyanListContentStyles = css`
 
 const marginBoxStyles = (styles: FlattenSimpleInterpolation) => css`
   ${styles}
-  margin: 1em;
+  margin: 1em 0;
+`;
+
+const paddedMarginBoxStyles = (styles: FlattenSimpleInterpolation) => css`
+  ${styles}
+  ${marginBoxStyles(styles)}
+  padding: 0.75em;
 `;
 
 const showLessMoreStyles = css`
@@ -2507,7 +2513,7 @@ function MonitoringLocationsContent({
 
       {(!onMonitoringReportPage ||
         layer.id === 'monitoringLocationsLayer-surrounding') && (
-        <p css={paragraphStyles}>
+        <div css={paddedMarginBoxStyles(textBoxStyles)}>
           <a
             rel="noopener noreferrer"
             target="_blank"
@@ -2515,14 +2521,14 @@ function MonitoringLocationsContent({
           >
             <i
               css={iconStyles}
-              className="fas fa-info-circle"
+              className="fas fa-file-alt"
               aria-hidden="true"
             />
             View Monitoring Report
           </a>
           &nbsp;&nbsp;
-          <small css={disclaimerStyles}>(opens new browser tab)</small>
-        </p>
+          <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>
+        </div>
       )}
     </>
   );

--- a/app/client/src/utils/hooks/index.ts
+++ b/app/client/src/utils/hooks/index.ts
@@ -798,53 +798,10 @@ function useDynamicPopup() {
     dynamicPopupFields = fields;
   };
 
-  const [hucInfo, setHucInfo] = useState<ClickedHucState>({
-    status: 'none',
-    data: null,
-  });
-
-  const [lastLocation, setLastLocation] = useState<{
-    latitude: number;
-    longitude: number;
-  } | null>(null);
-
   const getClickedHuc = useCallback(
     (location: __esri.Point) => {
       if (services.status !== 'success') return null;
       return new Promise<ClickedHucState>((resolve, reject) => {
-        const testLocation = {
-          latitude: location.latitude,
-          longitude: location.longitude,
-        };
-
-        function poll(timeout: number) {
-          if (['none', 'fetching'].includes(hucInfo.status)) {
-            setTimeout(poll, timeout);
-          } else {
-            resolve(hucInfo);
-          }
-        }
-        // check if the location changed
-        if (
-          testLocation &&
-          lastLocation &&
-          testLocation.latitude === lastLocation.latitude &&
-          testLocation.longitude === lastLocation.longitude
-        ) {
-          // polls the dom, based on provided timeout, until the esri search input
-          // is added. Once the input is added this sets the id attribute and stops
-          // the polling.
-          poll(1000);
-
-          return;
-        }
-
-        setLastLocation(testLocation);
-        setHucInfo({
-          status: 'fetching',
-          data: null,
-        });
-
         //get the huc boundaries of where the user clicked
         const queryParams = {
           returnGeometry: true,
@@ -863,14 +820,13 @@ function useDynamicPopup() {
             }
 
             const { attributes } = boundaries.features[0];
-            setHucInfo({
+            resolve({
               status: 'success',
               data: {
                 huc12: attributes.huc12,
                 watershed: attributes.name,
               },
             });
-            resolve(hucInfo);
           })
           .catch((err) => {
             console.error(err);
@@ -878,7 +834,7 @@ function useDynamicPopup() {
           });
       });
     },
-    [hucInfo, lastLocation, services],
+    [services],
   );
 
   // Wrapper function for getting the content of the popup


### PR DESCRIPTION
## Related Issues:
* [HMW-413](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-413)
* [HMW-440](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-440)

## Main Changes:
* Added shaded boxes around the "data systems" links on the _Data_ page.
* Added shaded boxes around the "View Waterbody Report" and "View Monitoring Report" links in the waterbody and past water conditions popups/accordion items.
* Changed the icon of the "View Monitoring Report" link to match that of the waterbody report.
* Removed some code from the `getClickedHuc` function. This was recently converted to a memoized function, and in the process some dependency issues were created. In looking it over, I couldn't figure out why the DOM was being polled: it seems to function correctly with the polling removed, so I assume it was leftover from the past, but I could be mistaken.

## Steps To Test:
1. Visit the _Data_ page and confirm that the links appear as expected, and that they still function.
2. Visit the _Community_ page, open a waterbody popup or accordion item, and confirm the "View Waterbody Report" link is displayed in a shaded box.
3. Open a "Past Water Conditions" popup or accordion item, and make sure the link is displayed in a similar fashion to the waterbody link.
4. Click a location on the map outside the current HUC, and confirm that the "Change to this Location?" popup functions correctly (test with both an outside feature and and outside vacant area).