### PR TITLE
Feature/452 separate surrounding visibility

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -38,7 +38,6 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import {
-  getEnclosedLayer,
   useStreamgages,
   useMonitoringGroups,
   useWaterbodyOnMap,
@@ -891,8 +890,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
       setAllToggled(true);
       if (!monitoringLocationsLayer) return;
 
-      const layer = getEnclosedLayer(monitoringLocationsLayer);
-      if (layer) layer.definitionExpression = '';
+      monitoringLocationsLayer.definitionExpression = '';
     };
   }, [huc12, monitoringLocationsLayer, resetWorkerData]);
 
@@ -933,9 +931,6 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
   useEffect(() => {
     if (!monitoringLocationsLayer || !monitoringGroups) return;
 
-    const layer = getEnclosedLayer(monitoringLocationsLayer);
-    if (!layer) return;
-
     const { toggledLocations, allLocations } = filterLocations(
       monitoringGroups,
       yearsRange,
@@ -954,11 +949,13 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
 
     // update the filters on the layer
     if (toggledLocations.length === monitoringGroups?.['All'].stations.length) {
-      layer.definitionExpression = '';
+      monitoringLocationsLayer.definitionExpression = '';
     } else if (locationIds.length === 0) {
-      layer.definitionExpression = '1=0';
+      monitoringLocationsLayer.definitionExpression = '1=0';
     } else {
-      layer.definitionExpression = `uniqueId IN ('${locationIds.join("','")}')`;
+      monitoringLocationsLayer.definitionExpression = `uniqueId IN ('${locationIds.join(
+        "','",
+      )}')`;
     }
 
     setCurrentLocations(allLocations);

--- a/app/client/src/components/pages/Community.js
+++ b/app/client/src/components/pages/Community.js
@@ -138,6 +138,8 @@ function Community() {
     };
   }, [fetchedDataDispatch, resetData, setLastSearchText, setSearchText]);
 
+  // Carry over surrounding features layer visibility between tabs.
+  // A ref is used to prevent state updates when surrounding layers are toggled.
   const { visible: surroundingsVisible } = useSurroundingsState();
   const surroundingsVisibleRef = useRef(surroundingsVisible);
 

--- a/app/client/src/components/pages/Community.js
+++ b/app/client/src/components/pages/Community.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import { css } from 'styled-components/macro';
 import { WindowSize } from '@reach/window-size';
@@ -22,6 +22,7 @@ import {
 import { EsriMapProvider } from 'contexts/EsriMap';
 import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
+import { useSurroundingsState } from 'contexts/Surroundings';
 // config
 import { tabs } from 'config/communityConfig.js';
 // styles
@@ -137,6 +138,13 @@ function Community() {
     };
   }, [fetchedDataDispatch, resetData, setLastSearchText, setSearchText]);
 
+  const { visible: surroundingsVisible } = useSurroundingsState();
+  const surroundingsVisibleRef = useRef(surroundingsVisible);
+
+  useEffect(() => {
+    surroundingsVisibleRef.current = surroundingsVisible;
+  }, [surroundingsVisible]);
+
   useEffect(() => {
     // don't show any tab based layers if on community landing page
     if (window.location.pathname === '/community' || activeTabIndex === -1) {
@@ -145,6 +153,7 @@ function Community() {
 
     updateVisibleLayers(
       {
+        ...surroundingsVisibleRef.current,
         ...tabs[activeTabIndex].layers,
       },
       false,

--- a/app/client/src/components/pages/Community.js
+++ b/app/client/src/components/pages/Community.js
@@ -286,15 +286,15 @@ function Community() {
 export default function CommunityContainer() {
   return (
     <EsriMapProvider>
-      <LayersProvider>
-        <CommunityTabsProvider>
+      <CommunityTabsProvider>
+        <LayersProvider>
           <MapHighlightProvider>
             <FullscreenProvider>
               <Community />
             </FullscreenProvider>
           </MapHighlightProvider>
-        </CommunityTabsProvider>
-      </LayersProvider>
+        </LayersProvider>
+      </CommunityTabsProvider>
     </EsriMapProvider>
   );
 }

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -49,10 +49,9 @@ import { MapHighlightProvider } from 'contexts/MapHighlight';
 // helpers
 import { fetchPost } from 'utils/fetchUtils';
 import {
-  getEnclosedLayer,
   useAbort,
   useMonitoringLocations,
-  useMonitoringLocationsLayer,
+  useMonitoringLocationsLayers,
   useSharedLayers,
 } from 'utils/hooks';
 import { isAbort, toFixedFloat } from 'utils/utils';
@@ -2085,14 +2084,18 @@ function SiteMap({ layout, site, siteFilter, siteStatus, widthRef }) {
     };
   }, [mapView]);
 
-  const monitoringLocationsLayer = useMonitoringLocationsLayer(siteFilter);
+  const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
+    useMonitoringLocationsLayers(siteFilter);
 
   // Initialize the layers
   useEffect(() => {
-    if (!monitoringLocationsLayer) return;
     if (!getSharedLayers || layersInitialized) return;
 
-    setLayers([...getSharedLayers(), monitoringLocationsLayer]);
+    setLayers([
+      ...getSharedLayers(),
+      monitoringLocationsLayer,
+      surroundingMonitoringLocationsLayer,
+    ]);
     updateVisibleLayers({ monitoringLocationsLayer: true });
     setLayersInitialized(true);
   }, [
@@ -2104,6 +2107,7 @@ function SiteMap({ layout, site, siteFilter, siteStatus, widthRef }) {
     setLayers,
     site,
     siteStatus,
+    surroundingMonitoringLocationsLayer,
     updateVisibleLayers,
   ]);
 
@@ -2114,10 +2118,9 @@ function SiteMap({ layout, site, siteFilter, siteStatus, widthRef }) {
     if (!mapView || !layersInitialized || !homeWidget) return;
     if (siteStatus !== 'success') return;
 
-    const stationLayer = getEnclosedLayer(monitoringLocationsLayer);
-    if (!stationLayer) return;
+    if (!monitoringLocationsLayer) return;
 
-    zoomToStation(stationLayer, mapView, getSignal())
+    zoomToStation(monitoringLocationsLayer, mapView, getSignal())
       .then(() => {
         // set map zoom and home widget's viewpoint
         mapView.zoom = mapView.zoom - 1;

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -2061,13 +2061,12 @@ function SliderContainer({ min, max, disabled = false, onChange }) {
 
 function SiteMap({ layout, site, siteFilter, siteStatus, widthRef }) {
   const [layersInitialized, setLayersInitialized] = useState(false);
+  const [layers, setLayers] = useState([]);
   const [mapLoading, setMapLoading] = useState(true);
 
   const services = useServicesContext();
   const getSharedLayers = useSharedLayers();
-  const { homeWidget, layers, mapView, resetData, setLayers } = useContext(
-    LocationSearchContext,
-  );
+  const { homeWidget, mapView, resetData } = useContext(LocationSearchContext);
 
   const { updateVisibleLayers } = useLayers();
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -645,10 +645,7 @@ function StateTribal() {
                         {stateIntro.description && (
                           <>
                             <h2>
-                              <i
-                                aria-hidden="true"
-                                className="fas fa-question-circle"
-                              />
+                              <i aria-hidden="true" className="fas fa-water" />
                               About <strong>{activeState.label}</strong>
                             </h2>
                             <div css={modifiedIntroBoxStyles}>

--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -73,7 +73,7 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
-  const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
+  const { surroundingMonitoringLocationsLayer } =
     useMonitoringLocationsLayers();
 
   // Initially sets up the layers
@@ -96,7 +96,6 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     setLayers([
       ...getSharedLayers(),
       localActionsLayer,
-      monitoringLocationsLayer,
       surroundingMonitoringLocationsLayer,
     ]);
     updateVisibleLayers({
@@ -107,7 +106,6 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     actionsWaterbodies,
     getSharedLayers,
     layersInitialized,
-    monitoringLocationsLayer,
     setLayer,
     surroundingMonitoringLocationsLayer,
     updateVisibleLayers,

--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -19,7 +19,7 @@ import { useServicesContext } from 'contexts/LookupFiles';
 import { fetchCheck } from 'utils/fetchUtils';
 import {
   useSharedLayers,
-  useMonitoringLocationsLayer,
+  useMonitoringLocationsLayers,
   useWaterbodyHighlight,
 } from 'utils/hooks';
 import { browserIsCompatibleWithArcGIS } from 'utils/utils';
@@ -73,12 +73,12 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
-  const monitoringLocationsLayer = useMonitoringLocationsLayer();
+  const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
+    useMonitoringLocationsLayers();
 
   // Initially sets up the layers
   const [layersInitialized, setLayersInitialized] = useState(false);
   useEffect(() => {
-    if (!monitoringLocationsLayer) return;
     if (!getSharedLayers || layersInitialized) return;
 
     let localActionsLayer = actionsWaterbodies;
@@ -97,10 +97,10 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
       ...getSharedLayers(),
       localActionsLayer,
       monitoringLocationsLayer,
+      surroundingMonitoringLocationsLayer,
     ]);
     updateVisibleLayers({
       actionsWaterbodies: true,
-      monitoringLocationsLayer: true,
     });
     setLayersInitialized(true);
   }, [
@@ -109,6 +109,7 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     layersInitialized,
     monitoringLocationsLayer,
     setLayer,
+    surroundingMonitoringLocationsLayer,
     updateVisibleLayers,
   ]);
 

--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -45,7 +45,13 @@ const tooltipCost =
 const tooltipFiltered = 'This layer will be saved with your selected filters.';
 const tooltipNotLoaded = 'This layer may not have been loaded yet.';
 
-const layersToIgnore = ['nonprofitsLayer', 'protectedAreasHighlightLayer'];
+const layersToIgnore = [
+  'nonprofitsLayer',
+  'protectedAreasHighlightLayer',
+  'surroundingDischargersLayer',
+  'surroundingMonitoringLocationsLayer',
+  'surroundingUsgsStreamgagesLayer',
+];
 if (
   window.location.pathname.includes('/plan-summary') ||
   window.location.pathname.includes('/waterbody-report')

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -604,9 +604,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setWaterbodyCountMismatch,
   ]);
 
-  const getSharedLayers = useSharedLayers({
-    allWaterbodiesLayer: { visible: true },
-  });
+  const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
   const { getTitle, getTemplate, setDynamicPopupFields } = useDynamicPopup();

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -60,9 +60,9 @@ import {
   useSharedLayers,
   useWaterbodyHighlight,
   useWaterbodyFeatures,
-  useDischargersLayer,
-  useMonitoringLocationsLayer,
-  useStreamgageLayer,
+  useDischargersLayers,
+  useMonitoringLocationsLayers,
+  useStreamgageLayers,
 } from 'utils/hooks';
 import { fetchCheck, fetchPostForm } from 'utils/fetchUtils';
 import {
@@ -224,11 +224,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     waterbodyLayer,
   } = useLayers();
 
-  const dischargersLayer = useDischargersLayer();
-  const monitoringLocationsLayer = useMonitoringLocationsLayer(
-    huc12 ? `huc=${huc12}` : null,
-  );
-  const usgsStreamgagesLayer = useStreamgageLayer();
+  const { dischargersLayer, surroundingDischargersLayer } =
+    useDischargersLayers();
+  const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
+    useMonitoringLocationsLayers(huc12 ? `huc=${huc12}` : null);
+  const { usgsStreamgagesLayer, surroundingUsgsStreamgagesLayer } =
+    useStreamgageLayers();
 
   const stateNationalUses = useStateNationalUsesContext();
 
@@ -603,7 +604,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     setWaterbodyCountMismatch,
   ]);
 
-  const getSharedLayers = useSharedLayers();
+  const getSharedLayers = useSharedLayers({
+    allWaterbodiesLayer: { visible: true },
+  });
   useWaterbodyHighlight();
 
   const { getTitle, getTemplate, setDynamicPopupFields } = useDynamicPopup();
@@ -611,8 +614,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   // Builds the layers that have no dependencies
   const [layersInitialized, setLayersInitialized] = useState(false);
   useEffect(() => {
-    if (!dischargersLayer || !monitoringLocationsLayer || !usgsStreamgagesLayer)
-      return;
     if (!getSharedLayers || layersInitialized) return;
 
     if (layers.length > 0) return;
@@ -772,9 +773,12 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       newCyanLayer,
       upstreamLayer,
       monitoringLocationsLayer,
+      surroundingMonitoringLocationsLayer,
       usgsStreamgagesLayer,
+      surroundingUsgsStreamgagesLayer,
       issuesLayer,
       dischargersLayer,
+      surroundingDischargersLayer,
       nonprofitsLayer,
       searchIconLayer,
     ]);
@@ -793,6 +797,9 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     layersInitialized,
     services,
     navigate,
+    surroundingDischargersLayer,
+    surroundingMonitoringLocationsLayer,
+    surroundingUsgsStreamgagesLayer,
     updateErroredLayers,
     updateVisibleLayers,
     usgsStreamgagesLayer,

--- a/app/client/src/components/shared/SurroundingsWidget.tsx
+++ b/app/client/src/components/shared/SurroundingsWidget.tsx
@@ -4,7 +4,7 @@ import { createPortal, render } from 'react-dom';
 // contexts
 import { useLayersState } from 'contexts/Layers';
 import {
-  isBoundariesToggleLayerId,
+  isSurroundingFeaturesLayerId,
   useSurroundingsState,
 } from 'contexts/Surroundings';
 // utils
@@ -14,7 +14,7 @@ import { fonts } from 'styles';
 // types
 import type { LayersState } from 'contexts/Layers';
 import type {
-  BoundariesToggleLayerId,
+  SurroundingFeaturesLayerId,
   SurroundingsState,
 } from 'contexts/Surroundings';
 import type { MutableRefObject, ReactNode } from 'react';
@@ -30,7 +30,7 @@ export function useSurroundingsWidget(triggerVisible: boolean) {
   const includedLayers = useMemo(() => {
     return Object.keys(visibleLayers).reduce<Partial<LayersState['layers']>>(
       (included, key) => {
-        if (layers.hasOwnProperty(key) && isBoundariesToggleLayerId(key)) {
+        if (layers.hasOwnProperty(key) && isSurroundingFeaturesLayerId(key)) {
           return {
             ...included,
             [key]: layers[key],
@@ -93,8 +93,8 @@ function SurroundingsWidget(props: SurroundingsWidgetProps) {
         updating={Object.entries(layersUpdating).some(
           ([id, isUpdating]) =>
             isUpdating === true &&
-            surroundingsVisible[id as BoundariesToggleLayerId] &&
-            !togglesDisabled[id as BoundariesToggleLayerId],
+            surroundingsVisible[id as SurroundingFeaturesLayerId] &&
+            !togglesDisabled[id as SurroundingFeaturesLayerId],
         )}
         visible={triggerVisible}
       />
@@ -115,39 +115,41 @@ function SurroundingsWidgetContent({
         <h1>Surrounding Features:</h1>
         <div>
           <ul>
-            {(Object.keys(toggles) as BoundariesToggleLayerId[]).map((id) => {
-              const layer = layers[id];
-              if (!layer) return null;
-              let title = `Show Surrounding ${layer.title}`;
-              if (togglesDisabled[id]) {
-                title = `Surrounding ${layer.title} Not Available`;
-              } else if (surroundingsVisible[id]) {
-                title = `Hide Surrounding ${layer.title}`;
-              }
-              return (
-                <li key={id}>
-                  <div title={title}>
-                    <div
-                      css={listItemContentStyles(togglesDisabled[id])}
-                      onClick={
-                        togglesDisabled[id]
-                          ? undefined
-                          : toggles[id](!surroundingsVisible[id])
-                      }
-                    >
-                      <span
-                        className={`esri-icon-${
-                          !togglesDisabled[id] && surroundingsVisible[id]
-                            ? ''
-                            : 'non-'
-                        }visible`}
-                      ></span>
-                      <span>{layer.title}</span>
+            {(Object.keys(toggles) as SurroundingFeaturesLayerId[]).map(
+              (id) => {
+                const layer = layers[id];
+                if (!layer) return null;
+                let title = `Show ${layer.title}`;
+                if (togglesDisabled[id]) {
+                  title = `${layer.title} Not Available`;
+                } else if (surroundingsVisible[id]) {
+                  title = `Hide ${layer.title}`;
+                }
+                return (
+                  <li key={id}>
+                    <div title={title}>
+                      <div
+                        css={listItemContentStyles(togglesDisabled[id])}
+                        onClick={
+                          togglesDisabled[id]
+                            ? undefined
+                            : toggles[id](!surroundingsVisible[id])
+                        }
+                      >
+                        <span
+                          className={`esri-icon-${
+                            !togglesDisabled[id] && surroundingsVisible[id]
+                              ? ''
+                              : 'non-'
+                          }visible`}
+                        ></span>
+                        <span>{layer.title.replace('Surrounding ', '')}</span>
+                      </div>
                     </div>
-                  </div>
-                </li>
-              );
-            })}
+                  </li>
+                );
+              },
+            )}
           </ul>
         </div>
       </div>
@@ -311,8 +313,8 @@ type SurroundingsWidgetContentProps = Omit<
 };
 
 type SurroundingsWidgetProps = {
-  layers: Partial<Pick<LayersState['layers'], BoundariesToggleLayerId>>;
-  layersUpdating: Partial<{ [B in BoundariesToggleLayerId]: boolean }>;
+  layers: Partial<Pick<LayersState['layers'], SurroundingFeaturesLayerId>>;
+  layersUpdating: Partial<{ [B in SurroundingFeaturesLayerId]: boolean }>;
   surroundingsVisible: SurroundingsState['visible'];
   toggles: SurroundingsState['togglers'];
   togglesDisabled: SurroundingsState['disabled'];

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -54,7 +54,7 @@ import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
 // helpers
 import {
   useMonitoringLocations,
-  useMonitoringLocationsLayer,
+  useMonitoringLocationsLayers,
   useSharedLayers,
   useWaterbodyHighlight,
 } from 'utils/hooks';
@@ -602,15 +602,16 @@ function TribalMap({
     );
   }, [activeState]);
 
-  const monitoringLocationsLayer = useMonitoringLocationsLayer(
-    monitoringLocationsFilter,
-  );
+  const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
+    useMonitoringLocationsLayers(monitoringLocationsFilter);
 
   const navigate = useNavigate();
   const services = useServicesContext();
   useWaterbodyHighlight();
 
-  const getSharedLayers = useSharedLayers(4622350);
+  const getSharedLayers = useSharedLayers({
+    allWaterbodiesLayer: { minScale: 4622350 },
+  });
   const [layers, setLayers] = useState(null);
 
   // reset the home widget
@@ -623,7 +624,6 @@ function TribalMap({
   const [layersInitialized, setLayersInitialized] = useState(false);
   const [selectedTribeLayer, setSelectedTribeLayer] = useState(null);
   useEffect(() => {
-    if (!monitoringLocationsLayer) return;
     if (!activeState?.attainsId || !getSharedLayers || layersInitialized) {
       return;
     }
@@ -736,6 +736,7 @@ function TribalMap({
       upstreamLayer,
       selectedTribeLayer,
       monitoringLocationsLayer,
+      surroundingMonitoringLocationsLayer,
       waterbodyLayer,
     ]);
 
@@ -755,6 +756,7 @@ function TribalMap({
     services,
     setLayer,
     setResetHandler,
+    surroundingMonitoringLocationsLayer,
     updateVisibleLayers,
   ]);
 

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -609,9 +609,7 @@ function TribalMap({
   const services = useServicesContext();
   useWaterbodyHighlight();
 
-  const getSharedLayers = useSharedLayers({
-    allWaterbodiesLayer: { minScale: 4622350 },
-  });
+  const getSharedLayers = useSharedLayers(4622350);
   const [layers, setLayers] = useState(null);
 
   // reset the home widget

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2507,7 +2507,7 @@ function MonitoringLocationsContent({
       )}
 
       {(!onMonitoringReportPage ||
-        layer.id === 'monitoringLocationsLayer-surrounding') && (
+        layer.id === 'surroundingMonitoringLocationsLayer') && (
         <div css={paddedMarginBoxStyles(textBoxStyles)}>
           <a
             rel="noopener noreferrer"

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -308,7 +308,6 @@ const tabs = [
     upper: <OverviewUpper />,
     lower: <Overview />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
       waterbodyLayer: true,
@@ -321,7 +320,6 @@ const tabs = [
     upper: <SwimmingUpper />,
     lower: <Swimming />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
       waterbodyLayer: true,
@@ -334,7 +332,6 @@ const tabs = [
     upper: <EatingFishUpper />,
     lower: <EatingFish />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
       waterbodyLayer: true,
@@ -347,7 +344,6 @@ const tabs = [
     upper: <AquaticLifeUpper />,
     lower: <AquaticLife />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
       waterbodyLayer: true,
@@ -360,7 +356,6 @@ const tabs = [
     upper: <DrinkingWaterUpper />,
     lower: <DrinkingWater />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: false,
       searchIconLayer: true,
       providersLayer: true,
@@ -373,7 +368,6 @@ const tabs = [
     upper: <MonitoringUpper />,
     lower: <Monitoring />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       cyanLayer: true,
       searchIconLayer: true,
@@ -387,7 +381,6 @@ const tabs = [
     upper: <IdentifiedIssuesUpper />,
     lower: <IdentifiedIssues />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       issuesLayer: true,
       searchIconLayer: true,
@@ -400,7 +393,6 @@ const tabs = [
     upper: <RestoreUpper />,
     lower: <Restore />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
     },
@@ -412,7 +404,6 @@ const tabs = [
     upper: <ProtectUpper />,
     lower: <Protect />,
     layers: {
-      allWaterbodiesLayer: true,
       boundariesLayer: true,
       searchIconLayer: true,
     },

--- a/app/client/src/contexts/FetchedData.tsx
+++ b/app/client/src/contexts/FetchedData.tsx
@@ -102,10 +102,10 @@ function buildNewDataState(action: FetchedDataAction) {
 
 const dataKeys = [
   'monitoringLocations',
-  'permittedDischargers',
+  'dischargers',
   'usgsStreamgages',
   'surroundingMonitoringLocations',
-  'surroundingPermittedDischargers',
+  'surroundingDischargers',
   'surroundingUsgsStreamgages',
 ];
 
@@ -135,10 +135,10 @@ export type FetchState<T> = EmptyFetchState | FetchSuccessState<T>;
 
 export type FetchedData = {
   monitoringLocations: MonitoringLocationAttributes[];
-  permittedDischargers: Facility[];
+  dischargers: Facility[];
   usgsStreamgages: UsgsStreamgageAttributes[];
   surroundingMonitoringLocations: MonitoringLocationAttributes[];
-  surroundingPermittedDischargers: Facility[];
+  surroundingDischargers: Facility[];
   surroundingUsgsStreamgages: UsgsStreamgageAttributes[];
 };
 

--- a/app/client/src/contexts/Layers.tsx
+++ b/app/client/src/contexts/Layers.tsx
@@ -1,4 +1,10 @@
-import { createContext, useCallback, useContext, useReducer } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+} from 'react';
 // types
 import type { Dispatch, ReactNode } from 'react';
 
@@ -14,6 +20,12 @@ function reducer(state: LayersState, action: Action): LayersState {
           ...state.errored,
           ...action.payload,
         },
+      };
+    }
+    case 'initialized': {
+      return {
+        ...state,
+        initialized: action.payload,
       };
     }
     case 'layersMulti': {
@@ -96,6 +108,75 @@ export function useLayers() {
   const state = useLayersState();
   const dispatch = useLayersDispatch();
 
+  // Order of layers for the Community page.
+  // Other pages use a local `layers` state variable.
+  const { layers } = state;
+  const orderedLayers = useMemo(() => {
+    const {
+      actionsWaterbodies,
+      allWaterbodiesLayer,
+      boundariesLayer,
+      congressionalLayer,
+      countyLayer,
+      cyanLayer,
+      dischargersLayer,
+      ejscreenLayer,
+      issuesLayer,
+      landCoverLayer,
+      mappedWaterLayer,
+      monitoringLocationsLayer,
+      nonprofitsLayer,
+      protectedAreasHighlightLayer,
+      protectedAreasLayer,
+      providersLayer,
+      searchIconLayer,
+      selectedTribeLayer,
+      stateBoundariesLayer,
+      surroundingDischargersLayer,
+      surroundingMonitoringLocationsLayer,
+      surroundingUsgsStreamgagesLayer,
+      tribalLayer,
+      upstreamLayer,
+      usgsStreamgagesLayer,
+      waterbodyLayer,
+      watershedsLayer,
+      wildScenicRiversLayer,
+      wsioHealthIndexLayer,
+    } = layers;
+
+    return [
+      ejscreenLayer,
+      wsioHealthIndexLayer,
+      landCoverLayer,
+      protectedAreasLayer,
+      protectedAreasHighlightLayer,
+      wildScenicRiversLayer,
+      tribalLayer,
+      congressionalLayer,
+      stateBoundariesLayer,
+      mappedWaterLayer,
+      countyLayer,
+      watershedsLayer,
+      allWaterbodiesLayer,
+      actionsWaterbodies,
+      selectedTribeLayer,
+      providersLayer,
+      boundariesLayer,
+      waterbodyLayer,
+      issuesLayer,
+      cyanLayer,
+      upstreamLayer,
+      monitoringLocationsLayer,
+      surroundingMonitoringLocationsLayer,
+      usgsStreamgagesLayer,
+      surroundingUsgsStreamgagesLayer,
+      dischargersLayer,
+      surroundingDischargersLayer,
+      nonprofitsLayer,
+      searchIconLayer,
+    ].filter((layer) => layer !== null);
+  }, [layers]);
+
   const { resetters } = state;
   const resetLayers = useCallback(
     (resetVisibility = false) => {
@@ -113,6 +194,13 @@ export function useLayers() {
   const setLayer = useCallback(
     <L extends LayerId>(layerId: L, layer: LayersState['layers'][L]) => {
       dispatch({ type: 'layers', id: layerId, payload: layer });
+    },
+    [dispatch],
+  );
+
+  const setLayersInitialized = useCallback(
+    (isInitialized: boolean) => {
+      dispatch({ type: 'initialized', payload: isInitialized });
     },
     [dispatch],
   );
@@ -149,8 +237,11 @@ export function useLayers() {
   return {
     ...state.layers,
     erroredLayers: state.errored,
+    layersInitialized: state.initialized,
+    orderedLayers,
     resetLayers,
     setLayer,
+    setLayersInitialized,
     setResetHandler,
     updateErroredLayers,
     updateVisibleLayers,
@@ -187,7 +278,6 @@ const featureLayerIds = [
   'countyLayer',
   'congressionalLayer',
   'dischargersLayer',
-  'ejscreenLayer',
   'monitoringLocationsLayer',
   'surroundingDischargersLayer',
   'surroundingMonitoringLocationsLayer',
@@ -215,6 +305,7 @@ const graphicsLayerIds = [
 const groupLayerIds = [
   'allWaterbodiesLayer',
   'cyanLayer',
+  'ejscreenLayer',
   'tribalLayer',
   'waterbodyLayer',
 ] as const;
@@ -242,6 +333,7 @@ const initialState = layerIds.reduce(
         ...state.errored,
         [layerId]: false,
       },
+      initialized: false,
       layers: {
         ...state.layers,
         [layerId]: null,
@@ -272,6 +364,10 @@ type Action =
   | {
       type: 'erroredMulti';
       payload: LayersState['errored'];
+    }
+  | {
+      type: 'initialized';
+      payload: boolean;
     }
   | {
       type: 'layersMulti';
@@ -308,6 +404,7 @@ export type LayersState = {
   errored: {
     [L in LayerId]: boolean;
   };
+  initialized: boolean;
   layers: {
     [F in (typeof featureLayerIds)[number]]: __esri.FeatureLayer | null;
   } & {

--- a/app/client/src/contexts/Layers.tsx
+++ b/app/client/src/contexts/Layers.tsx
@@ -186,7 +186,13 @@ const featureLayerIds = [
   'waterbodyAreas',
   'countyLayer',
   'congressionalLayer',
+  'dischargersLayer',
   'ejscreenLayer',
+  'monitoringLocationsLayer',
+  'surroundingDischargersLayer',
+  'surroundingMonitoringLocationsLayer',
+  'surroundingUsgsStreamgagesLayer',
+  'usgsStreamgagesLayer',
   'waterbodyLines',
   'waterbodyPoints',
   'watershedsLayer',
@@ -209,10 +215,7 @@ const graphicsLayerIds = [
 const groupLayerIds = [
   'allWaterbodiesLayer',
   'cyanLayer',
-  'monitoringLocationsLayer',
-  'dischargersLayer',
   'tribalLayer',
-  'usgsStreamgagesLayer',
   'waterbodyLayer',
 ] as const;
 

--- a/app/client/src/contexts/Surroundings.tsx
+++ b/app/client/src/contexts/Surroundings.tsx
@@ -123,9 +123,9 @@ function initialToggler(_showSurroundings: boolean) {
   return () => {};
 }
 
-export function isBoundariesToggleLayerId(
+export function isSurroundingFeaturesLayerId(
   layerId: string,
-): layerId is BoundariesToggleLayerId {
+): layerId is SurroundingFeaturesLayerId {
   return (layerIds as readonly string[]).includes(layerId);
 }
 
@@ -135,9 +135,9 @@ export function isBoundariesToggleLayerId(
 
 const layerIds = [
   'allWaterbodiesLayer',
-  'monitoringLocationsLayer',
-  'dischargersLayer',
-  'usgsStreamgagesLayer',
+  'surroundingMonitoringLocationsLayer',
+  'surroundingDischargersLayer',
+  'surroundingUsgsStreamgagesLayer',
 ] as const;
 
 const initialState = layerIds.reduce(
@@ -175,44 +175,44 @@ const initialState = layerIds.reduce(
 
 type Action =
   | { type: 'resetAll' }
-  | { type: 'reset'; id: BoundariesToggleLayerId }
+  | { type: 'reset'; id: SurroundingFeaturesLayerId }
   | {
       type: 'togglers';
-      id: BoundariesToggleLayerId;
+      id: SurroundingFeaturesLayerId;
       payload: (showSurroundings: boolean) => MouseEventHandler<HTMLDivElement>;
     }
   | {
       type: 'disabled';
-      id: BoundariesToggleLayerId;
+      id: SurroundingFeaturesLayerId;
       payload: boolean;
     }
   | {
       type: 'updating';
-      id: BoundariesToggleLayerId;
+      id: SurroundingFeaturesLayerId;
       payload: boolean;
     }
   | {
       type: 'visible';
-      id: BoundariesToggleLayerId;
+      id: SurroundingFeaturesLayerId;
       payload: boolean;
     };
 
-export type BoundariesToggleLayerId = (typeof layerIds)[number];
+export type SurroundingFeaturesLayerId = (typeof layerIds)[number];
 
 export type SurroundingsState = {
   togglers: {
-    [B in BoundariesToggleLayerId]: (
+    [B in SurroundingFeaturesLayerId]: (
       showSurroundings: boolean,
     ) => MouseEventHandler<HTMLDivElement>;
   };
   disabled: {
-    [B in BoundariesToggleLayerId]: boolean;
+    [B in SurroundingFeaturesLayerId]: boolean;
   };
   updating: {
-    [B in BoundariesToggleLayerId]: boolean;
+    [B in SurroundingFeaturesLayerId]: boolean;
   };
   visible: {
-    [B in BoundariesToggleLayerId]: boolean;
+    [B in SurroundingFeaturesLayerId]: boolean;
   };
 };
 

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -30,7 +30,6 @@ type State = {
   cipSummary: { status: Status, data: Huc12SummaryData },
   nonprofits: Object,
   mapView: __esri.MapView | null,
-  layers: Object[],
   basemap: Object,
   homeWidget: Object,
   upstreamWidget: Object,
@@ -96,7 +95,6 @@ export class LocationSearchProvider extends Component<Props, State> {
     cipSummary: { status: 'fetching', data: {} },
     nonprofits: { status: 'fetching', data: [] },
     mapView: null,
-    layers: [],
     homeWidget: null,
     upstreamWidget: null,
     upstreamWidgetDisabled: false,
@@ -214,9 +212,6 @@ export class LocationSearchProvider extends Component<Props, State> {
     getUpstreamExtent: () => {
       return this.state.upstreamExtent;
     },
-    setLayers: (layers) => {
-      this.setState({ layers });
-    },
     setUpstreamWatershedResponse: (upstreamWatershedResponse) => {
       this.setState({ upstreamWatershedResponse });
     },
@@ -313,31 +308,7 @@ export class LocationSearchProvider extends Component<Props, State> {
     },
 
     resetMap: (useDefaultZoom = false) => {
-      const { initialExtent, layers, mapView, homeWidget } = this.state;
-
-      // Clear waterbody layers from state
-      let newState = {};
-
-      const layersToRemove = [
-        'waterbodyPoints',
-        'waterbodyLines',
-        'waterbodyAreas',
-        'waterbodyLayer',
-      ];
-
-      // remove the layers from state layers list
-      let removedLayers = false;
-      for (let i = layers.length - 1; i >= 0; i--) {
-        const item = layers[i];
-        const itemId = item.id;
-        if (layersToRemove.includes(itemId)) {
-          layers.splice(i, 1);
-          removedLayers = true;
-        }
-      }
-      if (removedLayers) newState['layers'] = layers;
-
-      this.setState(newState);
+      const { initialExtent, mapView, homeWidget } = this.state;
 
       // reset the zoom and home widget to the initial extent
       if (useDefaultZoom && mapView) {

--- a/app/client/src/types/arcgis.d.ts
+++ b/app/client/src/types/arcgis.d.ts
@@ -1,11 +1,26 @@
 declare namespace __esri {
   interface FeatureLayer {
+    addHandles(
+      handleOrHandles: __esri.WatchHandle | __esri.WatchHandle[],
+      groupKey: any,
+    ): void;
     featureReduction:
       | __esri.FeatureReductionBinning
       | __esri.FeatureReductionCluster
       | __esri.FeatureReductionSelection
       | null;
     globalIdField: string | null;
+    hasHandles(groupKey?: any): boolean;
+    removeHandles(groupKey?: any): void;
+  }
+
+  interface GraphicsLayer {
+    addHandles(
+      handleOrHandles: __esri.WatchHandle | __esri.WatchHandle[],
+      groupKey: any,
+    ): void;
+    hasHandles(groupKey?: any): boolean;
+    removeHandles(groupKey?: any): void;
   }
 
   interface GroupLayer {

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -686,16 +686,6 @@ async function applyEdits({
         ) as __esri.FeatureLayer;
 
         if (subLayer) await processLayerFeatures(subLayer, adds);
-      } else if (
-        [
-          'dischargersLayer',
-          'monitoringLocationsLayer',
-          'usgsStreamgagesLayer',
-        ].includes(layer.id)
-      ) {
-        const groupLayer = layer.layer as __esri.GroupLayer;
-        const enclosedLayer = groupLayer.findLayerById(`${layer.id}-enclosed`);
-        await processLayerFeatures(enclosedLayer, adds);
       } else if (layer.widgetLayer?.type === 'file') {
         adds = layer.widgetLayer.rawLayer.featureSet.features;
       } else {

--- a/app/client/src/utils/hooks/allWaterbodies.ts
+++ b/app/client/src/utils/hooks/allWaterbodies.ts
@@ -8,7 +8,10 @@ import {
   useSurroundingsState,
 } from 'contexts/Surroundings';
 
-export function useAllWaterbodiesLayer(minScale = 577791) {
+export function useAllWaterbodiesLayer(
+  initialVisible = false,
+  minScale = 577791,
+) {
   const { mapView } = useContext(LocationSearchContext);
   const { disabled, updating } = useSurroundingsState();
   const { allWaterbodiesLayer, updateVisibleLayers, visibleLayers } =
@@ -24,6 +27,11 @@ export function useAllWaterbodiesLayer(minScale = 577791) {
       (layer as __esri.FeatureLayer).minScale = minScale;
     });
   }, [minScale, allWaterbodiesLayer]);
+
+  // Externally control initial layer visibility
+  useEffect(() => {
+    updateVisibleLayers({ [layerId]: initialVisible });
+  }, [initialVisible, surroundingsDispatch, updateVisibleLayers]);
 
   // Synchronize layer visibility in widget with actual layer visibility
   useEffect(() => {

--- a/app/client/src/utils/hooks/allWaterbodies.ts
+++ b/app/client/src/utils/hooks/allWaterbodies.ts
@@ -8,11 +8,8 @@ import {
   useSurroundingsState,
 } from 'contexts/Surroundings';
 
-export function useAllWaterbodiesLayer(
-  initialVisible = false,
-  minScale = 577791,
-) {
-  const { mapView } = useContext(LocationSearchContext);
+export function useAllWaterbodiesLayer(minScale = 577791) {
+  const { huc12, mapView } = useContext(LocationSearchContext);
   const { disabled, updating } = useSurroundingsState();
   const { allWaterbodiesLayer, updateVisibleLayers, visibleLayers } =
     useLayers();
@@ -28,10 +25,11 @@ export function useAllWaterbodiesLayer(
     });
   }, [minScale, allWaterbodiesLayer]);
 
-  // Externally control initial layer visibility
+  // Show the layer when a HUC is searched
   useEffect(() => {
-    updateVisibleLayers({ [layerId]: initialVisible });
-  }, [initialVisible, surroundingsDispatch, updateVisibleLayers]);
+    if (!huc12) return;
+    updateVisibleLayers({ [layerId]: true });
+  }, [huc12, surroundingsDispatch, updateVisibleLayers]);
 
   // Synchronize layer visibility in widget with actual layer visibility
   useEffect(() => {

--- a/app/client/src/utils/hooks/boundariesToggleLayer.ts
+++ b/app/client/src/utils/hooks/boundariesToggleLayer.ts
@@ -345,13 +345,6 @@ export function filterData<T>(
   });
 }
 
-export function removeDuplicateData<T>(data: T[], keys: Array<keyof T>) {
-  return data.reduce<T[]>((unique, next) => {
-    if (unique.find((datum) => matchKeys(datum, next, keys))) return unique;
-    return [...unique, next];
-  }, []);
-}
-
 async function updateFeatureLayer(
   layer: __esri.FeatureLayer | null,
   features?: __esri.Graphic[] | null,

--- a/app/client/src/utils/hooks/boundariesToggleLayer.ts
+++ b/app/client/src/utils/hooks/boundariesToggleLayer.ts
@@ -45,10 +45,10 @@ export function useLocalData<E extends keyof FetchedDataState>(
   return localData;
 }
 
-export function useAllFeaturesLayer<
+export function useAllFeaturesLayers<
   E extends keyof FetchedDataState,
   S extends keyof FetchedDataState,
->(args: UseAllFeaturesLayerParams<E, S>) {
+>(args: UseAllFeaturesLayersParams<E, S>) {
   return useBoundariesToggleLayer({
     ...args,
     updateLayer: updateFeatureLayer,
@@ -266,15 +266,6 @@ function useBoundariesToggleLayer<
 ## Utils
 */
 
-export function getEnclosedLayer(
-  parentLayer: __esri.GroupLayer | null,
-): __esri.FeatureLayer | null {
-  if (!parentLayer) return null;
-  return parentLayer.findLayerById(
-    `${parentLayer.id}-enclosed`,
-  ) as __esri.FeatureLayer;
-}
-
 function getExtentArea(extent: __esri.Extent) {
   return (
     Math.abs(extent.xmax - extent.xmin) * Math.abs(extent.ymax - extent.ymin)
@@ -310,17 +301,6 @@ export async function getGeographicExtent(mapView: __esri.MapView | '') {
   return webMercatorUtils.webMercatorToGeographic(
     extentMercator,
   ) as __esri.Extent;
-}
-
-export function getSurroundingLayer(
-  parentLayer: __esri.GroupLayer | null,
-): __esri.FeatureLayer | null {
-  if (!parentLayer) return null;
-  return (
-    (parentLayer.findLayerById(
-      `${parentLayer.id}-surrounding`,
-    ) as __esri.FeatureLayer) ?? null
-  );
 }
 
 export function handleFetchError(err: unknown): EmptyFetchState {
@@ -388,7 +368,7 @@ type UseBoundariesToggleLayerParams<
   updateLayer: (layer: T | null, features?: __esri.Graphic[]) => Promise<void>;
 };
 
-type UseAllFeaturesLayerParams<
+type UseAllFeaturesLayersParams<
   E extends keyof FetchedDataState,
   S extends keyof FetchedDataState,
 > = Omit<

--- a/app/client/src/utils/hooks/dischargers.ts
+++ b/app/client/src/utils/hooks/dischargers.ts
@@ -15,7 +15,7 @@ import {
   getGeographicExtent,
   filterData,
   handleFetchError,
-  useAllFeaturesLayer,
+  useAllFeaturesLayers,
   useLocalData,
 } from 'utils/hooks/boundariesToggleLayer';
 import { getPopupContent, getPopupTitle } from 'utils/mapFunctions';
@@ -53,7 +53,7 @@ export function useDischargersLayers() {
   const updateSurroundingData = useUpdateData();
 
   // Build a group layer with toggleable boundaries
-  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayer({
+  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayers({
     buildBaseLayer,
     buildFeatures,
     enclosedFetchedDataKey: localFetchedDataKey,

--- a/app/client/src/utils/hooks/dischargers.ts
+++ b/app/client/src/utils/hooks/dischargers.ts
@@ -38,14 +38,14 @@ import { colors } from 'styles';
 ## Hooks
 */
 
-export function useDischargersLayer() {
+export function useDischargersLayers() {
   // Build the base feature layer
   const services = useServicesContext();
   const navigate = useNavigate();
 
   const buildBaseLayer = useCallback(
-    (baseLayerId: string, type: SublayerType) => {
-      return buildLayer(baseLayerId, navigate, services, type);
+    (type: SublayerType) => {
+      return buildLayer(navigate, services, type);
     },
     [navigate, services],
   );
@@ -53,14 +53,18 @@ export function useDischargersLayer() {
   const updateSurroundingData = useUpdateData();
 
   // Build a group layer with toggleable boundaries
-  return useAllFeaturesLayer({
-    layerId,
+  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayer({
     buildBaseLayer,
     buildFeatures,
     enclosedFetchedDataKey: localFetchedDataKey,
     surroundingFetchedDataKey,
     updateSurroundingData,
   });
+
+  return {
+    dischargersLayer: enclosedLayer,
+    surroundingDischargersLayer: surroundingLayer,
+  };
 }
 
 export function useDischargers() {
@@ -169,15 +173,17 @@ function buildFeatures(data: Facility[]) {
 
 // Builds the base feature layer
 function buildLayer(
-  baseLayerId: string,
   navigate: NavigateFunction,
   services: ServicesState,
   type: SublayerType,
 ) {
   return new FeatureLayer({
-    id: baseLayerId,
-    title: 'Dischargers',
-    listMode: 'hide',
+    id:
+      type === 'enclosed'
+        ? `${localFetchedDataKey}Layer`
+        : `${surroundingFetchedDataKey}Layer`,
+    title: `${type === 'surrounding' ? 'Surrounding ' : ''}Dischargers`,
+    listMode: type === 'enclosed' ? 'show' : 'hide',
     legendEnabled: false,
     fields: [
       { name: 'OBJECTID', type: 'oid' },
@@ -233,7 +239,7 @@ function buildLayer(
 async function fetchAndTransformData(
   promise: ReturnType<typeof fetchPermittedDischargers>,
   dispatch: Dispatch<FetchedDataAction>,
-  fetchedDataId: 'permittedDischargers' | 'surroundingPermittedDischargers',
+  fetchedDataId: 'dischargers' | 'surroundingDischargers',
   dataToExclude?: Facility[] | null,
   violatingOnly = false,
 ) {
@@ -340,9 +346,8 @@ async function getExtentFilter(mapView: __esri.MapView | '') {
 ## Constants
 */
 
-const localFetchedDataKey = 'permittedDischargers';
-const surroundingFetchedDataKey = 'surroundingPermittedDischargers';
-const layerId = 'dischargersLayer';
+const localFetchedDataKey = 'dischargers';
+const surroundingFetchedDataKey = 'surroundingDischargers';
 const dataKeys = ['SourceID'] as Array<keyof Facility>;
 
 /*

--- a/app/client/src/utils/hooks/index.ts
+++ b/app/client/src/utils/hooks/index.ts
@@ -27,9 +27,7 @@ import { useLayers } from 'contexts/Layers';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useMapHighlightState } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
-import { isBoundariesToggleLayerId } from 'contexts/Surroundings';
 // utilities
-import { getEnclosedLayer } from './boundariesToggleLayer';
 import { useAllWaterbodiesLayer } from './allWaterbodies';
 import {
   createWaterbodySymbol,
@@ -596,10 +594,6 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
 
     if (!layer) return;
 
-    if (isBoundariesToggleLayerId(layer.id)) {
-      layer = getEnclosedLayer(layer);
-    }
-
     const parent = (graphic.layer as ExtendedLayer)?.parent;
     if (parent && 'id' in parent && parent.id === 'allWaterbodiesLayer') return;
 
@@ -886,7 +880,9 @@ function useDynamicPopup() {
   return { getTitle, getTemplate, setDynamicPopupFields };
 }
 
-function useSharedLayers(allWaterbodiesMinScale?: number) {
+function useSharedLayers(overrides?: {
+  [layerId: string]: { visible?: boolean; minScale?: number };
+}) {
   const services = useServicesContext();
   const { setLayer, setResetHandler } = useLayers();
 
@@ -1533,7 +1529,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
     // Make the waterbody layer into a single layer
     const allWaterbodiesLayer = new GroupLayer({
       id: 'allWaterbodiesLayer',
-      title: 'All Waterbodies',
+      title: 'Surrounding Waterbodies',
       listMode: 'hide',
       visible: false,
       minScale,
@@ -1549,7 +1545,10 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
     return allWaterbodiesLayer;
   }
 
-  useAllWaterbodiesLayer(allWaterbodiesMinScale);
+  useAllWaterbodiesLayer(
+    overrides?.allWaterbodiesLayer?.visible,
+    overrides?.allWaterbodiesLayer?.minScale,
+  );
 
   function getLandCoverLayer() {
     return new WMSLayer({

--- a/app/client/src/utils/hooks/index.ts
+++ b/app/client/src/utils/hooks/index.ts
@@ -880,9 +880,7 @@ function useDynamicPopup() {
   return { getTitle, getTemplate, setDynamicPopupFields };
 }
 
-function useSharedLayers(overrides?: {
-  [layerId: string]: { visible?: boolean; minScale?: number };
-}) {
+function useSharedLayers(allWaterbodiesMinScale?: number) {
   const services = useServicesContext();
   const { setLayer, setResetHandler } = useLayers();
 
@@ -1529,7 +1527,7 @@ function useSharedLayers(overrides?: {
     // Make the waterbody layer into a single layer
     const allWaterbodiesLayer = new GroupLayer({
       id: 'allWaterbodiesLayer',
-      title: 'Surrounding Waterbodies',
+      title: 'All Waterbodies',
       listMode: 'hide',
       visible: false,
       minScale,
@@ -1545,10 +1543,7 @@ function useSharedLayers(overrides?: {
     return allWaterbodiesLayer;
   }
 
-  useAllWaterbodiesLayer(
-    overrides?.allWaterbodiesLayer?.visible,
-    overrides?.allWaterbodiesLayer?.minScale,
-  );
+  useAllWaterbodiesLayer(allWaterbodiesMinScale);
 
   function getLandCoverLayer() {
     return new WMSLayer({

--- a/app/client/src/utils/hooks/index.ts
+++ b/app/client/src/utils/hooks/index.ts
@@ -1227,7 +1227,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       },
     });
 
-    return new GroupLayer({
+    const tribalLayer = new GroupLayer({
       id: 'tribalLayer',
       title: 'Tribal Areas',
       listMode: 'show',
@@ -1240,6 +1240,8 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
         otherTribes,
       ],
     });
+    setLayer('tribalLayer', tribalLayer);
+    return tribalLayer;
   }
 
   function getCongressionalLayer() {
@@ -1254,7 +1256,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       'SQMI',
     ];
 
-    return new FeatureLayer({
+    const congressionalLayer = new FeatureLayer({
       id: 'congressionalLayer',
       url: services.data.congressional,
       title: 'Congressional Districts',
@@ -1278,10 +1280,12 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
         outFields: congressionalLayerOutFields,
       },
     });
+    setLayer('congressionalLayer', congressionalLayer);
+    return congressionalLayer;
   }
 
   function getMappedWaterLayer() {
-    return new MapImageLayer({
+    const mappedWaterLayer = new MapImageLayer({
       id: 'mappedWaterLayer',
       // sublayers have minScale of 288896,
       // but this doesn't match the actual behavior
@@ -1293,11 +1297,13 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       listMode: 'hide-children',
       visible: false,
     });
+    setLayer('mappedWaterLayer', mappedWaterLayer);
+    return mappedWaterLayer;
   }
 
   function getCountyLayer() {
     const countyLayerOutFields = ['NAME', 'CNTY_FIPS', 'STATE_NAME'];
-    return new FeatureLayer({
+    const countyLayer = new FeatureLayer({
       id: 'countyLayer',
       url: services.data.counties,
       title: 'County',
@@ -1321,10 +1327,12 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
         outFields: countyLayerOutFields,
       },
     });
+    setLayer('countyLayer', countyLayer);
+    return countyLayer;
   }
 
   function getStateBoundariesLayer() {
-    return new MapImageLayer({
+    const stateBoundariesLayer = new MapImageLayer({
       id: 'stateBoundariesLayer',
       url: services.data.stateBoundaries,
       title: 'State',
@@ -1333,10 +1341,12 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       visible: false,
       legendEnabled: false,
     });
+    setLayer('stateBoundariesLayer', stateBoundariesLayer);
+    return stateBoundariesLayer;
   }
 
   function getWatershedsLayer() {
-    return new FeatureLayer({
+    const watershedsLayer = new FeatureLayer({
       id: 'watershedsLayer',
       url: services.data.wbd,
       title: 'Watersheds',
@@ -1344,6 +1354,8 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       visible: false,
       outFields: ['*'],
     });
+    setLayer('watershedsLayer', watershedsLayer);
+    return watershedsLayer;
   }
 
   function getEjscreen() {
@@ -1433,7 +1445,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       popupTemplate: ejscreenPopupTemplate,
     });
 
-    return new GroupLayer({
+    const ejscreenLayer = new GroupLayer({
       id: 'ejscreenLayer',
       title: 'Demographic Indicators',
       listMode: 'show',
@@ -1449,6 +1461,8 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       ],
       minScale: 577791,
     });
+    setLayer('ejscreenLayer', ejscreenLayer);
+    return ejscreenLayer;
   }
 
   function getAllWaterbodiesLayer() {
@@ -1539,14 +1553,13 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       waterbodyPoints,
     ]);
     setLayer('allWaterbodiesLayer', allWaterbodiesLayer);
-
     return allWaterbodiesLayer;
   }
 
   useAllWaterbodiesLayer(allWaterbodiesMinScale);
 
   function getLandCoverLayer() {
-    return new WMSLayer({
+    const landCoverLayer = new WMSLayer({
       id: 'landCoverLayer',
       legendEnabled: true,
       listMode: 'hide-children',
@@ -1554,6 +1567,8 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       visible: false,
       url: services.data.landCover,
     });
+    setLayer('landCoverLayer', landCoverLayer);
+    return landCoverLayer;
   }
 
   // Gets the settings for the WSIO Health Index layer.

--- a/app/client/src/utils/hooks/monitoringLocations.tsx
+++ b/app/client/src/utils/hooks/monitoringLocations.tsx
@@ -21,7 +21,7 @@ import {
   getExtentBoundingBox,
   getGeographicExtent,
   handleFetchError,
-  useAllFeaturesLayer,
+  useAllFeaturesLayers,
   useLocalData,
 } from 'utils/hooks/boundariesToggleLayer';
 import {
@@ -68,7 +68,7 @@ export function useMonitoringLocationsLayers(
   const updateSurroundingData = useUpdateData(localFilter);
 
   // Build a group layer with toggleable boundaries
-  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayer({
+  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayers({
     buildBaseLayer,
     buildFeatures,
     enclosedFetchedDataKey: localFetchedDataKey,

--- a/app/client/src/utils/hooks/streamgages.ts
+++ b/app/client/src/utils/hooks/streamgages.ts
@@ -16,7 +16,7 @@ import {
   getExtentBoundingBox,
   getGeographicExtent,
   handleFetchError,
-  useAllFeaturesLayer,
+  useAllFeaturesLayers,
   useLocalData,
 } from 'utils/hooks/boundariesToggleLayer';
 import { getPopupContent, getPopupTitle } from 'utils/mapFunctions';
@@ -59,7 +59,7 @@ export function useStreamgageLayers() {
   const updateSurroundingData = useUpdateData();
 
   // Build a group layer with toggleable boundaries
-  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayer({
+  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayers({
     buildFeatures,
     enclosedFetchedDataKey: localFetchedDataKey,
     buildBaseLayer,

--- a/app/client/src/utils/hooks/streamgages.ts
+++ b/app/client/src/utils/hooks/streamgages.ts
@@ -44,14 +44,14 @@ import { colors } from 'styles';
 ## Hooks
 */
 
-export function useStreamgageLayer() {
+export function useStreamgageLayers() {
   // Build the base feature layer
   const services = useServicesContext();
   const navigate = useNavigate();
 
   const buildBaseLayer = useCallback(
-    (baseLayerId: string, type: SublayerType) => {
-      return buildLayer(baseLayerId, navigate, services, type);
+    (type: SublayerType) => {
+      return buildLayer(navigate, services, type);
     },
     [navigate, services],
   );
@@ -59,14 +59,18 @@ export function useStreamgageLayer() {
   const updateSurroundingData = useUpdateData();
 
   // Build a group layer with toggleable boundaries
-  return useAllFeaturesLayer({
+  const { enclosedLayer, surroundingLayer } = useAllFeaturesLayer({
     buildFeatures,
     enclosedFetchedDataKey: localFetchedDataKey,
-    layerId,
     buildBaseLayer,
     surroundingFetchedDataKey,
     updateSurroundingData,
   });
+
+  return {
+    usgsStreamgagesLayer: enclosedLayer,
+    surroundingUsgsStreamgagesLayer: surroundingLayer,
+  };
 }
 
 export function useStreamgages() {
@@ -191,15 +195,17 @@ function buildFeatures(data: UsgsStreamgageAttributes[]) {
 
 // Builds the base feature layer
 function buildLayer(
-  baseLayerId: string,
   navigate: NavigateFunction,
   services: ServicesState,
   type: SublayerType,
 ) {
   return new FeatureLayer({
-    id: baseLayerId,
-    title: 'USGS Sensors',
-    listMode: 'hide',
+    id:
+      type === 'enclosed'
+        ? `${localFetchedDataKey}Layer`
+        : `${surroundingFetchedDataKey}Layer`,
+    title: `${type === 'surrounding' ? 'Surrounding ' : ''}USGS Sensors`,
+    listMode: type === 'enclosed' ? 'show' : 'hide',
     legendEnabled: false,
     fields: [
       { name: 'OBJECTID', type: 'oid' },
@@ -565,7 +571,6 @@ function getExtentWkt(extent: __esri.Extent | null) {
 
 const localFetchedDataKey = 'usgsStreamgages';
 const surroundingFetchedDataKey = 'surroundingUsgsStreamgages';
-const layerId = 'usgsStreamgagesLayer';
 const dataKeys = ['orgId', 'siteId'] as Array<keyof UsgsStreamgageAttributes>;
 
 /*

--- a/app/client/src/utils/hooks/streamgages.ts
+++ b/app/client/src/utils/hooks/streamgages.ts
@@ -12,10 +12,10 @@ import { useServicesContext } from 'contexts/LookupFiles';
 // utils
 import { fetchCheck } from 'utils/fetchUtils';
 import {
+  filterData,
   getExtentBoundingBox,
   getGeographicExtent,
   handleFetchError,
-  removeDuplicateData,
   useAllFeaturesLayer,
   useLocalData,
 } from 'utils/hooks/boundariesToggleLayer';
@@ -271,10 +271,7 @@ async function fetchAndTransformData(
       ...(responses.map((res) => res.data) as UsgsServiceData),
     );
     const payload = additionalData
-      ? removeDuplicateData(
-          [...usgsStreamgageAttributes, ...additionalData],
-          dataKeys,
-        )
+      ? filterData(usgsStreamgageAttributes, additionalData, dataKeys)
       : usgsStreamgageAttributes;
     dispatch({
       type: 'success',


### PR DESCRIPTION
## Related Issues:
* [HMW-452](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-452)

## Main Changes:
* Pulled the HUC and surrounding features layers out from their parent Group layers.
* Stopped linking surrounding feature layer visibility with HUC layer visibility.
  * Additionally, surrounding layers maintain their visibility between tabs, rather than match the visibility of their corresponding layers in the layer list.
* Switched to creating the `layers` object passed to the map from the layers in the Layers context. This was done to address an issue with surrounding layers when switching to a fullscreen map on the _Community_ page, and to further ensure that the `layers` object is always up to date.

## Steps To Test:
1. Test toggling on various layers in the layer list and surrounding features widget, and confirm they operate independently.
2. On the _Community_ page, toggle on a surrounding features layer, then switch tabs. Confirm the layer is still visible.
3. On all pages, toggle on a surrounding features layer, then activate the fullscreen map widget. Confirm the surrounding layer still updates as the map is panned.
4. Save the map with the "Add & Save Data Widget", and confirm that surrounding feature layers (except for the `allWaterbodiesLayer`) are excluded from the hosted feature service and web map.
