### PR TITLE
Feature/555 add cyan to overview

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -404,8 +404,18 @@
         });
 
         window.addEventListener('error', function (event) {
+          if (
+            event.message ===
+              'ResizeObserver loop completed with undelivered notifications.' ||
+            event.message === 'ResizeObserver loop limit exceeded'
+          ) {
+            event.stopImmediatePropagation();
+            return;
+          }
           window.logToGa('send', 'exception', {
-            exDescription: `${event.error.message}${event.error.stack}`,
+            exDescription: event.error
+              ? `${event.error.message}${event.error.stack}`
+              : event.message,
             exFatal: true,
           });
 

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -596,7 +596,7 @@ function CurrentConditionsTab({
           <div css={legendItemsStyles}>
             <span>
               {waterwayIcon({ color: '#6c95ce' })}
-              &nbsp;CyAN Satellite Imagery&nbsp;
+              &nbsp;Harmful Algal Blooms (HABs)&nbsp;
             </span>
             <span>
               {squareIcon({ color: '#fffe00' })}
@@ -640,7 +640,7 @@ function CurrentConditionsTab({
                         cyanWaterbodies.length === 0
                       }
                     />
-                    <span>CyAN Satellite Imagery</span>
+                    <span>Harmful Algal Blooms (HABs)</span>
                   </label>
                 </td>
                 <td>{cyanWaterbodies.length ?? 'N/A'}</td>
@@ -1017,10 +1017,6 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
       ? displayedLocations.sort((a, b) => {
           if (sortBy === 'totalMeasurements') {
             return b.totalMeasurements - a.totalMeasurements;
-          }
-
-          if (sortBy === 'siteId') {
-            return a.siteId.localeCompare(b.siteId);
           }
 
           return a[sortBy].localeCompare(b[sortBy]);

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -140,7 +140,7 @@ function Overview() {
 
   const [waterbodiesDisplayed, setWaterbodiesDisplayed] = useState(true);
 
-  const [cyanDisplayed, setCyanDisplayed] = useState(true);
+  const [cyanDisplayed, setCyanDisplayed] = useState(false);
 
   const [monitoringLocationsDisplayed, setMonitoringLocationsDisplayed] =
     useState(false);
@@ -185,6 +185,7 @@ function Overview() {
       setMonitoringLocationsDisplayed(checked);
       setCyanDisplayed(checked);
       updateVisibleLayers({
+        cyanLayer: checked,
         usgsStreamgagesLayer: checked,
         monitoringLocationsLayer: checked,
       });
@@ -292,7 +293,7 @@ function Overview() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {totalPermittedDischargers ? totalPermittedDischargers : 'N/A'}
+                {totalPermittedDischargers ?? 'N/A'}
               </span>
               <p css={keyMetricLabelStyles}>Permitted Dischargers</p>
               <div>

--- a/app/client/src/components/shared/MessageBoxes.js
+++ b/app/client/src/components/shared/MessageBoxes.js
@@ -3,10 +3,7 @@
 import { css } from 'styled-components/macro';
 
 const boxStyles = css`
-  padding-top: 0.5em !important;
-  padding-bottom: 0.5em !important;
-  padding-left: 0.75em !important;
-  padding-right: 0.75em !important;
+  padding: 0.5em 0.75em !important;
   border-width: 1px;
   border-style: solid;
   border-radius: 0.25em;

--- a/app/client/src/components/shared/MessageBoxes.js
+++ b/app/client/src/components/shared/MessageBoxes.js
@@ -3,7 +3,10 @@
 import { css } from 'styled-components/macro';
 
 const boxStyles = css`
-  padding: 0.5em 0.75em !important;
+  padding-top: 0.5em !important;
+  padding-bottom: 0.5em !important;
+  padding-left: 0.75em !important;
+  padding-right: 0.75em !important;
   border-width: 1px;
   border-style: solid;
   border-radius: 0.25em;

--- a/app/client/src/components/shared/MessageBoxes.js
+++ b/app/client/src/components/shared/MessageBoxes.js
@@ -3,7 +3,7 @@
 import { css } from 'styled-components/macro';
 
 const boxStyles = css`
-  padding: 0.5em 0.75em;
+  padding: 0.5em 0.75em !important;
   border-width: 1px;
   border-style: solid;
   border-radius: 0.25em;

--- a/app/client/src/components/shared/VirtualizedList.tsx
+++ b/app/client/src/components/shared/VirtualizedList.tsx
@@ -86,7 +86,7 @@ function VirtualizedListInner({ items, renderer }: Props) {
       const { offsetTop } = outerRef.current || { offsetTop: 0 };
 
       const scrollPosition =
-        window['pageYOffset'] ||
+        window['scrollY'] ||
         document.documentElement['scrollTop'] ||
         document.body['scrollTop'] ||
         0;
@@ -117,7 +117,7 @@ function VirtualizedListInner({ items, renderer }: Props) {
       }}
     >
       {({ index, style }) => (
-        <div style={{ ...style, overflowX: 'hidden' }}>
+        <div style={style}>
           <RowRenderer
             listId={listId}
             index={index}

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -640,10 +640,7 @@ function WaterbodyInfo({
 
                             {selectedUseField &&
                               useAttainments.status === 'success' && (
-                                <table
-                                  css={modalTableStyles}
-                                  className="table"
-                                >
+                                <table css={modalTableStyles} className="table">
                                   <thead>
                                     <tr>
                                       <th>
@@ -1740,6 +1737,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
         });
       })
       .catch((err) => {
+        if (isAbort(err)) return;
         console.error(err);
         setCellConcentration({
           status: 'failure',
@@ -1820,6 +1818,10 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
     const propsPromise = fetcher(propertiesUrl, abortController.signal);
     Promise.all([imagePromise, propsPromise])
       .then(([blob, propsRes]) => {
+        if (blob.type !== 'image/png') {
+          setImageStatus('idle');
+          return;
+        }
         // read the image blob to convert it to base64
         const reader = new FileReader();
         reader.readAsDataURL(blob);


### PR DESCRIPTION
## Related Issues:
* [HMW-555](https://jira.epa.gov/browse/HMW-555)

## Main Changes:
* Added CyAN content to the Community page's _Overview_ tab.
* Added a `ResizeObserver` to the `VirtualizedList` component to address rows with dynamically-sized content.
  * This addition caused many errors with the message "ResizeObserver loop completed with undelivered notifications" or "ResizeObserver loop limit exceeded", which have not been thrown with other instances of `ResizeObserver` in the app. This is due to the rate at which elements in the virtualized list are added to the observation list: the errors are triggered when `ResizeObserver` sends multiple messages inside a single animation frame, fearing an infinite loop, which is not the case here. As stated by the author (https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded#comment86691361_49384120 and https://github.com/WICG/resize-observer/issues/38), this error is usually benign and can be ignored.
* Fixed some style issues in the popups.
* Changed the text 'CyAN Satellite Imagery' to 'Harmful Algal Blooms (HABs)'.

## Steps To Test:
1. Navigate to http://localhost:3000/community/lake%20okeechobee/overview.
2. Open the _Water Monitoring Locations_ tab, and confirm that the CyAN layer toggles on (and is visible), along with the other monitoring layers.
3. Expand the Lake Okeechobee CyAN list item, and confirm that all content is visible without scrolling in the accordion item.
4. Confirm the proper text changes were made in this tab and in the "Current Water Conditions" of the _Water Monitoring_ tab.

## TODO:
- [ ] We should wait to hear back about the proper text changes before merging this in. While the email states the change should be "Harmful Algal Blooms (HABs)", "Potentially Harmful Algal Blooms (HABs)" was discussed in a recent meeting, along with other potential changes.
