### PR TITLE
Feature/492 save map pdf

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -18,6 +18,7 @@ import Home from '@arcgis/core/widgets/Home';
 import LayerList from '@arcgis/core/widgets/LayerList';
 import Legend from '@arcgis/core/widgets/Legend';
 import Point from '@arcgis/core/geometry/Point';
+import Print from '@arcgis/core/widgets/Print.js';
 import PortalBasemapsSource from '@arcgis/core/widgets/BasemapGallery/support/PortalBasemapsSource';
 import * as query from '@arcgis/core/rest/query';
 import ScaleBar from '@arcgis/core/widgets/ScaleBar';
@@ -903,6 +904,32 @@ function MapWidgets({
     fullScreenWidgetCreated,
   ]);
 
+  // create download widget
+  const downloadWidget = useMemo(() => {
+    if (!view) return null;
+    const container = document.createElement('div');
+    container.style.width = '50%';
+    const downloadContent = new Print({ view, container, label: 'sfasdfsdf' });
+
+    return new Expand({
+      expandIconClass: 'esri-icon-download',
+      expandTooltip: 'Open Download Widget',
+      collapseTooltip: 'Close Download Widget',
+      view,
+      mode: 'floating',
+      autoCollapse: true,
+      content: downloadContent,
+    });
+  }, [view]);
+
+  useEffect(() => {
+    if (downloadWidget)
+      view?.ui.add(downloadWidget, { position: 'top-right', index: 3 });
+    return function cleanup() {
+      if (downloadWidget) view?.ui.remove(downloadWidget);
+    };
+  }, [downloadWidget, view]);
+
   // watch for location changes and disable/enable the upstream widget accordingly
   // widget should only be displayed on Tribal page or valid Community page location
   useEffect(() => {
@@ -1000,7 +1027,7 @@ function MapWidgets({
 
     render(widget, node);
     setUpstreamWidget(node); // store the widget in context so it can be shown or hidden later
-    view.ui.add(node, { position: 'top-right', index: 3 });
+    view.ui.add(node, { position: 'top-right', index: 4 });
 
     return function cleanup() {
       view?.ui.remove(node);

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -922,6 +922,7 @@ function MapWidgets({
     });
   }, [view]);
 
+  // add the download widget
   useEffect(() => {
     if (downloadWidget)
       view?.ui.add(downloadWidget, { position: 'top-right', index: 3 });

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -912,6 +912,7 @@ function MapWidgets({
     const printContent = new Print({
       view,
       container,
+      printServiceUrl: services.data.printService,
     });
 
     return new Expand({

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -912,7 +912,6 @@ function MapWidgets({
     const printContent = new Print({
       view,
       container,
-      printServiceUrl: services.data.printService,
     });
 
     return new Expand({

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -906,10 +906,13 @@ function MapWidgets({
 
   // create download widget
   const downloadWidget = useMemo(() => {
-    if (!view) return null;
+    if (!view || services.status !== 'success') return null;
     const container = document.createElement('div');
-    container.style.width = '50%';
-    const downloadContent = new Print({ view, container, label: 'sfasdfsdf' });
+    const downloadContent = new Print({
+      view,
+      container,
+      // printServiceUrl: `${services.data.printService}`,
+    });
 
     return new Expand({
       expandIconClass: 'esri-icon-download',
@@ -920,7 +923,7 @@ function MapWidgets({
       autoCollapse: true,
       content: downloadContent,
     });
-  }, [view]);
+  }, [services, view]);
 
   // add the download widget
   useEffect(() => {

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -8,7 +8,7 @@
   background-color: white;
 }
 
-.esri-widget--panel,
+.hmw-map-layers,
 .esri-view .esri-basemap-gallery {
   min-width: 200px;
   max-width: 200px;
@@ -43,6 +43,12 @@
   border-bottom: none;
   line-height: 1;
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
+}
+
+.esri-print__header-title {
+  font-size: 1.25em;
+  font-weight: 500;
+  line-height: 1.2;
 }
 
 .esri-layer-list__item-title {

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -63,6 +63,7 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
+  "printService": "https://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -383,6 +384,11 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
+    },
+    {
+      "urlLookup": "printService",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "print service"
     }
   ]
 }

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -63,7 +63,6 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
-  "printService": "https://gispub.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -384,11 +383,6 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
-    },
-    {
-      "urlLookup": "printService",
-      "wildcardUrl": "{urlLookup}*",
-      "name": "print service"
     }
   ]
 }

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -63,6 +63,7 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
+  "printService": "https://gispub.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -383,6 +384,11 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
+    },
+    {
+      "urlLookup": "printService",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "print service"
     }
   ]
 }

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -63,6 +63,7 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
+  "printService": "https://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -383,6 +384,11 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
+    },
+    {
+      "urlLookup": "printService",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "print service"
     }
   ]
 }

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -63,7 +63,6 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
-  "printService": "https://gispub.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -384,11 +383,6 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
-    },
-    {
-      "urlLookup": "printService",
-      "wildcardUrl": "{urlLookup}*",
-      "name": "print service"
     }
   ]
 }

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -63,6 +63,7 @@
     "properties": "https://cyan.epa.gov/waterbody/properties",
     "waterbodies": "https://services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0"
   },
+  "printService": "https://gispub.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer",
   "googleAnalyticsMapping": [
     {
       "urlLookup": "attains.serviceUrl",
@@ -383,6 +384,11 @@
       "urlLookup": "cyan.dataDownload",
       "wildcardUrl": "{urlLookup}/*",
       "name": "CyAN - data download"
+    },
+    {
+      "urlLookup": "printService",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "print service"
     }
   ]
 }


### PR DESCRIPTION
## Related Issues:
* [HMW-492](https://jira.epa.gov/browse/HMW-492)

## Main Changes:
* Added a ESRI's print widget to the map.
  * I tested using EPA's print service (https://gispub.epa.gov/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task), but each time a _504 Gateway Time-out_ was returned. Per a previous discussion, using ESRI's default print service should not be an issue unless it is heavily abused.

## Steps To Test:
1. Navigate to any page with a map.
2. Open the print/download widget.
3. Test the various options, and confirm the "Layout" and "Map only" options export correctly.