### PR TITLE
Bugfix/510 saving baton rouge fails

### DIFF
--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -599,7 +599,7 @@ async function processLayerFeatures(layer: __esri.Layer, adds: IFeature[]) {
     layer.graphics.forEach((graphic) => {
       adds.push({
         attributes: graphic.attributes,
-        geometry: graphic.geometry.toJSON(),
+        geometry: graphic.geometry?.toJSON(),
       });
     });
   } else if (isFeatureLayer(layer)) {
@@ -607,7 +607,7 @@ async function processLayerFeatures(layer: __esri.Layer, adds: IFeature[]) {
     features.features.forEach((feature) => {
       adds.push({
         attributes: feature.attributes,
-        geometry: feature.geometry.toJSON(),
+        geometry: feature.geometry?.toJSON(),
       });
     });
   }


### PR DESCRIPTION
## Related Issues:
* [HMW-510](https://jira.epa.gov/browse/HMW-510)

## Main Changes:
* Fixed issue of trying to save from baton rouge, la failing due to null geometry.

## Steps To Test:
1. Navigate to http://localhost:3000/community/baton%20rouge%20la/overview
2. Open the add/save data widget and go to the save panel
3. Verify that Waterbodies is toggled on
4. Save
5. Verify the save succeeds
