### PR TITLE
Feature/464 check accessibility

### DIFF
--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -516,7 +516,7 @@ function CommunityTabs() {
 
         <header css={tabHeaderStyles}>
           <div>
-            <img src={tabs[activeTabIndex].icon} alt="" />
+            <img aria-hidden="true" src={tabs[activeTabIndex].icon} alt="" />
             <h1 css={tabTitleStyles}>{tabs[activeTabIndex].title}</h1>
           </div>
 

--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -516,10 +516,7 @@ function CommunityTabs() {
 
         <header css={tabHeaderStyles}>
           <div>
-            <img
-              src={tabs[activeTabIndex].icon}
-              alt={tabs[activeTabIndex].title}
-            />
+            <img src={tabs[activeTabIndex].icon} alt="" />
             <h1 css={tabTitleStyles}>{tabs[activeTabIndex].title}</h1>
           </div>
 

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -638,17 +638,6 @@ function handleCheckbox(id, accessor, dispatch) {
   };
 }
 
-const lineColors = {
-  Bacterial: '#03a66a',
-  Metals: '#526571',
-  Nutrients: '#00de04',
-  Other: '#38a6ee',
-  Pesticides: '#400587',
-  PFAS: '#eb4034',
-  Physical: '#ad9e71',
-  Sediments: '#9c7803',
-};
-
 function loadNewData(data, state) {
   const newCharcs = {};
   const newGroups = {};
@@ -1221,7 +1210,6 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
             </div>
             <ChartContainer
               range={range}
-              charcName={charcName}
               data={chartData}
               scaleType={scaleType}
               dataKeys={dataKeys}
@@ -1396,19 +1384,7 @@ function CharacteristicsTableSection({
   );
 }
 
-function ChartContainer({
-  range,
-  data,
-  charcName,
-  dataKeys,
-  scaleType,
-  yTitle,
-  unit,
-}) {
-  const charcLabel = getCharcLabel(
-    getCharcGroup(charcName, characteristicsByGroup),
-    characteristicGroupMappings,
-  );
+function ChartContainer({ range, data, dataKeys, scaleType, yTitle, unit }) {
   const chartRef = useRef(null);
 
   if (!data?.length)
@@ -1431,7 +1407,7 @@ function ChartContainer({
     <div ref={chartRef} css={chartContainerStyles}>
       <ScatterPlot
         buildTooltip={buildTooltip(unit)}
-        color={lineColors[charcLabel]}
+        color="#38a6ee"
         containerRef={chartRef.current}
         data={data}
         dataKeys={dataKeys}

--- a/app/client/src/components/shared/MapLegend.js
+++ b/app/client/src/components/shared/MapLegend.js
@@ -107,9 +107,28 @@ function MapLegend({
   visibleLayers,
   additionalLegendInfo,
 }: Props) {
-  const filteredVisibleLayers = visibleLayers.filter(
-    (layer) => !ignoreLayers.includes(layer.id) && isInScale(layer, view.scale),
-  );
+  const filteredVisibleLayers = visibleLayers.filter((layer) => {
+    if (ignoreLayers.includes(layer.id)) return false;
+    if (!isInScale(layer, view.scale)) return false;
+
+    // Filter out duplicate surrounding layers.
+    if (
+      layer.id === 'allWaterbodiesLayer' &&
+      visibleLayers.find((l) => l.id === 'waterbodyLayer')
+    )
+      return false;
+    if (
+      layer.id === 'surroundingUsgsStreamgagesLayer' &&
+      visibleLayers.find((l) => l.id === 'usgsStreamgagesLayer')
+    )
+      return false;
+    if (
+      layer.id === 'surroundingDischargersLayer' &&
+      visibleLayers.find((l) => l.id === 'dischargersLayer')
+    )
+      return false;
+    return true;
+  });
 
   // no legend data
   if (filteredVisibleLayers.length === 0 && !displayEsriLegend) {
@@ -120,30 +139,17 @@ function MapLegend({
     );
   }
 
-  let waterbodyLayerAdded = false;
-
   return (
     <div css={containerStyles}>
       <ul css={listStyles}>
-        {filteredVisibleLayers.map((layer, index) => {
-          if (
-            layer.visible &&
-            (layer.id === 'waterbodyLayer' ||
-              layer.id === 'allWaterbodiesLayer')
-          ) {
-            if (waterbodyLayerAdded) return null;
-            waterbodyLayerAdded = true;
-          }
-
-          return (
-            <MapLegendContent
-              key={layer.id}
-              view={view}
-              layer={layer}
-              additionalLegendInfo={additionalLegendInfo}
-            />
-          );
-        })}
+        {filteredVisibleLayers.map((layer) => (
+          <MapLegendContent
+            key={layer.id}
+            view={view}
+            layer={layer}
+            additionalLegendInfo={additionalLegendInfo}
+          />
+        ))}
       </ul>
     </div>
   );
@@ -868,8 +874,16 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
     return isRestoreProtect ? actionsWaterbodiesLegend : waterbodyLegend;
   }
   if (layer.id === 'issuesLayer') return issuesLegend;
-  if (layer.id === 'usgsStreamgagesLayer') return usgsStreamgagesLegend;
-  if (layer.id === 'dischargersLayer') return dischargersLegend;
+  if (
+    layer.id === 'usgsStreamgagesLayer' ||
+    layer.id === 'surroundingUsgsStreamgagesLayer'
+  )
+    return usgsStreamgagesLegend;
+  if (
+    layer.id === 'dischargersLayer' ||
+    layer.id === 'surroundingDischargersLayer'
+  )
+    return dischargersLegend;
   if (layer.id === 'nonprofitsLayer') return nonprofitsLegend;
   if (layer.id === 'providersLayer') return providersLegend;
   if (layer.id === 'boundariesLayer') return boundariesLegend;

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -44,7 +44,7 @@ import {
   isPolygon,
   shallowCompare,
 } from 'utils/mapFunctions';
-import { isAbort } from 'utils/utils';
+import { isAbort, isClick } from 'utils/utils';
 // helpers
 import { useAbortSignal, useDynamicPopup } from 'utils/hooks';
 // icons
@@ -598,6 +598,7 @@ function MapWidgets({
     view.ui.add({
       component: surroundingsWidget,
       position: 'top-right',
+      index: 1,
     });
 
     return function cleanup() {
@@ -605,61 +606,68 @@ function MapWidgets({
     };
   }, [surroundingsWidget, view]);
 
-  // Creates and adds the legend widget to the map
+  // Creates and adds the add/save data widget to the map
   const rnd = useRef<Rnd | null>(null);
+
+  // Ensures the add data widget stays within the map div
+  const width = useRef(window.innerWidth);
+  const handleResize = useCallback(() => {
+    const difference = width.current - window.innerWidth;
+    width.current = window.innerWidth;
+    if (difference < 0 || !rnd?.current) return;
+
+    let mapRect = document
+      .getElementById('hmw-map-container')
+      ?.getBoundingClientRect();
+    let awdRect = document
+      .getElementById('add-save-data-widget')
+      ?.getBoundingClientRect();
+
+    if (!mapRect || !awdRect) return;
+
+    const maxLeft = mapRect.width - awdRect.width;
+    const curLeft = awdRect.left - mapRect.left;
+
+    // update the position of the add save data widget
+    const newPosition =
+      curLeft > maxLeft
+        ? maxLeft
+        : awdRect.left - mapRect.left - difference / 2;
+    rnd.current.updatePosition({
+      x: newPosition < 0 ? 0 : newPosition,
+      y: rnd.current.draggable.state.y,
+    });
+  }, []);
+
   const [addSaveDataWidget, setAddSaveDataWidget] =
     useState<HTMLDivElement | null>(null);
   useEffect(() => {
-    if (!view?.ui || addSaveDataWidget) return;
+    if (!view?.ui) return;
 
     const node = document.createElement('div');
-    view.ui.add(node, { position: 'top-right', index: 1 });
+    view.ui.add(node, { position: 'top-right', index: 2 });
 
     render(
       <ShowAddSaveDataWidget
-        setAddSaveDataWidgetVisibleParam={setAddSaveDataWidgetVisible}
+        addSaveDataWidgetVisible={addSaveDataWidgetVisible}
+        setAddSaveDataWidgetVisible={setAddSaveDataWidgetVisible}
       />,
       node,
     );
 
-    // Ensures the add data widget stays within the map div
-    let width = window.innerWidth;
-    function handleResize() {
-      const difference = width - window.innerWidth;
-      width = window.innerWidth;
-      if (difference < 0 || !rnd?.current) return;
-
-      let mapRect = document
-        .getElementById('hmw-map-container')
-        ?.getBoundingClientRect();
-      let awdRect = document
-        .getElementById('add-save-data-widget')
-        ?.getBoundingClientRect();
-
-      if (!mapRect || !awdRect) return;
-
-      const maxLeft = mapRect.width - awdRect.width;
-      const curLeft = awdRect.left - mapRect.left;
-
-      // update the position of the add save data widget
-      const newPosition =
-        curLeft > maxLeft
-          ? maxLeft
-          : awdRect.left - mapRect.left - difference / 2;
-      rnd.current.updatePosition({
-        x: newPosition < 0 ? 0 : newPosition,
-        y: rnd.current.draggable.state.y,
-      });
-    }
-
     window.addEventListener('resize', handleResize);
 
     setAddSaveDataWidget(node);
+
+    return function cleanup() {
+      view?.ui.remove(node);
+      window.removeEventListener('resize', handleResize);
+    };
   }, [
     view,
-    addSaveDataWidget,
     addSaveDataWidgetVisible,
     setAddSaveDataWidgetVisible,
+    handleResize,
   ]);
 
   // Fetch additional legend information. Data is stored in a dictionary
@@ -989,7 +997,7 @@ function MapWidgets({
 
     render(widget, node);
     setUpstreamWidget(node); // store the widget in context so it can be shown or hidden later
-    view.ui.add(node, { position: 'top-right', index: 2 });
+    view.ui.add(node, { position: 'top-right', index: 3 });
 
     return function cleanup() {
       view?.ui.remove(node);
@@ -1058,6 +1066,7 @@ function MapWidgets({
         <div
           id="add-save-data-widget"
           className={addSaveDataWidgetVisible ? '' : 'hidden'}
+          role="region"
           style={{
             backgroundColor: 'white',
             pointerEvents: 'all',
@@ -1100,38 +1109,50 @@ function MapWidgets({
 }
 
 function ShowAddSaveDataWidget({
-  setAddSaveDataWidgetVisibleParam,
+  addSaveDataWidgetVisible,
+  setAddSaveDataWidgetVisible,
 }: {
-  setAddSaveDataWidgetVisibleParam: Dispatch<SetStateAction<boolean>>;
+  addSaveDataWidgetVisible: boolean;
+  setAddSaveDataWidgetVisible: Dispatch<SetStateAction<boolean>>;
 }) {
   const [hover, setHover] = useState(false);
 
-  const widget = document.getElementById('add-save-data-widget');
-  const widgetHidden = widget?.classList.contains('hidden');
+  const clickHandler = useCallback(
+    (ev: React.MouseEvent | React.KeyboardEvent) => {
+      if (!isClick(ev)) return;
+      const widget = document.getElementById('add-save-data-widget');
+      if (!widget) return;
+
+      const widgetHidden = widget.classList.contains('hidden');
+      if (widgetHidden) {
+        widget.classList.remove('hidden');
+        setAddSaveDataWidgetVisible(true);
+      } else {
+        widget.classList.add('hidden');
+        setAddSaveDataWidgetVisible(false);
+      }
+    },
+    [setAddSaveDataWidgetVisible],
+  );
 
   return (
     <div
       className="add-save-data-widget"
       title={
-        widgetHidden
+        addSaveDataWidgetVisible
           ? 'Open Add & Save Data Widget'
           : 'Close Add & Save Data Widget'
       }
       style={hover ? divHoverStyle : divStyle}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
-      onClick={(_ev) => {
-        if (!widget) return;
-        if (widgetHidden) {
-          widget.classList.remove('hidden');
-          setAddSaveDataWidgetVisibleParam(true);
-        } else {
-          widget.classList.add('hidden');
-          setAddSaveDataWidgetVisibleParam(false);
-        }
-      }}
+      onClick={clickHandler}
+      onKeyDown={clickHandler}
+      role="button"
+      tabIndex={0}
     >
       <span
+        aria-hidden="true"
         className="esri-icon-add-attachment"
         style={hover ? buttonHoverStyle : buttonStyle}
       />
@@ -1186,6 +1207,22 @@ function ExpandCollapse({
 }: ExpandeCollapseProps) {
   const [hover, setHover] = useState(false);
 
+  const clickHandler = useCallback(
+    (ev: React.KeyboardEvent | React.MouseEvent) => {
+      if (!isClick(ev)) return;
+      // Toggle scroll bars
+      document.documentElement.style.overflow = fullscreenActive
+        ? 'auto'
+        : 'hidden';
+
+      // Toggle fullscreen mode
+      setFullscreenActive(!fullscreenActive);
+
+      mapViewSetter(null);
+    },
+    [fullscreenActive, mapViewSetter, setFullscreenActive],
+  );
+
   return (
     <div
       title={
@@ -1196,19 +1233,13 @@ function ExpandCollapse({
       style={hover ? divHoverStyle : divStyle}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
-      onClick={(_ev) => {
-        // Toggle scroll bars
-        document.documentElement.style.overflow = fullscreenActive
-          ? 'auto'
-          : 'hidden';
-
-        // Toggle fullscreen mode
-        setFullscreenActive(!fullscreenActive);
-
-        mapViewSetter(null);
-      }}
+      onClick={clickHandler}
+      onKeyDown={clickHandler}
+      role="button"
+      tabIndex={0}
     >
       <span
+        aria-hidden="true"
         className={
           fullscreenActive
             ? 'esri-icon esri-icon-zoom-in-fixed'
@@ -1392,7 +1423,7 @@ function retrieveUpstreamWatershed(
 
 interface ShowUpstreamWatershedProps {
   getUpstreamWidgetDisabled: () => boolean;
-  onClick: React.MouseEventHandler<HTMLDivElement>;
+  onClick: (ev: React.MouseEvent | React.KeyboardEvent) => void;
   selectionActive?: boolean;
   upstreamLayer: __esri.GraphicsLayer | null;
   upstreamLoading: boolean;
@@ -1426,8 +1457,12 @@ function ShowUpstreamWatershed({
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
       onClick={onClick}
+      onKeyDown={onClick}
+      role="button"
+      tabIndex={0}
     >
       <span
+        aria-hidden="true"
         className={iconClass}
         style={
           !upstreamWidgetDisabled && hover ? buttonHoverStyle : buttonStyle
@@ -1488,7 +1523,9 @@ function ShowCurrentUpstreamWatershed({
   const [upstreamLoading, setUpstreamLoading] = useState(false);
 
   const handleClick = useCallback(
-    (_ev) => {
+    (ev: React.MouseEvent | React.KeyboardEvent) => {
+      if (!isClick(ev)) return;
+
       retrieveUpstreamWatershed(
         abortSignal,
         getCurrentExtent,

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -176,9 +176,12 @@ const orderedLayers = [
   'waterbodyLayer',
   'allWaterbodiesLayer',
   'monitoringLocationsLayer',
+  'surroundingMonitoringLocationsLayer',
   'usgsStreamgagesLayer',
+  'surroundingUsgsStreamgagesLayer',
   'issuesLayer',
   'dischargersLayer',
+  'surroundingDischargersLayer',
   'cyanLayer',
   'nonprofitsLayer',
   'providersLayer',
@@ -249,7 +252,10 @@ function updateLegend(
       (layer.visible && layer.listMode !== 'hide') ||
       (layer.visible && layer.id === 'actionsWaterbodies') ||
       (layer.visible && layer.id === 'upstreamLayer') ||
-      (layer.visible && layer.id === 'allWaterbodiesLayer')
+      (layer.visible && layer.id === 'allWaterbodiesLayer') ||
+      (layer.visible && layer.id === 'surroundingDischargersLayer') ||
+      (layer.visible && layer.id === 'surroundingUsgsStreamgagesLayer') ||
+      (layer.visible && layer.id === 'surroundingMonitoringLocationsLayer')
     ) {
       visibleLayers.push(layer);
     }

--- a/app/client/src/components/shared/Page.js
+++ b/app/client/src/components/shared/Page.js
@@ -288,7 +288,6 @@ function Page({ children }: Props) {
         <ul>
           <li>
             <button
-              title="Glossary"
               className="js-glossary-toggle"
               data-disabled={!initialized || glossaryStatus === 'fetching'}
             >
@@ -299,7 +298,6 @@ function Page({ children }: Props) {
 
           <li>
             <button
-              title="Data"
               onClick={(_ev) => {
                 if (window.location.pathname !== '/data') {
                   setDataDisplayed(true);
@@ -315,7 +313,6 @@ function Page({ children }: Props) {
 
           <li>
             <button
-              title="About"
               onClick={(_ev) => {
                 if (window.location.pathname !== '/about') {
                   setDataDisplayed(false);
@@ -331,7 +328,6 @@ function Page({ children }: Props) {
 
           <li>
             <button
-              title="Educators"
               onClick={(_ev) => {
                 if (window.location.pathname !== '/educators') {
                   setDataDisplayed(false);
@@ -347,7 +343,6 @@ function Page({ children }: Props) {
 
           <li>
             <a
-              title="Contact Us"
               href="https://www.epa.gov/waterdata/forms/contact-us-about-hows-my-waterway"
               target="_blank"
               rel="noopener noreferrer"

--- a/app/client/src/contexts/Surroundings.tsx
+++ b/app/client/src/contexts/Surroundings.tsx
@@ -1,11 +1,6 @@
-import {
-  createContext,
-  MouseEventHandler,
-  useContext,
-  useReducer,
-} from 'react';
+import { createContext, useContext, useReducer } from 'react';
 // types
-import type { Dispatch, ReactNode } from 'react';
+import type { Dispatch, KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 const StateContext = createContext<SurroundingsState | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
@@ -179,7 +174,9 @@ type Action =
   | {
       type: 'togglers';
       id: SurroundingFeaturesLayerId;
-      payload: (showSurroundings: boolean) => MouseEventHandler<HTMLDivElement>;
+      payload: (
+        showSurroundings: boolean,
+      ) => (ev: KeyboardEvent | MouseEvent) => void;
     }
   | {
       type: 'disabled';
@@ -203,7 +200,7 @@ export type SurroundingsState = {
   togglers: {
     [B in SurroundingFeaturesLayerId]: (
       showSurroundings: boolean,
-    ) => MouseEventHandler<HTMLDivElement>;
+    ) => (ev: KeyboardEvent | MouseEvent) => void;
   };
   disabled: {
     [B in SurroundingFeaturesLayerId]: boolean;

--- a/app/client/src/routes.js
+++ b/app/client/src/routes.js
@@ -1,29 +1,9 @@
 // @flow
 
-import React from 'react';
+import { lazy, Suspense } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { css } from 'styled-components/macro';
 // components
-import Home from 'components/pages/Home';
-import Attains from 'components/pages/Attains';
-import Data from 'components/pages/Data';
-import About from 'components/pages/About';
-import Community from 'components/pages/Community';
-import CommunityIntro from 'components/pages/Community.Routes.CommunityIntro';
-import CommunityTabs from 'components/pages/Community.Routes.CommunityTabs';
-import StateTribal from 'components/pages/StateTribal';
-import StateTribalIntro from 'components/pages/StateTribal.Routes.StateTribalIntro';
-import StateTribalTabs from 'components/pages/StateTribal.Routes.StateTribalTabs';
-import National from 'components/pages/National';
-import MonitoringReport from 'components/pages/MonitoringReport';
-import DrinkingWater from 'components/pages/DrinkingWater';
-import Swimming from 'components/pages/Swimming';
-import EatingFish from 'components/pages/EatingFish';
-import AquaticLife from 'components/pages/AquaticLife';
-import Actions from 'components/pages/Actions';
-import WaterbodyReport from 'components/pages/WaterbodyReport';
-import Educators from 'components/pages/Educators';
-import ErrorPage from 'components/pages/404';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import AlertMessage from 'components/shared/AlertMessage';
 // styled components
@@ -40,6 +20,37 @@ const modifiedErrorBoxStyles = css`
   margin: 1rem;
   text-align: center;
 `;
+
+const Home = lazy(() => import('components/pages/Home'));
+const Attains = lazy(() => import('components/pages/Attains'));
+const Data = lazy(() => import('components/pages/Data'));
+const About = lazy(() => import('components/pages/About'));
+const Community = lazy(() => import('components/pages/Community'));
+const CommunityIntro = lazy(() =>
+  import('components/pages/Community.Routes.CommunityIntro'),
+);
+const CommunityTabs = lazy(() =>
+  import('components/pages/Community.Routes.CommunityTabs'),
+);
+const StateTribal = lazy(() => import('components/pages/StateTribal'));
+const StateTribalIntro = lazy(() =>
+  import('components/pages/StateTribal.Routes.StateTribalIntro'),
+);
+const StateTribalTabs = lazy(() =>
+  import('components/pages/StateTribal.Routes.StateTribalTabs'),
+);
+const National = lazy(() => import('components/pages/National'));
+const MonitoringReport = lazy(() =>
+  import('components/pages/MonitoringReport'),
+);
+const DrinkingWater = lazy(() => import('components/pages/DrinkingWater'));
+const Swimming = lazy(() => import('components/pages/Swimming'));
+const EatingFish = lazy(() => import('components/pages/EatingFish'));
+const AquaticLife = lazy(() => import('components/pages/AquaticLife'));
+const Actions = lazy(() => import('components/pages/Actions'));
+const WaterbodyReport = lazy(() => import('components/pages/WaterbodyReport'));
+const Educators = lazy(() => import('components/pages/Educators'));
+const ErrorPage = lazy(() => import('components/pages/404'));
 
 function AppRoutes() {
   const services = useServicesContext();
@@ -64,50 +75,52 @@ function AppRoutes() {
     <>
       <AlertMessage />
 
-      <Routes>
-        <Route index element={<Home />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/data" element={<Data />} />
-        <Route path="/attains" element={<Attains />} />
-        <Route path="/community" element={<Community />}>
-          <Route index element={<CommunityIntro />} />
-          <Route path=":urlSearch" element={<CommunityTabs />} />
-          <Route path=":urlSearch/:tabName" element={<CommunityTabs />} />
-        </Route>
-        <Route path="/state-and-tribal" element={<StateTribal />}>
-          <Route index element={<StateTribalIntro />} />
-        </Route>
-        <Route path="/state" element={<StateTribal />}>
-          <Route path="/state/:stateCode" element={<StateTribalTabs />} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <Routes>
+          <Route index element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/data" element={<Data />} />
+          <Route path="/attains" element={<Attains />} />
+          <Route path="/community" element={<Community />}>
+            <Route index element={<CommunityIntro />} />
+            <Route path=":urlSearch" element={<CommunityTabs />} />
+            <Route path=":urlSearch/:tabName" element={<CommunityTabs />} />
+          </Route>
+          <Route path="/state-and-tribal" element={<StateTribal />}>
+            <Route index element={<StateTribalIntro />} />
+          </Route>
+          <Route path="/state" element={<StateTribal />}>
+            <Route path="/state/:stateCode" element={<StateTribalTabs />} />
+            <Route
+              path="/state/:stateCode/:tabName"
+              element={<StateTribalTabs />}
+            />
+          </Route>
+          <Route path="/tribe" element={<StateTribal />}>
+            <Route path="/tribe/:stateCode" element={<StateTribalTabs />} />
+          </Route>
+          <Route path="/national" element={<National />} />
+          <Route path="/drinking-water" element={<DrinkingWater />} />
+          <Route path="/swimming" element={<Swimming />} />
+          <Route path="/eating-fish" element={<EatingFish />} />
+          <Route path="/aquatic-life" element={<AquaticLife />} />
+          <Route path="/plan-summary/:orgId/:actionId" element={<Actions />} />
           <Route
-            path="/state/:stateCode/:tabName"
-            element={<StateTribalTabs />}
+            path="/monitoring-report/:provider/:orgId/:siteId"
+            element={<MonitoringReport />}
           />
-        </Route>
-        <Route path="/tribe" element={<StateTribal />}>
-          <Route path="/tribe/:stateCode" element={<StateTribalTabs />} />
-        </Route>
-        <Route path="/national" element={<National />} />
-        <Route path="/drinking-water" element={<DrinkingWater />} />
-        <Route path="/swimming" element={<Swimming />} />
-        <Route path="/eating-fish" element={<EatingFish />} />
-        <Route path="/aquatic-life" element={<AquaticLife />} />
-        <Route path="/plan-summary/:orgId/:actionId" element={<Actions />} />
-        <Route
-          path="/monitoring-report/:provider/:orgId/:siteId"
-          element={<MonitoringReport />}
-        />
-        <Route
-          path="/waterbody-report/:orgId/:auId"
-          element={<WaterbodyReport />}
-        />
-        <Route
-          path="/waterbody-report/:orgId/:auId/:reportingCycle"
-          element={<WaterbodyReport />}
-        />
-        <Route path="/educators" element={<Educators />} />
-        <Route path="*" element={<ErrorPage />} />
-      </Routes>
+          <Route
+            path="/waterbody-report/:orgId/:auId"
+            element={<WaterbodyReport />}
+          />
+          <Route
+            path="/waterbody-report/:orgId/:auId/:reportingCycle"
+            element={<WaterbodyReport />}
+          />
+          <Route path="/educators" element={<Educators />} />
+          <Route path="*" element={<ErrorPage />} />
+        </Routes>
+      </Suspense>
     </>
   );
 }

--- a/app/client/src/utils/hooks/allWaterbodies.ts
+++ b/app/client/src/utils/hooks/allWaterbodies.ts
@@ -7,6 +7,8 @@ import {
   useSurroundingsDispatch,
   useSurroundingsState,
 } from 'contexts/Surroundings';
+// utils
+import { isClick } from 'utils/utils';
 
 export function useAllWaterbodiesLayer(minScale = 577791) {
   const { huc12, mapView } = useContext(LocationSearchContext);
@@ -91,12 +93,12 @@ export function useAllWaterbodiesLayer(minScale = 577791) {
   // Function for controlling layer visibility
   const toggleVisibility = useCallback(
     (showLayer: boolean) => {
-      return function toggle() {
-        if (!allWaterbodiesLayer) return;
+      return function toggle(ev: React.KeyboardEvent | React.MouseEvent) {
+        if (!isClick(ev)) return;
         updateVisibleLayers({ [layerId]: showLayer });
       };
     },
-    [allWaterbodiesLayer, updateVisibleLayers],
+    [updateVisibleLayers],
   );
 
   useEffect(() => {

--- a/app/client/src/utils/hooks/boundariesToggleLayer.ts
+++ b/app/client/src/utils/hooks/boundariesToggleLayer.ts
@@ -16,7 +16,7 @@ import {
 } from 'contexts/Surroundings';
 // utils
 import { useAbort } from 'utils/hooks';
-import { isAbort, toFixedFloat } from 'utils/utils';
+import { isAbort, isClick, toFixedFloat } from 'utils/utils';
 // types
 import type {
   EmptyFetchState,
@@ -216,7 +216,8 @@ function useBoundariesToggleLayer<
   // Manages the surrounding features visibility
   const toggleSurroundings = useCallback(
     (showSurroundings: boolean) => {
-      return function toggle() {
+      return function toggle(ev: React.KeyboardEvent | React.MouseEvent) {
+        if (!isClick(ev)) return;
         updateVisibleLayers({ [surroundingLayerId]: showSurroundings });
 
         surroundingsDispatch({

--- a/app/client/src/utils/utils.ts
+++ b/app/client/src/utils/utils.ts
@@ -1,5 +1,7 @@
 import Highcharts from 'highcharts';
 import Point from '@arcgis/core/geometry/Point';
+// types
+import type { KeyboardEvent, MouseEvent } from 'react';
 
 // utility function to split up an array into chunks of a designated length
 function chunkArray(array: any, chunkLength: number): Array<Array<any>> {
@@ -42,10 +44,21 @@ function isAbort(error: unknown) {
   return error.name === 'AbortError';
 }
 
+function isClick(ev: KeyboardEvent | MouseEvent) {
+  if (isKeyboardEvent(ev)) {
+    if (ev.key !== ' ' && ev.key !== 'Enter') return false;
+  } else if (ev.type !== 'click') return false;
+  return true;
+}
+
 function isEmpty<T>(
   v: T | null | undefined | [] | {},
 ): v is null | undefined | [] | {} {
   return !isNotEmpty(v);
+}
+
+function isKeyboardEvent(ev: KeyboardEvent | MouseEvent): ev is KeyboardEvent {
+  return ev.hasOwnProperty('key');
 }
 
 // Type predicate, negation is used to narrow to type `T`
@@ -519,8 +532,10 @@ export {
   formatNumber,
   getExtensionFromPath,
   isAbort,
+  isClick,
   isEmpty,
   isHuc12,
+  isKeyboardEvent,
   titleCase,
   titleCaseWithExceptions,
   createJsonLD,


### PR DESCRIPTION
## Related Issues:
* [HMW-464](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-464)
* [HMW-469](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-469)

## Main Changes:
* Updated several HTML element attributes in response to feedback from accessibility tools.
* Switched to lazily loaded routes to cut initial bundle size from ~3,300 KiB to ~1,500 KiB.
* Fixed issue of new surrounding features layers not appearing in legend.
* Switched to single color for scatter plot dots on _Monitoring Report_ page.
* Added ability to focus and trigger map widgets with keyboard.
  * Updated layer labels in the surrounding widget so that they are read by screen reader when focused.
  * The visible state of the **Add/Save Data Widget** was not updating properly: I altered it so the trigger re-renders when the visibility state changes, so that it has the latest value of the state variable. This causes the trigger to re-render more often, but I believe it will also aid in the switch to **React 18** in the future.
  * There is more that could be done to improve keyboard navigation, but these changes at least make it possible to operate the widgets with a keyboard.

## Steps To Test:
1. Navigate around various pages of the app and confirm that the lazily loaded routes still function as expected.
2. Go to the _Community_ page, open the **Surrounding Features** widget, and toggle on the "Dischargers" layer.
3. Confirm that the "Permitted Discharger" item is visible in the legend.
4. Toggle on the "Dischargers" layer in the layer list.
5. Confirm that only one "Permitted Discharger" item is visible in the legend.
6. Repeat steps 2 - 5 for the "USGS Streamgages" layer.

**NOTE:** The `monitoringLocationsLayer` and `surroundingMonitoringLocationsLayer` legend items are separate, because their cluster size varies between the layers.

7. Test navigating around the map canvas with the keyboard and triggering widgets with the "Enter" or "Space" key. 

## TODO:
- [ ] For the new items, there were additional accessibility issues, but they relate to other issues that were already present across the application: the "ARIA IDs are not unique" warnings all point to instances where the `@reach/tabs` library is used. This is because each ARIA ID is only unique within a particular `Tabs` group, but we use multiple such groups on a single page. This issue has been raised in reach/reach-ui#947, but it hasn't yet received a response, and, according to reach/reach-ui#972, the library currently isn't maintained. We should check back on this issue, but it might not be fixed anytime soon.
- [ ] To improve keyboard navigation across map widgets, we should consider automatically focusing panels when they are opened, and returning focus to the trigger when they are closed. Additionally, to match the behavior of Esri widgets, we may want the `Esc` key to close focused panels. 
