### PR TITLE
Feature/473 move no waterbodies message

### DIFF
--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -21,7 +21,7 @@ import MapVisibilityButton from 'components/shared/MapVisibilityButton';
 import VirtualizedList from 'components/shared/VirtualizedList';
 import DynamicExitDisclaimer from 'components/shared/DynamicExitDisclaimer';
 // styled components
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, textBoxStyles } from 'components/shared/MessageBoxes';
 import {
   splitLayoutContainerStyles,
   splitLayoutColumnsStyles,
@@ -182,6 +182,12 @@ const modifiedErrorBoxStyles = css`
   ${errorBoxStyles}
   margin: 1rem;
   text-align: center;
+`;
+
+const modifiedTextBoxStyles = css`
+  ${textBoxStyles}
+  margin: 1em 0;
+  padding: 0.75em;
 `;
 
 const inlineBoxStyles = css`
@@ -439,7 +445,7 @@ function Actions() {
             )}
 
             {assessmentUrl && (
-              <div>
+              <div css={modifiedTextBoxStyles}>
                 <a
                   href={assessmentUrl}
                   target="_blank"

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -11,7 +11,11 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import AssessmentSummary from 'components/shared/AssessmentSummary';
 import WaterbodyList from 'components/shared/WaterbodyList';
-import { errorBoxStyles, noteBoxStyles } from 'components/shared/MessageBoxes';
+import {
+  errorBoxStyles,
+  infoBoxStyles,
+  noteBoxStyles,
+} from 'components/shared/MessageBoxes';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
 import { tabsStyles } from 'components/shared/ContentTabs';
@@ -54,7 +58,6 @@ const modifiedNoteBoxStyles = css`
 
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
-  margin-bottom: 1em;
   text-align: center;
 `;
 
@@ -632,10 +635,12 @@ function DrinkingWater() {
                   {drinkingWater.data.length > 0 && (
                     <>
                       {providers.length === 0 && (
-                        <p css={centeredTextStyles}>
-                          There are no public drinking water systems serving{' '}
-                          {county} county/municipality.
-                        </p>
+                        <div css={infoBoxStyles}>
+                          <p css={centeredTextStyles}>
+                            There are no public drinking water systems serving{' '}
+                            {county} county/municipality.
+                          </p>
+                        </div>
                       )}
 
                       {providers.length > 0 && (
@@ -780,10 +785,12 @@ function DrinkingWater() {
                   {drinkingWater.data.length > 0 && (
                     <>
                       {totalWithdrawersCount === 0 && (
-                        <p css={centeredTextStyles}>
-                          There are no public water systems drawing water from
-                          the {watershed} watershed.
-                        </p>
+                        <div css={infoBoxStyles}>
+                          <p css={centeredTextStyles}>
+                            There are no public water systems drawing water from
+                            the {watershed} watershed.
+                          </p>
+                        </div>
                       )}
 
                       {totalWithdrawersCount > 0 && (

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -16,7 +16,7 @@ import { impairmentFields } from 'config/attainsToHmwMapping';
 import Switch from 'components/shared/Switch';
 import DisclaimerModal from 'components/shared/DisclaimerModal';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import TabErrorBoundary from 'components/shared/ErrorBoundary.TabErrorBoundary';
 import {
@@ -541,10 +541,12 @@ function IdentifiedIssues() {
                   {(cipSummary.data.count === 0 ||
                     (cipSummary.data.items &&
                       cipSummary.data.items.length === 0)) && (
-                    <p css={centeredTextStyles}>
-                      There are no impairment categories in the{' '}
-                      <em>{watershed}</em> watershed.
-                    </p>
+                    <div css={infoBoxStyles}>
+                      <p css={centeredTextStyles}>
+                        There are no impairment categories in the{' '}
+                        <em>{watershed}</em> watershed.
+                      </p>
+                    </div>
                   )}
 
                   {cipSummary.data.items &&
@@ -602,10 +604,12 @@ function IdentifiedIssues() {
 
                         {!emptyCategoriesWithPercent &&
                           zeroPollutedWaterbodies && (
-                            <p css={centeredTextStyles}>
-                              There are no impairment categories in the{' '}
-                              <em>{watershed}</em> watershed.
-                            </p>
+                            <div css={infoBoxStyles}>
+                              <p css={centeredTextStyles}>
+                                There are no impairment categories in the{' '}
+                                <em>{watershed}</em> watershed.
+                              </p>
+                            </div>
                           )}
 
                         {!emptyCategoriesWithPercent &&
@@ -712,11 +716,13 @@ function IdentifiedIssues() {
               {dischargersStatus === 'success' && (
                 <>
                   {!violatingDischargers.length && (
-                    <p css={centeredTextStyles}>
-                      There are no dischargers with significant{' '}
-                      <GlossaryTerm term="Effluent">effluent</GlossaryTerm>{' '}
-                      violations in the <em>{watershed}</em> watershed.
-                    </p>
+                    <div css={infoBoxStyles}>
+                      <p css={centeredTextStyles}>
+                        There are no dischargers with significant{' '}
+                        <GlossaryTerm term="Effluent">effluent</GlossaryTerm>{' '}
+                        violations in the <em>{watershed}</em> watershed.
+                      </p>
+                    </div>
                   )}
 
                   {violatingDischargers.length > 0 && (
@@ -738,7 +744,11 @@ function IdentifiedIssues() {
                       }
                     >
                       {violatingDischargers.map((discharger) => {
-                        const { uniqueId: id, CWPName: name, PermitComponents: components } = discharger;
+                        const {
+                          uniqueId: id,
+                          CWPName: name,
+                          PermitComponents: components,
+                        } = discharger;
 
                         const feature = {
                           geometry: {

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -25,7 +25,7 @@ import {
   squareIcon,
   waterwayIcon,
 } from 'components/shared/MapLegend';
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
 import ViewOnMapButton from 'components/shared/ViewOnMapButton';
@@ -1171,10 +1171,12 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
     return (
       <>
         {totalLocationsCount === 0 && (
-          <p css={centeredTextStyles}>
-            There are no monitoring sample locations in the {watershed}{' '}
-            watershed.
-          </p>
+          <div css={infoBoxStyles}>
+            <p css={centeredTextStyles}>
+              There are no monitoring sample locations in the {watershed}{' '}
+              watershed.
+            </p>
+          </div>
         )}
 
         {totalLocationsCount > 0 && (

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -102,6 +102,7 @@ const modifiedDisclaimerStyles = css`
 
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
+  margin-bottom: 1em;
   text-align: center;
 `;
 
@@ -1161,8 +1162,8 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
 
   if (monitoringLocations.status === 'failure') {
     return (
-      <div css={modifiedErrorBoxStyles}>
-        <p>{monitoringError}</p>
+      <div css={errorBoxStyles}>
+        <p css={centeredTextStyles}>{monitoringError}</p>
       </div>
     );
   }

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -48,7 +48,6 @@ import {
   echoError,
   streamgagesError,
   monitoringError,
-  huc12SummaryError,
   zeroAssessedWaterbodies,
 } from 'config/errorMessages';
 // styles
@@ -79,12 +78,6 @@ const legendItemsStyles = css`
 
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
-  margin-bottom: 1em;
-  text-align: center;
-`;
-
-const modifiedInfoBoxStyles = css`
-  ${infoBoxStyles};
   margin-bottom: 1em;
   text-align: center;
 `;
@@ -125,7 +118,7 @@ function Overview() {
     waterbodyLayer,
   } = useLayers();
 
-  const { cipSummary, watershed } = useContext(LocationSearchContext);
+  const { cipSummary } = useContext(LocationSearchContext);
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
@@ -218,34 +211,6 @@ function Overview() {
 
   return (
     <div css={containerStyles}>
-      {cipSummary.status === 'failure' && (
-        <div css={modifiedErrorBoxStyles}>
-          <p>{huc12SummaryError}</p>
-        </div>
-      )}
-
-      {streamgagesStatus === 'failure' &&
-        monitoringLocationsStatus === 'failure' && (
-          <div css={modifiedErrorBoxStyles}>
-            <p>{streamgagesError}</p>
-            <p>{monitoringError}</p>
-          </div>
-        )}
-
-      {dischargersStatus === 'failure' && (
-        <div css={modifiedErrorBoxStyles}>
-          <p>{echoError}</p>
-        </div>
-      )}
-
-      {cipSummary.status === 'success' &&
-        waterbodies !== null &&
-        totalWaterbodies === 0 && (
-          <div css={modifiedInfoBoxStyles}>
-            <p>{zeroAssessedWaterbodies(watershed)}</p>
-          </div>
-        )}
-
       <div css={keyMetricsStyles}>
         <div css={keyMetricStyles}>
           {(!waterbodyLayer || waterbodies === null) &&
@@ -371,7 +336,7 @@ function Overview() {
 }
 
 function WaterbodiesTab() {
-  const { watershed } = useContext(LocationSearchContext);
+  const { cipSummary, watershed } = useContext(LocationSearchContext);
   const waterbodies = useWaterbodyFeatures();
 
   const uniqueWaterbodies = waterbodies
@@ -382,6 +347,18 @@ function WaterbodiesTab() {
 
   // draw the waterbody on the map
   useWaterbodyOnMap();
+
+  if (
+    cipSummary.status === 'success' &&
+    waterbodies !== null &&
+    totalWaterbodies === 0
+  ) {
+    return (
+      <div css={infoBoxStyles}>
+        <p css={centeredTextStyles}>{zeroAssessedWaterbodies(watershed)}</p>
+      </div>
+    );
+  }
 
   return (
     <WaterbodyList
@@ -613,6 +590,18 @@ function MonitoringAndSensorsTab({
   );
 
   if (
+    streamgagesStatus === 'failure' &&
+    monitoringLocationsStatus === 'failure'
+  ) {
+    return (
+      <div css={errorBoxStyles}>
+        <p>{streamgagesError}</p>
+        <p>{monitoringError}</p>
+      </div>
+    );
+  }
+
+  if (
     monitoringLocationsStatus === 'pending' ||
     streamgagesStatus === 'pending'
   ) {
@@ -655,10 +644,12 @@ function MonitoringAndSensorsTab({
         </p>
 
         {allMonitoringAndSensors.length === 0 && (
-          <p css={centeredTextStyles}>
-            There are no locations with data in the <em>{watershed}</em>{' '}
-            watershed.
-          </p>
+          <div css={infoBoxStyles}>
+            <p css={centeredTextStyles}>
+              There are no locations with data in the <em>{watershed}</em>{' '}
+              watershed.
+            </p>
+          </div>
         )}
 
         {allMonitoringAndSensors.length > 0 && (
@@ -1064,8 +1055,8 @@ function PermittedDischargersTab({
 
   if (dischargersStatus === 'failure') {
     return (
-      <div css={modifiedErrorBoxStyles}>
-        <p>{echoError}</p>
+      <div css={errorBoxStyles}>
+        <p css={centeredTextStyles}>{echoError}</p>
       </div>
     );
   }
@@ -1074,9 +1065,11 @@ function PermittedDischargersTab({
     return (
       <>
         {totalPermittedDischargers === 0 && (
-          <p css={centeredTextStyles}>
-            There are no dischargers in the <em>{watershed}</em> watershed.
-          </p>
+          <div css={infoBoxStyles}>
+            <p css={centeredTextStyles}>
+              There are no dischargers in the <em>{watershed}</em> watershed.
+            </p>
+          </div>
         )}
 
         {totalPermittedDischargers > 0 && (

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -9,7 +9,7 @@ import { ListContent } from 'components/shared/BoxContent';
 import { tabsStyles } from 'components/shared/ContentTabs';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
-import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import TabErrorBoundary from 'components/shared/ErrorBoundary.TabErrorBoundary';
 import {
   keyMetricsStyles,
@@ -121,13 +121,15 @@ function Restore() {
                 {grts.status === 'success' && (
                   <>
                     {sortedGrtsData.length === 0 && (
-                      <p css={textStyles}>
-                        There are no{' '}
-                        <GlossaryTerm term="Clean Water Act Section 319 Projects">
-                          Clean Water Act Section 319
-                        </GlossaryTerm>{' '}
-                        projects in the <em>{watershed}</em> watershed.
-                      </p>
+                      <div css={infoBoxStyles}>
+                        <p css={textStyles}>
+                          There are no{' '}
+                          <GlossaryTerm term="Clean Water Act Section 319 Projects">
+                            Clean Water Act Section 319
+                          </GlossaryTerm>{' '}
+                          projects in the <em>{watershed}</em> watershed.
+                        </p>
+                      </div>
                     )}
 
                     {sortedGrtsData.length > 0 && (
@@ -232,13 +234,15 @@ function Restore() {
                 {attainsPlans.status === 'success' && (
                   <>
                     {sortedAttainsPlanData.length === 0 && (
-                      <p css={textStyles}>
-                        There are no EPA funded{' '}
-                        <GlossaryTerm term="Restoration plan">
-                          restoration plans
-                        </GlossaryTerm>{' '}
-                        in the <em>{watershed}</em> watershed.
-                      </p>
+                      <div css={infoBoxStyles}>
+                        <p css={textStyles}>
+                          There are no EPA funded{' '}
+                          <GlossaryTerm term="Restoration plan">
+                            restoration plans
+                          </GlossaryTerm>{' '}
+                          in the <em>{watershed}</em> watershed.
+                        </p>
+                      </div>
                     )}
 
                     {sortedAttainsPlanData.length > 0 && (

--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -70,7 +70,12 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
   const [layers, setLayers] = useState(null);
 
   const services = useServicesContext();
-  const getSharedLayers = useSharedLayers();
+  const excludedLayers = [
+    ...(window.location.pathname.includes('/plan-summary')
+      ? ['allWaterbodiesLayer']
+      : []),
+  ];
+  const getSharedLayers = useSharedLayers({ excludedLayers });
   useWaterbodyHighlight();
 
   const { surroundingMonitoringLocationsLayer } =

--- a/app/client/src/components/shared/EducatorsContent.js
+++ b/app/client/src/components/shared/EducatorsContent.js
@@ -68,7 +68,8 @@ const containerStyles = css`
 
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles}
-  margin-bottom: 1.25rem;
+  margin: 1rem;
+  text-align: center;
 `;
 
 const contentStyles = css`

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -609,7 +609,13 @@ function TribalMap({
   const services = useServicesContext();
   useWaterbodyHighlight();
 
-  const getSharedLayers = useSharedLayers(4622350);
+  const getSharedLayers = useSharedLayers({
+    overrides: {
+      allWaterbodiesLayer: {
+        minScale: 4622350,
+      },
+    },
+  });
   const [layers, setLayers] = useState(null);
 
   // reset the home widget

--- a/app/client/src/components/shared/WaterbodyList.js
+++ b/app/client/src/components/shared/WaterbodyList.js
@@ -56,7 +56,6 @@ const waterbodyItemStyles = css`
 
 const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
-  margin-bottom: 1em;
   text-align: center;
 `;
 

--- a/app/client/src/utils/hooks/allWaterbodies.ts
+++ b/app/client/src/utils/hooks/allWaterbodies.ts
@@ -44,6 +44,7 @@ export function useAllWaterbodiesLayer(minScale = 577791) {
 
   // Mark the layer as updating, when necessary
   useEffect(() => {
+    if (!allWaterbodiesLayer) return;
     const updatingHandle = reactiveUtils.watch(
       () => mapView?.navigating,
       () => {
@@ -60,12 +61,13 @@ export function useAllWaterbodiesLayer(minScale = 577791) {
     );
 
     return function cleanup() {
-      updatingHandle.remove();
+      updatingHandle?.remove();
     };
-  }, [mapView, surroundingsDispatch, updating]);
+  }, [allWaterbodiesLayer, mapView, surroundingsDispatch, updating]);
 
   // Mark the layer as disabled when out of scale
   useEffect(() => {
+    if (!allWaterbodiesLayer) return;
     const disabledHandle = reactiveUtils.watch(
       () => mapView?.scale,
       () => {
@@ -86,7 +88,7 @@ export function useAllWaterbodiesLayer(minScale = 577791) {
     );
 
     return function cleanup() {
-      disabledHandle.remove();
+      disabledHandle?.remove();
     };
   }, [disabled, mapView, surroundingsDispatch, allWaterbodiesLayer]);
 

--- a/app/client/src/utils/hooks/index.ts
+++ b/app/client/src/utils/hooks/index.ts
@@ -880,7 +880,17 @@ function useDynamicPopup() {
   return { getTitle, getTemplate, setDynamicPopupFields };
 }
 
-function useSharedLayers(allWaterbodiesMinScale?: number) {
+function useSharedLayers({
+  excludedLayers = [],
+  overrides,
+}: {
+  excludedLayers?: string[];
+  overrides?: {
+    [layerId: string]: {
+      minScale?: number;
+    };
+  };
+} = {}) {
   const services = useServicesContext();
   const { setLayer, setResetHandler } = useLayers();
 
@@ -1466,6 +1476,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
   }
 
   function getAllWaterbodiesLayer() {
+    if (excludedLayers.includes('allWaterbodiesLayer')) return null;
     const popupTemplate = {
       title: getTitle,
       content: getTemplate,
@@ -1556,7 +1567,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
     return allWaterbodiesLayer;
   }
 
-  useAllWaterbodiesLayer(allWaterbodiesMinScale);
+  useAllWaterbodiesLayer(overrides?.allWaterbodiesLayer?.minScale);
 
   function getLandCoverLayer() {
     const landCoverLayer = new WMSLayer({
@@ -1613,7 +1624,7 @@ function useSharedLayers(allWaterbodiesMinScale?: number) {
       countyLayer,
       watershedsLayer,
       allWaterbodiesLayer,
-    ];
+    ].filter((layer) => layer !== null);
   };
 }
 


### PR DESCRIPTION
## Related Issues:
* [HMW-473](https://jira.epa.gov/secure/RapidBoard.jspa?rapidView=864&view=detail&selectedIssue=HMW-473)

## Main Changes:
* Moved the "There are no waterbodies assessed..." message that displayed above the switches of the _Overview_ tab into the _Waterbodies_ panel.
* Moved the error messages that were displayed above the switches into their respective panels, where necessary. No other tabs display error messages in that location.
* Placed other "There are no..." info messages across the application into blue-shaded boxes for uniformity.
* Updated other message box spacing for uniformity.
* Removed the `allWaterbodiesLayer` from the _Plan Summary_ page.
* Added a shaded box around the "View Waterbody Report" link in the popups and accordion items on the _Plan Summary_ page. This is already done for other such links, but the Plan Summary page creates the content separately.

## Steps To Test:
1. Navigate to http://localhost:3000/community/150601030107/overview.
2. Confirm that "There are no waterbodies assessed in the Fox Canyon watershed" is displayed in the _Waterbodies_ panel, and not above the toggle switches.
3. Block https://attains.epa.gov/attains-public/api/huc12summary, https://labs.waterdata.usgs.gov/sta/v1.1/Things, https://www.waterqualitydata.us/data/summary/monitoringlocation/, and https://echodata.epa.gov/echo/cwa_rest_services.get_facilities, and confirm that error messages do not show above the switches.
4. Open the _Monitoring Locations_ and _Permitted Dischargers_ tabs, and confirm that the "no locations" messages are displayed in blue-shaded info boxes.
5. Click around other tabs of this location and confirm that other "no locations" messages are shown in blue-shaded boxes. This may need to be forced in the _Who provides the drinking water here?_ panel of the _Drinking Water_ tab, since I couldn't find a location without public water systems.
6. Verify that the All Waterbodies is not included in the Surrounding Features widget on the Plan Summary page, but that it is an option on the Waterbody Report page.