### PR TITLE
Bugfix/545 detailed uses issues

### DIFF
--- a/app/client/src/components/shared/GlossaryPanel.js
+++ b/app/client/src/components/shared/GlossaryPanel.js
@@ -52,7 +52,7 @@ const panelStyles = css`
   position: fixed;
   z-index: 1001;
   top: 0;
-  right: 0;
+  right: -22.375rem;
   overflow-y: auto;
   width: 22rem;
   height: 100%;
@@ -60,8 +60,8 @@ const panelStyles = css`
   box-shadow: -0.375em -0.375em 0.625em -0.375em ${colors.black(0.25)};
   transition: right 0.2s;
 
-  &[aria-hidden='true'] {
-    right: -22.375rem;
+  &[aria-hidden='false'] {
+    right: 0;
   }
 
   @media (max-width: 400px) {

--- a/app/client/src/components/shared/HelpTooltip.tsx
+++ b/app/client/src/components/shared/HelpTooltip.tsx
@@ -3,7 +3,7 @@ import { TooltipPopup, useTooltip } from '@reach/tooltip';
 import { css } from 'styled-components/macro';
 // styles
 import '@reach/tooltip/styles.css';
-import { colors } from 'styles';
+import { colors, iconButtonStyles } from 'styles';
 // types
 import type { Position } from '@reach/tooltip';
 import type { ReactElement, ReactNode, Ref } from 'react';
@@ -15,14 +15,9 @@ const helpIconStyles = css`
   cursor: help;
 `;
 
-const tooltipIconStyles = css`
-  background: none;
-  border: none;
-  color: inherit;
+const modifiedIconButtonStyles = css`
+  ${iconButtonStyles}
   cursor: unset !important;
-  margin: 0;
-  outline: inherit;
-  padding: 0;
 `;
 
 const tooltipStyles = css`
@@ -94,7 +89,7 @@ function HelpTooltip({
   return (
     <Tooltip label={label} triggerRef={triggerRef}>
       <button
-        css={tooltipIconStyles}
+        css={modifiedIconButtonStyles}
         onClick={(_ev) => triggerRef.current?.focus()}
         ref={triggerRef}
       >

--- a/app/client/src/components/shared/Modal.tsx
+++ b/app/client/src/components/shared/Modal.tsx
@@ -4,7 +4,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 // types
 import type { ReactNode } from 'react';
 // styles
-import { colors } from 'styles/index.js';
+import { colors, iconButtonStyles } from 'styles/index.js';
 
 const buttonContainerStyles = css`
   margin-top: 15px;
@@ -225,7 +225,13 @@ export function DisclaimerModal({
       label="Disclaimer"
       triggerElm={
         infoIcon ? (
-          <i css={helpIconStyles} className="fas fa-question-circle"></i>
+          <button aria-label="Disclaimer" css={iconButtonStyles}>
+            <i
+              aria-hidden
+              css={helpIconStyles}
+              className="fas fa-question-circle"
+            ></i>
+          </button>
         ) : (
           <button
             css={disclaimerButtonStyles}

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -59,6 +59,7 @@ import {
   colors,
   disclaimerStyles,
   fonts,
+  iconButtonStyles,
   iconStyles,
   modifiedTableStyles,
   tableStyles,
@@ -135,11 +136,6 @@ function labelValue(
 /*
 ## Styles
 */
-const detailedUsesIconStyles = css`
-  margin-right: 0.25rem;
-  color: #485566;
-`;
-
 const linkSectionStyles = css`
   p {
     padding-bottom: 1.5em;
@@ -148,6 +144,12 @@ const linkSectionStyles = css`
   small {
     display: inline-block;
   }
+`;
+
+const modifiedIconButtonStyles = css`
+  ${iconButtonStyles}
+  margin-right: 0.25rem;
+  color: #485566;
 `;
 
 const popupContainerStyles = css`
@@ -629,15 +631,19 @@ function WaterbodyInfo({
                             maxWidth="35rem"
                             onClose={() => setSelectedUseField(null)}
                             triggerElm={
-                              <i
-                                className="fas fa-info-circle"
-                                css={detailedUsesIconStyles}
-                                title={`View detailed uses for ${useField.label}`}
-                                onClick={() => {
-                                  setSelectedUseField(useField);
-                                  fetchDetailedUses();
-                                }}
-                              ></i>
+                              <button
+                                aria-label={`View detailed uses for ${useField.label}`}
+                                css={modifiedIconButtonStyles}
+                              >
+                                <i
+                                  aria-hidden
+                                  className="fas fa-info-circle"
+                                  onClick={() => {
+                                    setSelectedUseField(useField);
+                                    fetchDetailedUses();
+                                  }}
+                                ></i>
+                              </button>
                             }
                           >
                             {useAttainments.status === 'fetching' && (
@@ -646,10 +652,7 @@ function WaterbodyInfo({
 
                             {selectedUseField &&
                               useAttainments.status === 'success' && (
-                                <table
-                                  css={modalTableStyles}
-                                  className="table"
-                                >
+                                <table css={modalTableStyles} className="table">
                                   <thead>
                                     <tr>
                                       <th>

--- a/app/client/src/styles/index.js
+++ b/app/client/src/styles/index.js
@@ -55,6 +55,15 @@ const downloadLinksStyles = css`
   }
 `;
 
+const iconButtonStyles = css`
+  background: none;
+  border: none;
+  color: inherit;
+  margin: 0;
+  outline: inherit;
+  padding: 0;
+`;
+
 const iconStyles = css`
   margin-right: 5px;
 `;
@@ -143,6 +152,7 @@ export {
   disclaimerStyles,
   downloadLinksStyles,
   fonts,
+  iconButtonStyles,
   iconStyles,
   modifiedTableStyles,
   reactSelectStyles,


### PR DESCRIPTION
## Related Issues:
* [HMW-545](https://jira.epa.gov/browse/HMW-545)

## Main Changes:
* Fixed issue of glossary being re-opened when closing the detailed uses modal.
  * Note: This was caused by radix-ui. Radix-ui uses the `aria-hidden` package, which when called removes the `aria-hidden` attribute from the glossary panel, instead of setting it to true. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/blacksburg,%20va/overview
2. Open one of the waterbodies
3. Click on one of the glossary items
4. Click on one of the detailed use buttons (i.e., info icons)
5. Verify the glossary is closed and the modal is opened
6. Close the modal
7. Verify the glossary does not open back up
    * Note: If you repeat the above steps on the dev site, the glossary will be visible and show all terms.
8. Verify other usages of the glossary still works correctly
