### PR TITLE
Feature/532 siteimprove

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -610,7 +610,7 @@
           </button>
         </div>
       </div>
-      <div id="root"></div>
+      <div id="root" role="presentation"></div>
     </section>
 
     <footer class="main-footer clearfix" role="contentinfo">

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -75,7 +75,6 @@
       color="#ffffff"
     />
     <meta name="msapplication-TileColor" content="#2b5797" />
-    <meta name="theme-color" content="#ffffff" />
     <style>
       /* bootstrap style overrides */
       .epa-search .form-text {

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -45,7 +45,10 @@ const containerStyles = css`
 `;
 
 const switchContainerStyles = css`
-  margin-top: 0.5em;
+  margin-bottom: 0;
+  & > div {
+    margin-top: 0.5em;
+  }
 `;
 
 const centeredTextStyles = css`
@@ -59,6 +62,11 @@ const accordionContentStyles = css`
 const toggleStyles = css`
   display: flex;
   align-items: center;
+  margin-bottom: 0;
+
+  label {
+    margin-bottom: 0;
+  }
 
   span {
     margin-left: 0.5rem;
@@ -468,24 +476,19 @@ function IdentifiedIssues() {
           {cipSummary.status === 'fetching' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {getImpairedWatersPercent()}
               </span>
               <p css={keyMetricLabelStyles}>of Assessed Waters are impaired</p>
-              <div css={switchContainerStyles}>
-                <Switch
-                  checked={
-                    toggleIssuesChecked && cipSummary.status !== 'failure'
-                  }
-                  onChange={() => toggleSwitch('Toggle Issues Layer')}
-                  disabled={
-                    zeroPollutedWaterbodies || cipSummary.status === 'failure'
-                  }
-                  ariaLabel="Toggle Issues Layer"
-                />
-              </div>
-            </>
+              <Switch
+                checked={toggleIssuesChecked && cipSummary.status !== 'failure'}
+                onChange={() => toggleSwitch('Toggle Issues Layer')}
+                disabled={
+                  zeroPollutedWaterbodies || cipSummary.status === 'failure'
+                }
+              />
+            </label>
           )}
         </div>
 
@@ -493,7 +496,7 @@ function IdentifiedIssues() {
           {dischargersStatus === 'pending' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {dischargersStatus === 'failure'
                   ? 'N/A'
@@ -502,15 +505,12 @@ function IdentifiedIssues() {
               <p css={keyMetricLabelStyles}>
                 Dischargers with Significant Violations
               </p>
-              <div css={switchContainerStyles}>
-                <Switch
-                  checked={toggleDischargersChecked}
-                  onChange={() => toggleSwitch('Toggle Dischargers Layer')}
-                  disabled={zeroDischargers}
-                  ariaLabel="Toggle Dischargers Layer"
-                />
-              </div>
-            </>
+              <Switch
+                checked={toggleDischargersChecked}
+                onChange={() => toggleSwitch('Toggle Dischargers Layer')}
+                disabled={zeroDischargers}
+              />
+            </label>
           )}
         </div>
       </div>
@@ -624,16 +624,15 @@ function IdentifiedIssues() {
                                 <thead>
                                   <tr>
                                     <th>
-                                      <div css={toggleStyles}>
+                                      <label css={toggleStyles}>
                                         <Switch
                                           checked={showAllParameters}
                                           onChange={(_ev) => {
                                             toggleSwitch('Toggle All');
                                           }}
-                                          ariaLabel="Toggle all impairment categories"
                                         />
                                         <span>Identified Issues</span>
-                                      </div>
+                                      </label>
                                     </th>
                                     <th>% of Assessed Area</th>
                                   </tr>
@@ -659,13 +658,17 @@ function IdentifiedIssues() {
                                       // if service contains a parameter we have no mapping for
                                       if (!mappedParameter) return false;
 
+                                      const parameterLabelId = `${mappedParameter.label.replaceAll(
+                                        ' ',
+                                        '-',
+                                      )}-label`;
                                       return (
                                         <tr key={mappedParameter.label}>
                                           <td>
                                             <div css={toggleStyles}>
                                               <Switch
-                                                ariaLabel={
-                                                  mappedParameter.label
+                                                ariaLabelledBy={
+                                                  parameterLabelId
                                                 }
                                                 checked={
                                                   parameterToggleObject[
@@ -678,11 +681,13 @@ function IdentifiedIssues() {
                                                   );
                                                 }}
                                               />
-                                              <GlossaryTerm
-                                                term={mappedParameter.term}
-                                              >
-                                                {mappedParameter.label}
-                                              </GlossaryTerm>
+                                              <label id={parameterLabelId}>
+                                                <GlossaryTerm
+                                                  term={mappedParameter.term}
+                                                >
+                                                  {mappedParameter.label}
+                                                </GlossaryTerm>
+                                              </label>
                                             </div>
                                           </td>
                                           <td>

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -681,13 +681,13 @@ function IdentifiedIssues() {
                                                   );
                                                 }}
                                               />
-                                              <label id={parameterLabelId}>
+                                              <span id={parameterLabelId}>
                                                 <GlossaryTerm
                                                   term={mappedParameter.term}
                                                 >
                                                   {mappedParameter.label}
                                                 </GlossaryTerm>
-                                              </label>
+                                              </span>
                                             </div>
                                           </td>
                                           <td>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -25,7 +25,11 @@ import {
   squareIcon,
   waterwayIcon,
 } from 'components/shared/MapLegend';
-import { errorBoxStyles, infoBoxStyles, textBoxStyles } from 'components/shared/MessageBoxes';
+import {
+  errorBoxStyles,
+  infoBoxStyles,
+  textBoxStyles,
+} from 'components/shared/MessageBoxes';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
 import ViewOnMapButton from 'components/shared/ViewOnMapButton';
@@ -150,7 +154,10 @@ const subheadingStyles = css`
 `;
 
 const switchContainerStyles = css`
-  margin-top: 0.5em;
+  margin-bottom: 0;
+  & > div {
+    margin-top: 0.5em;
+  }
 `;
 
 const tableFooterStyles = css`
@@ -172,6 +179,7 @@ const tableFooterStyles = css`
 const toggleStyles = css`
   display: flex;
   align-items: center;
+  margin-bottom: 0;
 
   span {
     margin-left: 0.5rem;
@@ -377,46 +385,40 @@ function Monitoring() {
           {usgsStreamgages.status === 'pending' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {totalCurrentWaterConditions || 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Current Water Conditions</p>
-              <div css={switchContainerStyles}>
-                <Switch
-                  checked={
-                    Boolean(totalCurrentWaterConditions) &&
-                    currentWaterConditionsDisplayed
-                  }
-                  onChange={handleCurrentWaterConditionsToggle}
-                  disabled={!Boolean(totalCurrentWaterConditions)}
-                  ariaLabel="Current Water Conditions"
-                />
-              </div>
-            </>
+              <Switch
+                checked={
+                  Boolean(totalCurrentWaterConditions) &&
+                  currentWaterConditionsDisplayed
+                }
+                onChange={handleCurrentWaterConditionsToggle}
+                disabled={!Boolean(totalCurrentWaterConditions)}
+              />
+            </label>
           )}
         </div>
         <div css={keyMetricStyles}>
           {monitoringLocations.status === 'pending' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {monitoringLocations.data?.length || 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Past Water Conditions</p>
-              <div css={switchContainerStyles}>
-                <Switch
-                  checked={
-                    Boolean(monitoringLocations.data?.length) &&
-                    monitoringDisplayed
-                  }
-                  onChange={handlePastWaterConditionsToggle}
-                  disabled={!Boolean(monitoringLocations.data?.length)}
-                  ariaLabel="Past Water Conditions"
-                />
-              </div>
-            </>
+              <Switch
+                checked={
+                  Boolean(monitoringLocations.data?.length) &&
+                  monitoringDisplayed
+                }
+                onChange={handlePastWaterConditionsToggle}
+                disabled={!Boolean(monitoringLocations.data?.length)}
+              />
+            </label>
           )}
         </div>
       </div>
@@ -618,23 +620,22 @@ function CurrentConditionsTab({
             <tbody>
               <tr>
                 <td>
-                  <div css={toggleStyles}>
+                  <label css={toggleStyles}>
                     <Switch
                       checked={
                         streamgages.length > 0 && usgsStreamgagesDisplayed
                       }
                       onChange={handleUsgsSensorsToggle}
                       disabled={streamgages.length === 0}
-                      ariaLabel="USGS Sensors"
                     />
                     <span>USGS Sensors</span>
-                  </div>
+                  </label>
                 </td>
                 <td>{streamgages.length}</td>
               </tr>
               <tr>
                 <td>
-                  <div css={toggleStyles}>
+                  <label css={toggleStyles}>
                     <Switch
                       checked={
                         cyanWaterbodies.data?.length > 0 && cyanDisplayed
@@ -644,10 +645,9 @@ function CurrentConditionsTab({
                         cyanWaterbodies.status !== 'success' ||
                         cyanWaterbodies.data?.length === 0
                       }
-                      ariaLabel="CyAN Satellite Imagery"
                     />
                     <span>CyAN Satellite Imagery</span>
-                  </div>
+                  </label>
                 </td>
                 <td>{cyanWaterbodies.data?.length ?? 'N/A'}</td>
               </tr>
@@ -1218,14 +1218,10 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
               <thead>
                 <tr>
                   <th>
-                    <div css={toggleStyles}>
-                      <Switch
-                        checked={allToggled}
-                        onChange={toggleAll}
-                        ariaLabel="Toggle all monitoring locations"
-                      />
+                    <label css={toggleStyles}>
+                      <Switch checked={allToggled} onChange={toggleAll} />
                       <span>All Monitoring Locations</span>
-                    </div>
+                    </label>
                   </th>
                   <th colSpan="2">Location Count</th>
                   <th>Measurement Count</th>
@@ -1249,14 +1245,13 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                     return (
                       <tr key={group.label}>
                         <td>
-                          <div css={toggleStyles}>
+                          <label css={toggleStyles}>
                             <Switch
                               checked={group.toggled}
                               onChange={groupToggleHandlers?.[group.label]}
-                              ariaLabel={`Toggle ${group.label}`}
                             />
                             <span>{group.label}</span>
-                          </div>
+                          </label>
                         </td>
                         <td colSpan="2">{locationCount.toLocaleString()}</td>
                         <td>{measurementCount.toLocaleString()}</td>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -83,7 +83,10 @@ const modifiedErrorBoxStyles = css`
 `;
 
 const switchContainerStyles = css`
-  margin-top: 0.5em;
+  margin-bottom: 0;
+  & > div {
+    margin-top: 0.5em;
+  }
 `;
 
 const centeredTextStyles = css`
@@ -97,6 +100,11 @@ const accordionContentStyles = css`
 const toggleStyles = css`
   display: flex;
   align-items: center;
+  margin-bottom: 0;
+
+  label {
+    margin-bottom: 0;
+  }
 
   span {
     margin-left: 0.5rem;
@@ -217,22 +225,21 @@ function Overview() {
           cipSummary.status !== 'failure' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {Boolean(totalWaterbodies) && cipSummary.status === 'success'
                   ? totalWaterbodies.toLocaleString()
                   : 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Waterbodies</p>
-              <div css={switchContainerStyles}>
+              <div>
                 <Switch
                   checked={Boolean(totalWaterbodies) && waterbodiesDisplayed}
                   onChange={handleWaterbodiesToggle}
                   disabled={!Boolean(totalWaterbodies)}
-                  ariaLabel="Waterbodies"
                 />
               </div>
-            </>
+            </label>
           )}
         </div>
 
@@ -243,14 +250,14 @@ function Overview() {
           streamgagesStatus === 'pending' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {Boolean(totalMonitoringAndSensors)
                   ? totalMonitoringAndSensors
                   : 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Monitoring Locations</p>
-              <div css={switchContainerStyles}>
+              <div>
                 <Switch
                   checked={
                     Boolean(totalMonitoringAndSensors) &&
@@ -258,10 +265,9 @@ function Overview() {
                   }
                   onChange={handleMonitoringLocationsToggle}
                   disabled={!Boolean(totalMonitoringAndSensors)}
-                  ariaLabel="Monitoring Stations"
                 />
               </div>
-            </>
+            </label>
           )}
         </div>
 
@@ -269,14 +275,14 @@ function Overview() {
           {dischargersStatus === 'pending' ? (
             <LoadingSpinner />
           ) : (
-            <>
+            <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
                 {Boolean(totalPermittedDischargers)
                   ? totalPermittedDischargers
                   : 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Permitted Dischargers</p>
-              <div css={switchContainerStyles}>
+              <div>
                 <Switch
                   checked={
                     Boolean(totalPermittedDischargers) &&
@@ -284,10 +290,9 @@ function Overview() {
                   }
                   onChange={handlePermittedDischargersToggle}
                   disabled={!Boolean(totalPermittedDischargers)}
-                  ariaLabel="Permitted Dischargers"
                 />
               </div>
-            </>
+            </label>
           )}
         </div>
       </div>
@@ -682,23 +687,22 @@ function MonitoringAndSensorsTab({
               <tbody>
                 <tr>
                   <td>
-                    <div css={toggleStyles}>
+                    <label css={toggleStyles}>
                       <Switch
                         checked={
                           streamgages.length > 0 && usgsStreamgagesDisplayed
                         }
                         onChange={handleUsgsSensorsToggle}
                         disabled={streamgages.length === 0}
-                        ariaLabel="USGS Sensors"
                       />
                       <span>USGS Sensors</span>
-                    </div>
+                    </label>
                   </td>
                   <td>{streamgages.length}</td>
                 </tr>
                 <tr>
                   <td>
-                    <div css={toggleStyles}>
+                    <label css={toggleStyles}>
                       <Switch
                         checked={
                           monitoringLocations.length > 0 &&
@@ -706,10 +710,9 @@ function MonitoringAndSensorsTab({
                         }
                         onChange={handlePastWaterConditionsToggle}
                         disabled={monitoringLocations.length === 0}
-                        ariaLabel="Past Water Conditions"
                       />
                       <span>Past Water Conditions</span>
-                    </div>
+                    </label>
                   </td>
                   <td>{monitoringLocations.length}</td>
                 </tr>
@@ -1090,14 +1093,14 @@ function PermittedDischargersTab({
               <thead>
                 <tr>
                   <th>
-                    <div css={toggleStyles}>
+                    <label css={toggleStyles}>
                       <Switch
                         checked={allToggled}
                         onChange={toggleAll}
                         ariaLabel="Toggle all permit components"
                       />
                       <span>All Permit Components</span>
-                    </div>
+                    </label>
                   </th>
                   <th>Count</th>
                 </tr>
@@ -1113,6 +1116,10 @@ function PermittedDischargersTab({
                       const componentLabel = !component.label
                         ? 'Not Specified'
                         : component.label;
+                      const componentLabelId = `${key.replaceAll(
+                        ' ',
+                        '-',
+                      )}-label`;
 
                       return (
                         <tr key={key}>
@@ -1124,13 +1131,16 @@ function PermittedDischargersTab({
                                   groupToggleHandlers?.[component.label]
                                 }
                                 ariaLabel={`Toggle ${componentLabel}`}
+                                ariaLabelledBy={componentLabelId}
                               />
                               {componentLabel === 'Not Specified' ? (
-                                <span>Not Specified</span>
+                                <span id={componentLabelId}>Not Specified</span>
                               ) : (
-                                <GlossaryTerm term={componentLabel}>
-                                  {componentLabel}
-                                </GlossaryTerm>
+                                <label id={componentLabelId}>
+                                  <GlossaryTerm term={componentLabel}>
+                                    {componentLabel}
+                                  </GlossaryTerm>
+                                </label>
                               )}
                             </div>
                           </td>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -1136,11 +1136,11 @@ function PermittedDischargersTab({
                               {componentLabel === 'Not Specified' ? (
                                 <span id={componentLabelId}>Not Specified</span>
                               ) : (
-                                <label id={componentLabelId}>
+                                <span id={componentLabelId}>
                                   <GlossaryTerm term={componentLabel}>
                                     {componentLabel}
                                   </GlossaryTerm>
-                                </label>
+                                </span>
                               )}
                             </div>
                           </td>

--- a/app/client/src/components/shared/Accordion.tsx
+++ b/app/client/src/components/shared/Accordion.tsx
@@ -283,7 +283,7 @@ function AccordionItem({
       onBlur={(_ev) => removeHighlight()}
       role="listitem"
     >
-      <header
+      <div
         aria-label={ariaLabel}
         css={headerStyles}
         className="hmw-accordion-header"
@@ -320,7 +320,7 @@ function AccordionItem({
           className={`fa fa-angle-${isOpen ? 'down' : 'right'}`}
           aria-hidden="true"
         />
-      </header>
+      </div>
 
       <div
         style={

--- a/app/client/src/components/shared/GlossaryPanel.js
+++ b/app/client/src/components/shared/GlossaryPanel.js
@@ -258,7 +258,13 @@ function GlossaryPanel({ path }) {
             />
           )}
 
-          <ul css={listStyles} className="js-glossary-list" />
+          <ul
+            aria-labelledby="glossary-title"
+            css={listStyles}
+            className="js-glossary-list"
+            tabIndex="0"
+            role="listbox"
+          />
         </div>
       </div>
     </>

--- a/app/client/src/components/shared/GlossaryPanel.js
+++ b/app/client/src/components/shared/GlossaryPanel.js
@@ -263,7 +263,6 @@ function GlossaryPanel({ path }) {
             css={listStyles}
             className="js-glossary-list"
             tabIndex="0"
-            role="listbox"
           />
         </div>
       </div>

--- a/app/client/src/components/shared/Page.js
+++ b/app/client/src/components/shared/Page.js
@@ -141,7 +141,12 @@ const textStyles = css`
 `;
 
 const titleStyles = css`
-  padding: 0.375em;
+  background: none;
+  border: none;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  font-weight: normal;
   font-family: ${fonts.secondary};
   font-size: 1.5em;
   color: white;
@@ -356,8 +361,9 @@ function Page({ children }: Props) {
 
       <div css={bannerStyles}>
         <div css={textStyles}>
-          <span
+          <button
             css={titleStyles}
+            tabIndex="0"
             onClick={(_ev) => {
               if (dataDisplayed) setDataDisplayed(false);
               if (aboutDisplayed) setAboutDisplayed(false);
@@ -366,7 +372,7 @@ function Page({ children }: Props) {
             }}
           >
             How’s My Waterway?
-          </span>
+          </button>
 
           <p css={subtitleStyles}>
             Informing the conversation about your waters.

--- a/app/client/src/components/shared/Switch.tsx
+++ b/app/client/src/components/shared/Switch.tsx
@@ -5,6 +5,7 @@ type Props = {
   onChange: (checked: boolean) => void;
   disabled?: boolean;
   ariaLabel: string;
+  ariaLabelledBy?: string;
 };
 
 function Switch({
@@ -12,6 +13,7 @@ function Switch({
   onChange = () => {},
   disabled = false,
   ariaLabel = '',
+  ariaLabelledBy = undefined,
 }: Props) {
   return (
     <ReactSwitch
@@ -28,6 +30,7 @@ function Switch({
       height={12}
       disabled={disabled}
       aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       aria-checked={checked}
     />
   );

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -54,6 +54,10 @@
   z-index: 0;
 }
 
+.esri-scale-bar__label {
+  overflow: auto;
+}
+
 .esri-view-width-less-than-medium .esri-popup__main-container {
   width: 350px;
 }
@@ -181,6 +185,10 @@
 
 .esri-legend__message {
   display: none;
+}
+
+.esri-attribution__powered-by {
+  overflow: auto;
 }
 
 .hidden {


### PR DESCRIPTION
## Related Issues:
* [HMW-532](https://jira.epa.gov/browse/HMW-532)

## Main Changes:
* Addressed several of the Accessibility Issues flagged by SiteImprove. As noted in the corresponding task, I believe one issue is a false positive, and another will be fixed when the tab component is replaced v3.
  * One issue was present in the `Glossary` component: the scroll behavior just needed to be made more explicit by adding a `tabIndex` to the list container.
  * Another issue concerned clipped text in the Esri map. The suggested fix is included, but it was difficult to see the issue, so it may not be successful.
* Addressed several other accessibility issues flagged by Firefox. Most of these had to do with tying visible labels to switches.

## Steps To Test:
1. Tab into the glossary, and confirm that the `ul` element is focusable, and that the arrow keys scroll the list.
2. Ensure switches still operate and display as before.

## TODO:
- [ ] Check again after changes are deployed, to confirm the fixes are reflected in the SiteImprove report.
