### PR TITLE
Bugfix/451 Monitoring page median

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1177,6 +1177,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   min={minYear}
                   disabled={!Boolean(Object.keys(annualData).length)}
                   onChange={handleDateSliderChange}
+                  range={yearsRange}
                 />
               )}
             </div>

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -596,7 +596,7 @@ function getMean(values) {
 }
 
 function getMedian(values) {
-  const sorted = [...values].sort();
+  const sorted = [...values].sort((a, b) => a - b);
   const numValues = values.length;
   let median = 0;
   if (numValues % 2 === 0) {

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -1023,6 +1023,11 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
   // Get the selected chart data and statistics
   const getChartData = useCallback(
     (newDomain, newMsmts) => {
+      if (!newDomain) {
+        setChartData(null);
+        return;
+      }
+
       // newMsmts must already be sorted by date
       const filteredMsmts =
         newMsmts?.filter((msmt) => {
@@ -1061,7 +1066,8 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
   const [minYear, setMinYear] = useState(null);
   const [maxYear, setMaxYear] = useState(null);
   const [selectedYears, setSelectedYears] = useState(null);
-  // Initialize the chart
+
+  // Initialize the date slider parameters
   useEffect(() => {
     if (measurements?.length) {
       const yearLow = measurements[0].year;
@@ -1070,20 +1076,19 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       setMaxYear(yearHigh);
       setSelectedYears([yearLow, yearHigh]);
     } else {
-      setChartData(null);
       setMinYear(null);
       setMaxYear(null);
       setSelectedYears(null);
     }
   }, [measurements]);
 
+  // Update the chart with selected parameters
   useEffect(() => {
-    if (!selectedYears) return;
-
     getChartData(selectedYears, measurements);
   }, [getChartData, measurements, selectedYears]);
 
   const displayUnit = unit === 'None' ? '' : unit;
+
   // Title for the y-axis
   let yTitle = charcName;
   if (fraction !== 'None') yTitle += ', ' + fraction?.replace(',', ' -');

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -985,6 +985,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
   const [mean, setMean] = useState(null);
   const [median, setMedian] = useState(null);
   const [stdDev, setStdDev] = useState(null);
+  const [msmtCount, setMsmtCount] = useState(null);
 
   // Parse the measurements into chartable data points
   const parseMeasurements = useCallback((newDomain, newMsmts) => {
@@ -995,7 +996,6 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
     let curCount = 0;
     newMsmts.forEach((msmt) => {
       if (msmt.year >= newDomain[0] && msmt.year <= newDomain[1]) {
-        curCount++;
         const dataPoint = {
           value: msmt.measurement,
           depth: msmt.depth,
@@ -1003,19 +1003,19 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
         };
         if (!curDatum || curDatum.x !== msmt.date) {
           curDatum && newChartData.push(curDatum);
-          curCount = 1;
           curDatum = {
             x: msmt.date,
             y: { 0: dataPoint },
           };
+          curCount = 1;
         } else {
           curDatum.y[curCount.toString()] = dataPoint;
+          curCount++;
         }
         if (curCount > maxCount) maxCount = curCount;
       }
     });
     curDatum && newChartData.push(curDatum);
-    setChartData(newChartData.length ? newChartData : null);
     setDataKeys([...Array(maxCount).keys()]);
     return newChartData;
   }, []);
@@ -1034,6 +1034,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
         }) || [];
 
       const newChartData = parseMeasurements(newDomain, filteredMsmts);
+      setChartData(newChartData.length ? newChartData : null);
 
       if (!newChartData.length) return;
 
@@ -1052,12 +1053,14 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       setMean(newMean);
       setMedian(getMedian(yValues));
       setStdDev(getStdDev(yValues, newMean));
+      setMsmtCount(yValues.length);
     },
     [fraction, medium, parseMeasurements, unit],
   );
 
   const [minYear, setMinYear] = useState(null);
   const [maxYear, setMaxYear] = useState(null);
+  const [selectedYears, setSelectedYears] = useState(null);
   // Initialize the chart
   useEffect(() => {
     if (measurements?.length) {
@@ -1065,13 +1068,20 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       const yearHigh = measurements[measurements.length - 1].year;
       setMinYear(yearLow);
       setMaxYear(yearHigh);
-      getChartData([yearLow, yearHigh], measurements);
+      setSelectedYears([yearLow, yearHigh]);
     } else {
       setChartData(null);
       setMinYear(null);
       setMaxYear(null);
+      setSelectedYears(null);
     }
-  }, [getChartData, measurements]);
+  }, [measurements]);
+
+  useEffect(() => {
+    if (!selectedYears) return;
+
+    getChartData(selectedYears, measurements);
+  }, [getChartData, measurements, selectedYears]);
 
   const displayUnit = unit === 'None' ? '' : unit;
   // Title for the y-axis
@@ -1119,7 +1129,8 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
               min={minYear}
               max={maxYear}
               disabled={!Boolean(records.length)}
-              onChange={(newDomain) => getChartData(newDomain, measurements)}
+              onChange={(newDomain) => setSelectedYears(newDomain)}
+              range={selectedYears}
             />
             <div css={selectContainerStyles}>
               <span>
@@ -1231,7 +1242,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
                     },
                     {
                       label: 'Number of Measurements Shown',
-                      value: chartData.length.toLocaleString(),
+                      value: msmtCount.toLocaleString(),
                     },
                     {
                       label: 'Average of Values',
@@ -1603,6 +1614,7 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
           max={maxYear}
           min={minYear}
           onChange={(newRange) => setRange(newRange)}
+          range={range}
         />
         <div css={boxSectionStyles}>
           <div css={accordionStyles}>
@@ -2044,7 +2056,7 @@ function MonitoringReport() {
   );
 }
 
-function SliderContainer({ min, max, disabled = false, onChange }) {
+function SliderContainer({ min, max, disabled = false, onChange, range }) {
   if (!min || !max) return <LoadingSpinner />;
   else if (min === max)
     return (
@@ -2055,7 +2067,13 @@ function SliderContainer({ min, max, disabled = false, onChange }) {
 
   return (
     <div css={sliderContainerStyles}>
-      <DateSlider disabled={disabled} min={min} max={max} onChange={onChange} />
+      <DateSlider
+        disabled={disabled}
+        min={min}
+        max={max}
+        onChange={onChange}
+        range={range}
+      />
     </div>
   );
 }

--- a/app/client/src/components/shared/DateSlider.tsx
+++ b/app/client/src/components/shared/DateSlider.tsx
@@ -68,9 +68,10 @@ const trackStyles = {
 
 type Props = {
   disabled?: boolean;
-  min: number;
-  max: number;
+  min?: number;
+  max?: number;
   onChange: (newValues: number[]) => void;
+  range: number[];
 };
 
 function DateSlider({
@@ -78,13 +79,12 @@ function DateSlider({
   min = 0,
   max = new Date().getFullYear(),
   onChange,
+  range,
 }: Props) {
   const [minYear, setMinYear] = useState(min);
   const [maxYear, setMaxYear] = useState(max);
-  const [range, setRange] = useState([min, max]);
   useEffect(() => {
     if (!min || !max) return;
-    setRange([min, max]);
     setMinYear(min);
     setMaxYear(max);
   }, [min, max]);
@@ -95,7 +95,6 @@ function DateSlider({
     stepSize: 1,
     values: range,
     onChange,
-    onDrag: (newValues: number[]) => setRange(newValues),
   });
 
   return (


### PR DESCRIPTION
## Related Issues:
* [HMW-451](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-451)

## Main Changes:
* Fixed an issue on the _Monitoring Report_ page where the median for a particular characteristic was incorrectly calculated.
  * If the `sort()` function is not given a specific compare function, it sorts by the string representation of the values in the array. In this case, we want it to sort by the numeric value.
* Fixed an issue where the date range wasn't updating with new data. This was due to the fact that the slider wouldn't re-render if the `min` and `max` values didn't change. This has been fixed by lifting the `range` state up.
* Fixed an issue with the value of **Number of Measurements Shown**, which wasn't updated to account for multiple measurements on the same day.

## Steps To Test:
1. Navigate to http://localhost:3000/monitoring-report/STORET/CCU_EQL/CCU_EQL-BB/.
2. Select the characteristic **Total Coliform**.
3. Confirm that the **Median Value** is displayed as 1,133 cfu/100mL. To confirm the calculation, it may help to log the the sorted array in line **599** of `MonitoringReport.js`. The median value should be the value at position 163 of the array.
4. Adjust one of the handles of the chart's date slider.
5. Select a different characteristic, and confirm the slider resets to the entire date range.