### PR TITLE
Bugfix/485 empty log graph

### DIFF
--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -464,6 +464,8 @@ const treeStyles = (level, styles) => {
 ## Helpers
 */
 
+const measurementPrecision = 3;
+
 function buildOptions(values) {
   return Array.from(values).map((value) => {
     return { value: value, label: value };
@@ -591,7 +593,7 @@ function getCheckedStatus(numberSelected, children) {
 function getMean(values) {
   const sum = values.reduce((a, b) => a + b, 0);
   const mean = sum / values.length;
-  return parseFloat(mean.toFixed(3));
+  return parseFloat(mean.toFixed(measurementPrecision));
 }
 
 function getMedian(values) {
@@ -603,7 +605,7 @@ function getMedian(values) {
   } else {
     median = sorted[(numValues - 1) / 2];
   }
-  return parseFloat(median.toFixed(3));
+  return parseFloat(median.toFixed(measurementPrecision));
 }
 
 function getStdDev(values, mean = null) {
@@ -612,7 +614,7 @@ function getStdDev(values, mean = null) {
   const tss = values.reduce((a, b) => a + (b - sampleMean) ** 2, 0);
   const variance = tss / (values.length - 1);
   const stdDev = Math.sqrt(variance);
-  return parseFloat(stdDev.toFixed(3));
+  return parseFloat(stdDev.toFixed(measurementPrecision));
 }
 
 function getTotalCount(charcs) {
@@ -944,7 +946,9 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       mediumValues.add(record.medium);
 
       record.date = getDate(record);
-      record.measurement = parseFloat(record.measurement.toFixed(3));
+      record.measurement = parseFloat(
+        record.measurement.toFixed(measurementPrecision),
+      );
       newMeasurements.push(record);
     });
 
@@ -986,7 +990,8 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
     newMsmts.forEach((msmt) => {
       if (msmt.year >= newDomain[0] && msmt.year <= newDomain[1]) {
         const dataPoint = {
-          value: msmt.measurement,
+          // Map zero values to the lowest number afforded by the chosen precision
+          value: msmt.measurement || 1 * 10 ** (-1 * measurementPrecision),
           depth: msmt.depth,
           depthUnit: msmt.depthUnit,
         };

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -486,7 +486,8 @@ function buildTooltip(unit) {
       <div css={chartTooltipStyles}>
         <p>{datum.x}:</p>
         <p>
-          <em>Measurement</em>: {`${msmt.value} ${unit}`}
+          <em>Measurement</em>:{' '}
+          {`${msmt.value.toFixed(measurementPrecision)} ${unit}`}
           <br />
           {depth && (
             <>
@@ -590,10 +591,10 @@ function getCheckedStatus(numberSelected, children) {
   return status;
 }
 
-function getMean(values) {
+function getMean(values, precision) {
   const sum = values.reduce((a, b) => a + b, 0);
   const mean = sum / values.length;
-  return parseFloat(mean.toFixed(measurementPrecision));
+  return precision !== undefined ? parseFloat(mean.toFixed(precision)) : mean;
 }
 
 function getMedian(values) {
@@ -946,9 +947,7 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       mediumValues.add(record.medium);
 
       record.date = getDate(record);
-      record.measurement = parseFloat(
-        record.measurement.toFixed(measurementPrecision),
-      );
+      record.measurement = parseFloat(record.measurement);
       newMeasurements.push(record);
     });
 
@@ -990,8 +989,8 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
     newMsmts.forEach((msmt) => {
       if (msmt.year >= newDomain[0] && msmt.year <= newDomain[1]) {
         const dataPoint = {
-          // Map zero values to the lowest number afforded by the chosen precision
-          value: msmt.measurement || 1 * 10 ** (-1 * measurementPrecision),
+          // Map zero values to the lowest number possible
+          value: msmt.measurement || Number.EPSILON,
           depth: msmt.depth,
           depthUnit: msmt.depthUnit,
         };
@@ -1047,11 +1046,9 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       const newRange = [Math.min(...yValues), Math.max(...yValues)];
       setRange(newRange);
 
-      const newMean = getMean(yValues);
-
-      setMean(newMean);
+      setMean(getMean(yValues, measurementPrecision));
       setMedian(getMedian(yValues));
-      setStdDev(getStdDev(yValues, newMean));
+      setStdDev(getStdDev(yValues));
       setMsmtCount(yValues.length);
     },
     [fraction, medium, parseMeasurements, unit],

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -591,22 +591,19 @@ function getCheckedStatus(numberSelected, children) {
   return status;
 }
 
-function getMean(values, precision) {
+function getMean(values) {
   const sum = values.reduce((a, b) => a + b, 0);
-  const mean = sum / values.length;
-  return precision !== undefined ? parseFloat(mean.toFixed(precision)) : mean;
+  return sum / values.length;
 }
 
 function getMedian(values) {
   const sorted = [...values].sort((a, b) => a - b);
   const numValues = values.length;
-  let median = 0;
   if (numValues % 2 === 0) {
-    median = (sorted[numValues / 2 - 1] + sorted[numValues / 2]) / 2;
+    return (sorted[numValues / 2 - 1] + sorted[numValues / 2]) / 2;
   } else {
-    median = sorted[(numValues - 1) / 2];
+    return sorted[(numValues - 1) / 2];
   }
-  return parseFloat(median.toFixed(measurementPrecision));
 }
 
 function getStdDev(values, mean = null) {
@@ -614,8 +611,7 @@ function getStdDev(values, mean = null) {
   const sampleMean = mean ?? getMean(values);
   const tss = values.reduce((a, b) => a + (b - sampleMean) ** 2, 0);
   const variance = tss / (values.length - 1);
-  const stdDev = Math.sqrt(variance);
-  return parseFloat(stdDev.toFixed(measurementPrecision));
+  return Math.sqrt(variance);
 }
 
 function getTotalCount(charcs) {
@@ -1046,9 +1042,10 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
       const newRange = [Math.min(...yValues), Math.max(...yValues)];
       setRange(newRange);
 
-      setMean(getMean(yValues, measurementPrecision));
+      const newMean = getMean(yValues);
+      setMean(newMean);
       setMedian(getMedian(yValues));
-      setStdDev(getStdDev(yValues));
+      setStdDev(getStdDev(yValues, newMean));
       setMsmtCount(yValues.length);
     },
     [fraction, medium, parseMeasurements, unit],
@@ -1093,9 +1090,14 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
     infoText =
       'No measurements available to be charted for this characteristic.';
 
-  let average = mean?.toLocaleString('en-US');
+  let average = '';
+  if (mean)
+    average += toFixedFloat(mean, measurementPrecision).toLocaleString('en-US');
   if (stdDev)
-    average += ` ${String.fromCharCode(177)} ${stdDev.toLocaleString()}`;
+    average += ` ${String.fromCharCode(177)} ${toFixedFloat(
+      stdDev,
+      measurementPrecision,
+    ).toLocaleString()}`;
   average += ` ${displayUnit}`;
 
   return (
@@ -1245,7 +1247,10 @@ function CharacteristicChartSection({ charcName, charcsStatus, records }) {
                     },
                     {
                       label: 'Median Value',
-                      value: `${median.toLocaleString()} ${displayUnit}`,
+                      value: `${toFixedFloat(
+                        median,
+                        measurementPrecision,
+                      ).toLocaleString()} ${displayUnit}`,
                     },
                     {
                       label: 'Minimum Value',


### PR DESCRIPTION
## Related Issues:
* [HMW-485](https://jira.epa.gov/browse/HMW-485)

## Main Changes:
* Fixed a bug where measurements with zero values would cause the scatter plot on the Monitoring Report page to not show when using the logarithmic scale. This is due to the fact that log(0) is undefined, and XYChart chooses to not show the chart rather than drop the value.
  * This was fixed by simply converting zero values to `Number.EPSILON` (the smallest float that JavaScript can represent). This number is small enough that it won't affect other calculations, and it is rounded down to zero when it's displayed in the tooltip.
* Moved the chosen display precision to a global variable, to make it easy to change if the need arises.
* Updated some calculations to postpone rounding until the number is displayed.

## Steps To Test:
1. Go to http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-ANA21/.
2. In a separate tab, go to https://mywaterway.epa.gov/monitoring-report/STORET/CBP_WQX/CBP_WQX-ANA21/.
3. In both tabs, select "Ammonia" from the list of characteristics.
4. Select the "log" scale. This should not be displayed in the production application, but it should show on this branch.
5. On this branch, hover over the minimum value on the chart (it may help to adjust the date range). Confirm that the value displays as zero.
6. Compare the statistics shown to those displayed in the production application, and confirm that they match.