### PR TITLE
Feature/505 performance crop geometry

### DIFF
--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -837,36 +837,40 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           updateErroredLayers({ waterbodyLines: false });
 
           // crop the waterbodies geometry to within the huc
-          const features = cropGeometryToHuc(
+          cropGeometryToHuc(
             res.features,
             boundaries.features[0].geometry,
-          );
-
-          const linesRenderer = {
-            type: 'unique-value',
-            field: 'overallstatus',
-            fieldDelimiter: ', ',
-            defaultSymbol: createWaterbodySymbol({
-              condition: 'unassessed',
-              selected: false,
-              geometryType: 'polyline',
-            }),
-            uniqueValueInfos: createUniqueValueInfos('polyline'),
-          };
-          const newLinesLayer = new FeatureLayer({
-            id: 'waterbodyLines',
-            title: 'Waterbody Lines',
-            geometryType: res.geometryType,
-            spatialReference: res.spatialReference,
-            fields: res.fields,
-            source: features,
-            outFields: ['*'],
-            renderer: linesRenderer,
-            popupTemplate,
-          });
-          setLayer('waterbodyLines', newLinesLayer);
-          setResetHandler('waterbodyLines', () => {
-            setLayer('waterbodyLines', null);
+          ).then((features) => {
+            const linesRenderer = {
+              type: 'unique-value',
+              field: 'overallstatus',
+              fieldDelimiter: ', ',
+              defaultSymbol: createWaterbodySymbol({
+                condition: 'unassessed',
+                selected: false,
+                geometryType: 'polyline',
+              }),
+              uniqueValueInfos: createUniqueValueInfos('polyline'),
+            };
+            const newLinesLayer = new FeatureLayer({
+              id: 'waterbodyLines',
+              title: 'Waterbody Lines',
+              geometryType: res.geometryType,
+              spatialReference: res.spatialReference,
+              fields: res.fields,
+              source: features,
+              outFields: ['*'],
+              renderer: linesRenderer,
+              popupTemplate,
+            });
+            setLayer('waterbodyLines', newLinesLayer);
+            setResetHandler('waterbodyLines', () => {
+              setLayer('waterbodyLines', null);
+            });
+          }).catch((err) => {
+            handleMapServiceError(err);
+            updateErroredLayers({ waterbodyLines: true });
+            setLinesData({ features: [] });
           });
         })
         .catch((err) => {
@@ -910,36 +914,40 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           updateErroredLayers({ waterbodyAreas: false });
 
           // crop the waterbodies geometry to within the huc
-          const features = cropGeometryToHuc(
+          cropGeometryToHuc(
             res.features,
             boundaries.features[0].geometry,
-          );
-
-          const areasRenderer = {
-            type: 'unique-value',
-            field: 'overallstatus',
-            fieldDelimiter: ', ',
-            defaultSymbol: createWaterbodySymbol({
-              condition: 'unassessed',
-              selected: false,
-              geometryType: 'polygon',
-            }),
-            uniqueValueInfos: createUniqueValueInfos('polygon'),
-          };
-          const newAreasLayer = new FeatureLayer({
-            id: 'waterbodyAreas',
-            title: 'Waterbody Areas',
-            geometryType: res.geometryType,
-            spatialReference: res.spatialReference,
-            fields: res.fields,
-            source: features,
-            outFields: ['*'],
-            renderer: areasRenderer,
-            popupTemplate,
-          });
-          setLayer('waterbodyAreas', newAreasLayer);
-          setResetHandler('waterbodyAreas', () => {
-            setLayer('waterbodyAreas', null);
+          ).then((features) => {
+            const areasRenderer = {
+              type: 'unique-value',
+              field: 'overallstatus',
+              fieldDelimiter: ', ',
+              defaultSymbol: createWaterbodySymbol({
+                condition: 'unassessed',
+                selected: false,
+                geometryType: 'polygon',
+              }),
+              uniqueValueInfos: createUniqueValueInfos('polygon'),
+            };
+            const newAreasLayer = new FeatureLayer({
+              id: 'waterbodyAreas',
+              title: 'Waterbody Areas',
+              geometryType: res.geometryType,
+              spatialReference: res.spatialReference,
+              fields: res.fields,
+              source: features,
+              outFields: ['*'],
+              renderer: areasRenderer,
+              popupTemplate,
+            });
+            setLayer('waterbodyAreas', newAreasLayer);
+            setResetHandler('waterbodyAreas', () => {
+              setLayer('waterbodyAreas', null);
+            });
+          }).catch((err) => {
+            handleMapServiceError(err);
+            updateErroredLayers({ waterbodyAreas: true });
+            setAreasData({ features: [] });
           });
         })
         .catch((err) => {


### PR DESCRIPTION
## Related Issues:
* [HMW-505](https://jira.epa.gov/browse/HMW-505)

## Main Changes:
* Improved performance of cropping geometry by switching to async difference function.
  * This reduced the load time by about 40%. The cropping logic used to take about 4 - 5 minutes before and now it takes about 2 - 3 minutes. Definitely an improvement, but it is still pretty slow.
  * One other benefit of this change is the app isn't completely locked anymore, while the cropping is being done. Before you couldn't do anything for the entire 4 - 5 minutes it took to load. Now it will lock up for about 15 - 30 seconds, while it's firing off all of the difference requests, but then you can click around on the community page while the waterbodies are loading.

## Steps To Test:
1. Navigate to http://localhost:3000/community/long%20island%20sound/overview
2. Verify the location loads somewhat faster than the same location on the dev site

## TODO:
- [ ] I still want to look at more ways to speed this up, but this might be the best we can do.
- [ ] During the next internal meeting, discuss creating a GP Service for performing this operation. There is no guarantee that a GP Service will fix the issue since it will have to live on the already overburdened EPA GP Server, but it may be worth testing it to see if it can do better than the current 2 - 3 minutes.
