### PR TITLE
Updated a variable name that was missed in the last merge

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1196,7 +1196,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   min={minYear}
                   disabled={!Boolean(Object.keys(annualData).length)}
                   onChange={handleDateSliderChange}
-                  range={yearsRange}
+                  range={monitoringYearsRange}
                 />
               )}
             </div>


### PR DESCRIPTION
## Related Issues:
* [HMW-445](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-445)

## Main Changes:
* Updated the `yearsRange` variable used in the DateSlider component on the _Monitoring_ tab to `monitoringYearsRange`. The prop in question was recently added, and the changes weren't yet merged into the branch of #819.

## Steps to Test:
1. Confirm the branch compiles and passes all the tests of #819.
