### PR TITLE
Bugfix/526 tribal map zoom

### DIFF
--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -875,14 +875,6 @@ function TribalMap({
             let zoomParams = fullExtent;
             let homeParams = { targetGeometry: fullExtent };
 
-            if (pointsExtent.count === 1) {
-              zoomParams = { target: fullExtent, zoom: 15 };
-              homeParams = {
-                targetGeometry: fullExtent,
-                scale: 18056, // same as zoom 15, viewpoint only takes scale
-              };
-            }
-
             mapView.when(() => {
               mapView.goTo(zoomParams).then(() => {
                 setMapLoading(false);


### PR DESCRIPTION
## Related Issues:
* [HMW-526](https://jira.epa.gov/browse/HMW-526)

## Main Changes:
* Removed a block of code from `TribalMapList.js` that increased the map zoom level when there was only one point waterbody feature. This was carried over from `StateMap.js`, where it is used to zoom to search results consisting of a single point.

## Steps To Test:
1. Go to http://localhost:3000/tribe/UTEMTN.
2. Verify that, after the map loads, all the boundaries and features associated with the tribe are shown in the map's extent.