### PR TITLE
Bugfix/495 advanced search waterbody layer

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -97,6 +97,11 @@ const modifiedErrorBoxStyles = css`
   text-align: center;
 `;
 
+const modifiedInfoBoxStyles = css`
+  ${infoBoxStyles}
+  text-align: center;
+`;
+
 const infoBoxHeadingStyles = css`
   ${boxHeadingStyles};
   display: flex;
@@ -1233,10 +1238,12 @@ function WaterbodyReport() {
                       {waterbodySources.status === 'success' && (
                         <>
                           {waterbodySources.data.length === 0 ? (
-                            <p>
-                              No probable sources of impairment identified for
-                              this waterbody.
-                            </p>
+                            <div css={modifiedInfoBoxStyles}>
+                              <p>
+                                No probable sources of impairment identified for
+                                this waterbody.
+                              </p>
+                            </div>
                           ) : (
                             <ReactTable
                               data={waterbodySources.data}
@@ -1288,7 +1295,9 @@ function WaterbodyReport() {
                       {documents.status === 'success' && (
                         <>
                           {documents.data.length === 0 ? (
-                            <p>No documents are available</p>
+                            <div css={modifiedInfoBoxStyles}>
+                              <p>No documents are available</p>
+                            </div>
                           ) : (
                             <>
                               <em>Links below open in a new browser tab.</em>
@@ -1352,7 +1361,9 @@ function WaterbodyReport() {
                       {waterbodyActions.status === 'success' && (
                         <>
                           {waterbodyActions.data.length === 0 ? (
-                            <p>No plans specified for this waterbody.</p>
+                            <div css={modifiedInfoBoxStyles}>
+                              <p>No plans specified for this waterbody.</p>
+                            </div>
                           ) : (
                             <>
                               <em>Links below open in a new browser tab.</em>

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -209,6 +209,7 @@ function StateMap({
   }, [
     getSharedLayers,
     setLayer,
+    setResetHandler,
     layersInitialized,
     services,
     updateVisibleLayers,

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -88,6 +88,7 @@ function StateMap({
   const {
     resetLayers,
     setLayer,
+    setResetHandler,
     updateVisibleLayers,
     waterbodyAreas,
     waterbodyLayer,
@@ -135,6 +136,9 @@ function StateMap({
       popupTemplate,
     });
     setLayer('waterbodyPoints', waterbodyPoints);
+    setResetHandler('waterbodyPoints', () => {
+      setLayer('waterbodyPoints', null);
+    });
 
     const linesRenderer = {
       type: 'unique-value',
@@ -155,6 +159,9 @@ function StateMap({
       popupTemplate,
     });
     setLayer('waterbodyLines', waterbodyLines);
+    setResetHandler('waterbodyLines', () => {
+      setLayer('waterbodyLines', null);
+    });
 
     const areasRenderer = {
       type: 'unique-value',
@@ -175,6 +182,9 @@ function StateMap({
       popupTemplate,
     });
     setLayer('waterbodyAreas', waterbodyAreas);
+    setResetHandler('waterbodyAreas', () => {
+      setLayer('waterbodyAreas', null);
+    });
 
     // Make the waterbody layer into a single layer
     const waterbodyLayer = new GroupLayer({
@@ -186,6 +196,10 @@ function StateMap({
     });
     waterbodyLayer.addMany([waterbodyAreas, waterbodyLines, waterbodyPoints]);
     setLayer('waterbodyLayer', waterbodyLayer);
+    setResetHandler('waterbodyLayer', () => {
+      waterbodyLayer?.layers.removeAll();
+      setLayer('waterbodyLayer', null);
+    });
 
     setLayers([...getSharedLayers(), waterbodyLayer]);
 

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1165,7 +1165,7 @@ function MapPopup({
 const cyanListContentStyles = css`
   ${listContentStyles}
   border-top: none;
-  margin-bottom: 0;
+  padding-bottom: 0;
 
   .row-cell {
     background-color: initial !important;


### PR DESCRIPTION
## Related Issues:
* [HMW-495](https://jira.epa.gov/browse/HMW-495)

## Main Changes:
* Updated the State Map to reset waterbody layers on unmount. This is done in the _LocationMap_ component, but it was missed in the the _StateMap_ when separating out the _Layers_ context.
  * This fixes an issue where subsequent search on the Advanced Search page don't have waterbody layers.
* Adjusted some spacing in the CyAN accordion content.
* Added info boxes around some messages on the Waterbody Report page.

## Steps To Test:
1. Go to http://localhost:3000/state/AZ/advanced-search.
2. Select _Ammonia_ from the Parameter Groups drop-down, then click Search, then Continue.
3. Waterbody features should be visible on the map, and the map should zoom to Arizona.
4. Clear the Parameter Groups selection, then select Chlorine, click Search, then Continue.
5. New features should appear on the map.
6. Go to http://localhost:3000/waterbody-report/21AWIC/AL03140302-0506-102/2020.
7. The 'No probable sources of impairment identified for this waterbody', 'No plans specified for this waterbody', and 'No documents are available' messages should be shown in info boxes.