### PR TITLE
Bugfix/484 add save widget bugs

### DIFF
--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -781,6 +781,9 @@ function SavePanel({ visible }: Props) {
       // run publish
       await runPublish(portal, serviceMetaData, layersToPublish);
     } catch (err) {
+      setPublishResponse({
+        status: 'idle',
+      });
       console.error(err);
       setUserPortal(null);
     }

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -308,7 +308,10 @@ function MapWidgets({
 }: Props) {
   const {
     addSaveDataWidgetVisible,
+    setActiveTabIndex,
     setAddSaveDataWidgetVisible,
+    setSaveAsName,
+    setSaveDescription,
     widgetLayers,
   } = useAddSaveDataWidgetState();
 
@@ -1042,10 +1045,24 @@ function MapWidgets({
     visibleLayers,
   ]);
 
+  // Focus on the add/save data widget when it is first opened
   useEffect(() => {
     if (!addSaveDataWidgetVisible) return;
     document.getElementById('add-save-data-widget')?.focus();
   }, [addSaveDataWidgetVisible]);
+
+  // Reset the add/save data widget values when users change pages
+  useEffect(() => {
+    setActiveTabIndex(0);
+    setAddSaveDataWidgetVisible(false);
+    setSaveAsName('');
+    setSaveDescription('');
+  }, [
+    setActiveTabIndex,
+    setAddSaveDataWidgetVisible,
+    setSaveAsName,
+    setSaveDescription,
+  ]);
 
   if (!addSaveDataWidget) return null;
 


### PR DESCRIPTION
## Related Issues:
* [HMW-484](https://jira.epa.gov/browse/HMW-484)

## Main Changes:
* Fixed an issue of an infinite loading spinner if the user cancels logging in to AGO.
* Fixed an issue of the add save data widget being opened even after changing pages.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the `Add & Save Data Widget`
3. Type in a name
4. Click `Save to ArcGIS Online`
5. Close the login popup without loggin in or click Cancel
6. Verify the loading spinner goes away and the saving is canceled
7. Click on the `State & Tribal` button
8. Select a tribe and click Go
9. Verify the `Add & Save Data Widget` is not open
