### PR TITLE
Adjusted tooltip centering function

### DIFF
--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -43,7 +43,7 @@ const centered: Position = (triggerRect, tooltipRect) => {
   if (!triggerRect || !tooltipRect) return {};
   const triggerCenter = triggerRect.left + triggerRect.width / 2;
   const left = triggerCenter - tooltipRect.width / 2;
-  const maxLeft = document.body.clientWidth - tooltipRect.width;
+  const maxLeft = document.body.clientWidth - tooltipRect.width - 2;
   return {
     left: Math.min(Math.max(2, left), maxLeft) + window.scrollX,
     top: triggerRect.bottom + 8 + window.scrollY,


### PR DESCRIPTION
## Related Issues:
* [HMW-486]

## Main Changes:
* Adjusted the `centered` function in the HelpTooltip component to match the function used in an `@reach/tooltip` example. This prevents the tooltip width from constantly decreasing on some screen sizes when the tooltip boundary touches the client boundary.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/monitoring.
2. Hover over the help tooltip icon next to the "Date range for the Lower Anacostia River watershed" text.
3. Confirm that the tooltip width remains constant.
4. Repeat for a variety of screen widths.