### PR TITLE
Feature/543 547 549 text icon changes

### DIFF
--- a/app/client/src/components/pages/Community.Routes.CommunityIntro.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityIntro.js
@@ -131,11 +131,11 @@ function CommunityIntro() {
 
       <p css={topicStyles}>
         <span css={iconStyles}>
-          <img src={monitoringIcon} alt="Monitoring" />
+          <img src={monitoringIcon} alt="Water Monitoring" />
         </span>
 
         <span css={textStyles}>
-          <strong>Monitoring:</strong> &nbsp; View monitoring locations.
+          <strong>Water Monitoring:</strong> &nbsp; View monitoring locations.
         </span>
       </p>
 

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -254,7 +254,7 @@ function Overview() {
               <span css={keyMetricNumberStyles}>
                 {totalMonitoringAndSensors ? totalMonitoringAndSensors : 'N/A'}
               </span>
-              <p css={keyMetricLabelStyles}>Monitoring Locations</p>
+              <p css={keyMetricLabelStyles}>Water Monitoring Locations</p>
               <div>
                 <Switch
                   checked={
@@ -297,7 +297,7 @@ function Overview() {
         <Tabs onChange={handleTabClick}>
           <TabList>
             <Tab>Waterbodies</Tab>
-            <Tab>Monitoring Locations</Tab>
+            <Tab>Water Monitoring Locations</Tab>
             <Tab>Permitted Dischargers</Tab>
           </TabList>
 

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -201,6 +201,12 @@ const parameterStyles = css`
   }
 `;
 
+const tableStyles = css`
+  th {
+    vertical-align: middle !important;
+  }
+`;
+
 const dateCellStyles = css`
   @media (min-width: 25em) {
     white-space: nowrap;
@@ -1367,13 +1373,13 @@ function WaterbodyReport() {
                           ) : (
                             <>
                               <em>Links below open in a new browser tab.</em>
-                              <table className="table">
+                              <table className="table" css={tableStyles}>
                                 <thead>
                                   <tr>
                                     <th>Plan</th>
                                     <th>Impairments</th>
                                     <th>Type</th>
-                                    <th>Date</th>
+                                    <th>Completion Date</th>
                                   </tr>
                                 </thead>
                                 <tbody>

--- a/app/client/src/components/shared/GlossaryPanel.js
+++ b/app/client/src/components/shared/GlossaryPanel.js
@@ -45,6 +45,7 @@ const iconStyles = css`
   font-weight: 900;
   color: rgba(0, 113, 188, 0.5);
   margin-right: 0.25em;
+  padding-right: 0 !important;
 `;
 
 const panelStyles = css`

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -1177,7 +1177,11 @@ function ShowAddSaveDataWidget({
     >
       <span
         aria-hidden="true"
-        className="esri-icon-add-attachment"
+        className={
+          addSaveDataWidgetVisible
+            ? 'esri-icon-collapse'
+            : 'esri-icon-add-attachment'
+        }
         style={hover ? buttonHoverStyle : buttonStyle}
       />
     </div>
@@ -1464,14 +1468,31 @@ function ShowUpstreamWatershed({
 
   const upstreamWidgetDisabled = getUpstreamWidgetDisabled();
 
+  // This useEffect/watcher is here to ensure the correct title and icon 
+  // are being shown. Without this the icon/title don't change until
+  // the user moves the mouse off of the button.
+  const [watcher, setWatcher] = useState<IHandle | null>(null);
+  const [upstreamVisible, setUpstreamVisible] = useState(false);
+  useEffect(() => {
+    if(!upstreamLayer || watcher) return;
+
+    setWatcher(
+      reactiveUtils.watch(
+        () => upstreamLayer.visible,
+        () => setUpstreamVisible(upstreamLayer.visible),
+      )
+    );
+  }, [upstreamLayer, watcher]);
+
   if (!upstreamLayer) return null;
 
   let title = 'View Upstream Watershed';
   if (upstreamWidgetDisabled) title = 'Upstream Widget Not Available';
-  else if (upstreamLayer.visible) title = 'Hide Upstream Watershed';
+  else if (upstreamVisible) title = 'Hide Upstream Watershed';
   else if (selectionActive) title = 'Cancel Watershed Selection';
 
   let iconClass = 'esri-icon esri-icon-overview-arrow-top-left';
+  if (upstreamVisible) iconClass = 'esri-icon-collapse';
   if (upstreamLoading) iconClass = 'esri-icon-loading-indicator esri-rotating';
 
   return (

--- a/app/client/src/components/shared/SurroundingsWidget.tsx
+++ b/app/client/src/components/shared/SurroundingsWidget.tsx
@@ -196,13 +196,14 @@ function SurroundingsWidgetTrigger({
 }: SurroundingsWidgetTriggerProps) {
   const [hover, setHover] = useState(false);
 
-  const title = disabled
-    ? 'Surrounding Features Widget Not Available'
-    : 'Toggle Surrounding Features';
-
+  let title = 'Open Surrounding Features';
   let iconClass = 'esri-icon esri-icon-globe';
-  if (contentVisible) iconClass = 'esri-icon-collapse';
+  if (contentVisible) {
+    iconClass = 'esri-icon-collapse';
+    title = 'Close Surrounding Features';
+  }
   if (updating) iconClass = 'esri-icon-loading-indicator esri-rotating';
+  if (disabled) title = 'Surrounding Features Widget Not Available';
 
   if (!visible) return null;
 

--- a/app/client/src/components/shared/SurroundingsWidget.tsx
+++ b/app/client/src/components/shared/SurroundingsWidget.tsx
@@ -96,6 +96,7 @@ function SurroundingsWidget(props: SurroundingsWidgetProps) {
         </Portal>
       )}
       <SurroundingsWidgetTrigger
+        contentVisible={contentVisible}
         disabled={isEmpty(layers)}
         forwardedRef={triggerRef}
         onClick={toggleContentVisibility}
@@ -186,6 +187,7 @@ function Portal({ children, container }: PortalProps) {
 }
 
 function SurroundingsWidgetTrigger({
+  contentVisible,
   disabled,
   forwardedRef,
   onClick,
@@ -194,13 +196,13 @@ function SurroundingsWidgetTrigger({
 }: SurroundingsWidgetTriggerProps) {
   const [hover, setHover] = useState(false);
 
-  let title = disabled
+  const title = disabled
     ? 'Surrounding Features Widget Not Available'
     : 'Toggle Surrounding Features';
 
-  let iconClass = updating
-    ? 'esri-icon-loading-indicator esri-rotating'
-    : 'esri-icon esri-icon-globe';
+  let iconClass = 'esri-icon esri-icon-globe';
+  if (contentVisible) iconClass = 'esri-icon-collapse';
+  if (updating) iconClass = 'esri-icon-loading-indicator esri-rotating';
 
   if (!visible) return null;
 
@@ -361,6 +363,7 @@ type PortalProps = {
 };
 
 type SurroundingsWidgetTriggerProps = {
+  contentVisible: boolean;
   disabled: boolean;
   forwardedRef: MutableRefObject<HTMLDivElement | null>;
   onClick: (ev: MouseEvent | KeyboardEvent) => void;

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -383,7 +383,7 @@ function TribalMapList({
                   ? monitoringLocations.length
                   : 'N/A'}
               </span>
-              <p css={keyMetricLabelStyles}>Monitoring Locations</p>
+              <p css={keyMetricLabelStyles}>Water Monitoring Locations</p>
               <div css={switchContainerStyles}>
                 <Switch
                   checked={
@@ -403,7 +403,7 @@ function TribalMapList({
                     });
                   }}
                   disabled={!monitoringLocations.length}
-                  ariaLabel="Monitoring Stations"
+                  ariaLabel="Water Monitoring Stations"
                 />
               </div>
             </>
@@ -531,7 +531,7 @@ function TribalMapList({
           <Tabs>
             <TabList>
               <Tab css={largeTabStyles}>Waterbodies</Tab>
-              <Tab css={largeTabStyles}>Monitoring Locations</Tab>
+              <Tab css={largeTabStyles}>Water Monitoring Locations</Tab>
             </TabList>
             <TabPanels>
               <TabPanel>

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -360,7 +360,7 @@ const tabs = [
     },
   },
   {
-    title: 'Monitoring',
+    title: 'Water Monitoring',
     route: '/community/{urlSearch}/monitoring',
     icon: monitoringIcon,
     upper: <MonitoringUpper />,

--- a/app/cypress/e2e/community.Monitoring.cy.ts
+++ b/app/cypress/e2e/community.Monitoring.cy.ts
@@ -15,7 +15,7 @@ describe('Monitoring Tab', () => {
       'not.exist',
     );
 
-    cy.findByText('Monitoring').click();
+    cy.findByText('Water Monitoring').click();
     cy.findByRole('tab', { name: 'Past Water Conditions' }).click();
 
     // click Toggle All Monitoring Locations switch and check that all switches are toggled off
@@ -58,7 +58,7 @@ describe('Monitoring Tab', () => {
     );
 
     // navigate to the Past Water Conditions sub-tab
-    cy.findByRole('tab', { name: 'Monitoring' }).click();
+    cy.findByRole('tab', { name: 'Water Monitoring' }).click();
     cy.findByRole('tab', { name: 'Past Water Conditions' }).click();
 
     // turn off all switches
@@ -95,7 +95,7 @@ describe('Monitoring Tab', () => {
     );
 
     // navigate to the Past Water Conditions sub-tab
-    cy.findByRole('tab', { name: 'Monitoring' }).click();
+    cy.findByRole('tab', { name: 'Water Monitoring' }).click();
     cy.findByRole('tab', { name: 'Past Water Conditions' }).click();
 
     // turn off all switches
@@ -122,7 +122,7 @@ describe('Monitoring Tab', () => {
     );
     cy.findByText('Go').click();
 
-    cy.findByText('Monitoring').click();
+    cy.findByText('Water Monitoring').click();
 
     cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
       'not.exist',
@@ -154,7 +154,7 @@ describe('Monitoring Tab', () => {
 
     cy.findByText('Go').click();
 
-    cy.findByRole('tab', { name: 'Monitoring' }).click();
+    cy.findByRole('tab', { name: 'Water Monitoring' }).click();
 
     cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
       'not.exist',
@@ -202,7 +202,7 @@ describe('Monitoring Tab', () => {
 
     cy.findByText('Go').click();
 
-    cy.findByRole('tab', { name: 'Monitoring' }).click();
+    cy.findByRole('tab', { name: 'Water Monitoring' }).click();
 
     cy.findAllByTestId('hmw-loading-spinner', { timeout: 120000 }).should(
       'not.exist',

--- a/app/cypress/e2e/data.cy.ts
+++ b/app/cypress/e2e/data.cy.ts
@@ -27,7 +27,7 @@ describe('Data page', () => {
 
     // verify the page loads
     cy.findByText(
-      'pulls data from multiple databases at EPA and other federal agencies',
+      'retrieves data from various systems at the Environmental Protection Agency (EPA) and other federal agencies',
       { exact: false },
     );
 

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -19,7 +19,7 @@
       "linkHref": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
       "linkLabel": "CyAN Data/System",
       "shortName": "CyAN",
-      "siteLocation": "Information from CyAN can be found on the Community Page in the Monitoring Tab under current water conditions, CyAN Satellite Imagery.",
+      "siteLocation": "Information from CyAN can be found on the Community Page in the Water Monitoring tab under Current Water Conditions, CyAN Satellite Imagery.",
       "title": "Cyanobacteria Assessment Network (CyAN)"
     },
     {
@@ -49,7 +49,7 @@
       "linkHref": "https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/protected-areas",
       "linkLabel": "Protected Areas Data/System",
       "shortName": "Wild and Protected Areas",
-      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Protected Areas.",
+      "siteLocation": "Information from this database can be found on the Community page on the Protect tab under Watershed Health and Protection, Protected Areas.",
       "title": "Protected Areas"
     },
     {
@@ -69,7 +69,7 @@
       "linkHref": "https://waterdata.usgs.gov/nwis/rt",
       "linkLabel": "USGS Stream Gages Data/System",
       "shortName": "USGS Stream Gage",
-      "siteLocation": "Information from the USGS databases can be found on the Community page on the Overview tab under Monitoring Locations, Current Water Conditions, USGS Sensors and in the Monitoring Tab under current water conditions, USGS Sensors.",
+      "siteLocation": "Information from the USGS databases can be found on the Community page on the Overview tab under Water Monitoring Locations, Current Water Conditions, USGS Sensors and in the Water Monitoring tab under current water conditions, USGS Sensors.",
       "title": "USGS Sensors (USGS Stream Gages)"
     },
     {
@@ -79,7 +79,7 @@
       "linkHref": "https://www.waterqualitydata.us/",
       "linkLabel": "WQP Data/System",
       "shortName": "WQP",
-      "siteLocation": "Information from this database can be found on the Community page under the Overview tab under Monitoring Locations, Past Water Conditions, and on the Monitoring tab under Past Water Conditions, as well as on the Monitoring Report pages.",
+      "siteLocation": "Information from this database can be found on the Community page under the Overview tab under Water Monitoring Locations, Past Water Conditions, and on the Water Monitoring tab under Past Water Conditions, as well as on the Monitoring Report pages.",
       "title": "Water Quality Portal (WQP)"
     },
     {
@@ -99,7 +99,7 @@
       "linkHref": "https://www.epa.gov/wsio",
       "linkLabel": "WSIO Data/System",
       "shortName": "WSIO",
-      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Watershed Health Scores.",
+      "siteLocation": "Information from this database can be found on the Community page on the Protect tab under Watershed Health and Protection, Watershed Health Scores.",
       "title": "Watershed Index Online (WSIO)"
     },
     {
@@ -109,7 +109,7 @@
       "linkHref": "https://www.rivers.gov/",
       "linkLabel": "Wild and Scenic Rivers Data/System",
       "shortName": "Wild and Scenic Rivers",
-      "siteLocation": "Information from this database can be found on the Community page on the protect tab under Watershed Health and Protection, Wild and Scenic Rivers.",
+      "siteLocation": "Information from this database can be found on the Community page on the Protect tab under Watershed Health and Protection, Wild and Scenic Rivers.",
       "title": "Wild and Scenic Rivers"
     }
   ]


### PR DESCRIPTION
## Related Issues:
* [HMW-543](https://jira.epa.gov/browse/HMW-543)
* [HMW-547](https://jira.epa.gov/browse/HMW-547)
* [HMW-549](https://jira.epa.gov/browse/HMW-549)

## Main Changes:
* Updated map widgets to have the `>>` icon when the widgets are active.
  * I was a little hesitant to do this with the Upstream Watershed widget. I went ahead and did anyways to get some feedback.
* On the waterbody report page, changed the "Date" column to "Completion Date" to make it more clear what this date is. 
* Changed `Monitoring` to `Water Monitoring`. 
* Fixed an issue on the data page, where there was large right hand padding for the glossary icons. 
* On the data page, made casing for tab names consistent. Mostly we used upper case for calling out tab names, but sometimes we used lower case. Now we should have upper case for all callouts to tabs.
* Updated cypress tests to account for above changes.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Verify the widget icons change to `>>` when the widget is open. 
3. Navigate to http://localhost:3000/waterbody-report/21AWIC/AL03150110-0202-200/2020
4. In the Plans to Restore Water Quality section, verify the `Date` column was changed to `Completion Date`.
5. Click around through the app and verify `Monitoring` was changed to `Water Monitoring`. Note: This change was not done on the Monitoring Report page.
6. Navigate to http://localhost:3000/data
7. Verify the glossary term icons have a normal padding level like the rest of the app
8. Verify the text looks correct on (i.e., `Monitoring` changed to `Water Monitoring` and tab name callouts have consistent casing)
