### PR TITLE
Feature/400 414 tribal page title cyan message

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -2,7 +2,7 @@
 
 import React, { useContext, useEffect, useRef } from 'react';
 import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
-import {} from 'styled-components/macro';
+import { css } from 'styled-components/macro';
 import { Tab, Tabs, TabList, TabPanel, TabPanels } from '@reach/tabs';
 import { useWindowSize } from '@reach/window-size';
 // components
@@ -16,6 +16,15 @@ import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
 // contexts
 import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
 import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
+
+const headingStyles = css`
+  margin-top: 0 !important;
+
+  i {
+    margin-right: 0.3125em;
+    color: #2c72b5;
+  }
+`;
 
 function StateTribalTabs() {
   const { stateCode, tabName } = useParams();
@@ -129,6 +138,10 @@ function StateTribalTabs() {
 
     return (
       <div>
+        <h2 css={headingStyles}>
+          <i className="fas fa-map-marked-alt" aria-hidden="true" />
+          <strong>{activeState.label}</strong> at a Glance
+        </h2>
         <div>{mapContent}</div>
         <hr />
         <WaterQualityOverview />

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -2,7 +2,7 @@
 
 import React, { useContext, useEffect, useRef } from 'react';
 import { useOutletContext, useParams, useNavigate } from 'react-router-dom';
-import { css } from 'styled-components/macro';
+import {} from 'styled-components/macro';
 import { Tab, Tabs, TabList, TabPanel, TabPanels } from '@reach/tabs';
 import { useWindowSize } from '@reach/window-size';
 // components
@@ -16,15 +16,6 @@ import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
 // contexts
 import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
 import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
-
-const headingStyles = css`
-  margin-top: 0 !important;
-
-  i {
-    margin-right: 0.3125em;
-    color: #2c72b5;
-  }
-`;
 
 function StateTribalTabs() {
   const { stateCode, tabName } = useParams();
@@ -138,7 +129,7 @@ function StateTribalTabs() {
 
     return (
       <div>
-        <h2 css={headingStyles}>
+        <h2>
           <i className="fas fa-map-marked-alt" aria-hidden="true" />
           <strong>{activeState.label}</strong> at a Glance
         </h2>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -131,7 +131,6 @@ const modifiedErrorBoxStyles = css`
 const modifiedIntroBoxStyles = css`
   ${introBoxStyles}
 
-  margin-top: 1.5rem;
   margin-bottom: 1rem;
   line-height: 1.375;
 
@@ -146,6 +145,7 @@ const disclaimerStyles = css`
 
 const byTheNumbersExplanationStyles = css`
   font-style: italic;
+  margin-bottom: 1rem;
   padding: 0.5rem 0 0 0;
 `;
 
@@ -643,14 +643,23 @@ function StateTribal() {
                         )}
 
                         {stateIntro.description && (
-                          <div css={modifiedIntroBoxStyles}>
-                            <p>
-                              <ShowLessMore
-                                text={stateIntro.description}
-                                charLimit={450}
+                          <>
+                            <h2>
+                              <i
+                                aria-hidden="true"
+                                className="fas fa-question-circle"
                               />
-                            </p>
-                          </div>
+                              About <strong>{activeState.label}</strong>
+                            </h2>
+                            <div css={modifiedIntroBoxStyles}>
+                              <p>
+                                <ShowLessMore
+                                  text={stateIntro.description}
+                                  charLimit={450}
+                                />
+                              </p>
+                            </div>
+                          </>
                         )}
 
                         <DisclaimerModal css={disclaimerStyles}>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1192,17 +1192,11 @@ const sliderContainerStyles = css`
 
 const subheadingStyles = css`
   font-weight: bold;
-  padding-bottom: 0.5em;
-  padding-top: 1em;
+  padding-bottom: 0;
 
   &.centered {
     text-align: center;
   }
-`;
-
-const subheadingBoxStyles = css`
-  ${subheadingStyles}
-  padding-top: 0;
 `;
 
 const oneDay = 1000 * 60 * 60 * 24;
@@ -1912,7 +1906,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                 `}
                   yUnit="%"
                 />
-                <p>
+                <p css={paragraphStyles}>
                   The categories in this figure are included to assist the user
                   in visually understanding the concentration values. Please
                   review the World Health Organization (WHO) guide,{' '}
@@ -1933,8 +1927,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
             {/* If `selectedDate` is null, no date with data was found */}
             {selectedDate ? (
               <>
-                <div css={textBoxStyles}>
-                  <p css={subheadingBoxStyles}>
+                <div css={marginBoxStyles(textBoxStyles)}>
+                  <p css={subheadingStyles}>
                     <HelpTooltip
                       label={
                         <>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1447,6 +1447,7 @@ function CyanDailyContent({
     );
   }
 }
+
 type CyanContentProps = {
   feature: __esri.Graphic;
   mapView?: __esri.MapView;
@@ -1969,7 +1970,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
               </>
             ) : (
               <p css={marginBoxStyles(infoBoxStyles)}>
-                There is no CyAN data from the past week for the{' '}
+                There is no measureable CyAN data from the past week for the{' '}
                 {attributes.GNIS_NAME} waterbody.
               </p>
             )}

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -36,7 +36,7 @@ export function proxyFetch(
   const { REACT_APP_PROXY_URL } = process.env;
   // if environment variable is not set, default to use the current site origin
   const proxyUrl = REACT_APP_PROXY_URL || `${window.location.origin}/proxy`;
-  const url = `${proxyUrl}?url=${apiUrl}`;
+  const url = `${proxyUrl}?url=${encodeURI(apiUrl)}`;
 
   return fetchCheck(url, signal, timeout, responseType);
 }

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -36,7 +36,7 @@ export function proxyFetch(
   const { REACT_APP_PROXY_URL } = process.env;
   // if environment variable is not set, default to use the current site origin
   const proxyUrl = REACT_APP_PROXY_URL || `${window.location.origin}/proxy`;
-  const url = `${proxyUrl}?url=${encodeURI(apiUrl)}`;
+  const url = `${proxyUrl}?url=${apiUrl}`;
 
   return fetchCheck(url, signal, timeout, responseType);
 }


### PR DESCRIPTION
## Related Issues:
* [HMW-400](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-400)
* [HMW-414](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-414)

## Main Changes:
* Added a title above the map on the tribal pages.
* Added a title above the descriptions on the state and tribal pages.
* Updated the message displayed when there is no meaningful data for the past week to "there is no **measurable** CyAN data from the past week for...".

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/PUEBLOOFTESUQUE.
2. Verify there is a title above the description box that reads "About Pueblo of Tesuque, New Mexico".
3. Verify there is a title above the map that reads "Pueblo of Tesuque at a Glance".
4. Comment out line 1559 of `WaterbodyInfo.tsx`:
```
setSelectedDate(newSelectedDate);
```
5. Navigate to http://localhost:3000/community/Lake%20Mattamuskeet,%20NC,%20USA/monitoring.
6. Open the accordion item for the "Lake Mattamuskeet" CyAN waterbody, and confirm the info box displayed (where the date selection slider and daily statistics would be) matches the message described above.