### PR TITLE
Updated casing in tribal mapserver URL

### DIFF
--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -6,7 +6,7 @@
   "mappedWater": "https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer",
   "upstreamWatershed": "https://gispub.epa.gov/arcgis/rest/services/OW/CatchmentFabric/MapServer/2/",
   "nonprofits": "https://services7.arcgis.com/RozrT2Mi6zTs0s5F/arcgis/rest/services/Nonprofits_10_24_18/FeatureServer/0/",
-  "tribal": "https://geopub.epa.gov/arcgis/rest/services/EMEF/tribal/MapServer",
+  "tribal": "https://geopub.epa.gov/arcgis/rest/services/EMEF/Tribal/MapServer",
   "congressional": "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_116th_Congressional_Districts_all/FeatureServer",
   "wsio": "https://gispub.epa.gov/arcgis/rest/services/r4/wsio/MapServer/0",
   "waterbodyService": {

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -6,7 +6,7 @@
   "mappedWater": "https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer",
   "upstreamWatershed": "https://gispub.epa.gov/arcgis/rest/services/OW/CatchmentFabric/MapServer/2/",
   "nonprofits": "https://services7.arcgis.com/RozrT2Mi6zTs0s5F/arcgis/rest/services/Nonprofits_10_24_18/FeatureServer/0/",
-  "tribal": "https://geopub.epa.gov/arcgis/rest/services/EMEF/tribal/MapServer",
+  "tribal": "https://geopub.epa.gov/arcgis/rest/services/EMEF/Tribal/MapServer",
   "congressional": "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_116th_Congressional_Districts_all/FeatureServer",
   "wsio": "https://gispub.epa.gov/arcgis/rest/services/r4/wsio/MapServer/0",
   "waterbodyService": {


### PR DESCRIPTION
## Main Changes:
* Updated the `tribal` entry in the `services.json` and `services-attains.json` files to its new URL, which uses a different casing.

## Steps to Test:
* Navigate to http://localhost:3000/community/dc/overview, and open the developer's console.
* Ensure that no Esri layer errors appear in the console (at least none related to the Tribal service).
* Verify that the Layer List widget is visible on the map, and that it includes the _Tribal Areas_ group layer.
