### PR TITLE
Feature/560 change cyanobacteria

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -162,7 +162,7 @@
         'drinking-water': "How's My Waterway - Explore - Drinking Water",
         attains: "How's My Waterway - ATTAINS",
         educators: "How's My Waterway - Educators",
-        'monitoring-report': "How's My Waterway - Monitoring Report",
+        'monitoring-report': "How's My Waterway - Water Monitoring Report",
       };
 
       const descriptionMapping = {
@@ -185,7 +185,7 @@
         educators:
           'Find How’s My Waterway resources for educators including lesson plans and other materials.',
         'monitoring-report':
-          'Use the monitoring report page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
+          'Use the water monitoring report page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
       };
 
       // update page title and description using mapping

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -574,7 +574,7 @@ function CurrentConditionsTab({
           <div css={legendItemsStyles}>
             <span>
               {waterwayIcon({ color: '#6c95ce' })}
-              &nbsp;Harmful Algal Blooms (HABs)&nbsp;
+              &nbsp;Potential Harmful Algal Blooms (HABs)&nbsp;
             </span>
             <span>
               {squareIcon({ color: '#fffe00' })}
@@ -618,7 +618,7 @@ function CurrentConditionsTab({
                         cyanWaterbodies.length === 0
                       }
                     />
-                    <span>Harmful Algal Blooms (HABs)</span>
+                    <span>Potential Harmful Algal Blooms (HABs)</span>
                   </label>
                 </td>
                 <td>{cyanWaterbodies.length ?? 'N/A'}</td>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -555,11 +555,10 @@ function CurrentConditionsTab({
                     Areas highlighted light blue are the lakes, reservoirs, and
                     other large waterbodies where CyAN satellite imagery data is
                     available. Daily data are a snapshot of{' '}
-                    <GlossaryTerm term="Cyanobacteria">
-                      cyanobacteria
+                    <GlossaryTerm term="Blue-Green Algae">
+                      blue-green algae
                     </GlossaryTerm>{' '}
-                    (sometimes referred to as blue-green algae) at the time of
-                    detection.
+                    at the time of detection.
                   </span>
 
                   <span css={showLessMoreStyles}>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -553,8 +553,8 @@ function CurrentConditionsTab({
                 <>
                   <span css={showLessMoreStyles}>
                     Areas highlighted light blue are the lakes, reservoirs, and
-                    other large waterbodies where CyAN satellite imagery data is
-                    available. Daily data are a snapshot of{' '}
+                    other large waterbodies where potential harmful algal bloom
+                    data is available. Daily data are a snapshot of{' '}
                     <GlossaryTerm term="Blue-Green Algae">
                       blue-green algae
                     </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -1253,15 +1253,11 @@ function PermittedDischargersTab({
                                 }
                                 ariaLabelledBy={componentLabelId}
                               />
-                              {componentLabel === 'Not Specified' ? (
-                                <span id={componentLabelId}>Not Specified</span>
-                              ) : (
-                                <span id={componentLabelId}>
-                                  <GlossaryTerm term={componentLabel}>
-                                    {componentLabel}
-                                  </GlossaryTerm>
-                                </span>
-                              )}
+                              <span id={componentLabelId}>
+                                <GlossaryTerm term={componentLabel}>
+                                  {componentLabel}
+                                </GlossaryTerm>
+                              </span>
                             </div>
                           </td>
                           <td>{component.dischargers.length}</td>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -738,11 +738,10 @@ function MonitoringAndSensorsTab({
                       Areas highlighted light blue are the lakes, reservoirs,
                       and other large waterbodies where CyAN satellite imagery
                       data is available. Daily data are a snapshot of{' '}
-                      <GlossaryTerm term="Cyanobacteria">
-                        cyanobacteria
+                      <GlossaryTerm term="Blue-Green Algae">
+                        blue-green algae
                       </GlossaryTerm>{' '}
-                      (sometimes referred to as blue-green algae) at the time of
-                      detection.
+                      at the time of detection.
                     </span>
                     <span css={showLessMoreStyles}>
                       Click on each monitoring location on the map or in the

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -736,8 +736,8 @@ function MonitoringAndSensorsTab({
                     </span>
                     <span css={showLessMoreStyles}>
                       Areas highlighted light blue are the lakes, reservoirs,
-                      and other large waterbodies where CyAN satellite imagery
-                      data is available. Daily data are a snapshot of{' '}
+                      and other large waterbodies where potential harmful algal
+                      bloom data is available. Daily data are a snapshot of{' '}
                       <GlossaryTerm term="Blue-Green Algae">
                         blue-green algae
                       </GlossaryTerm>{' '}

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -416,7 +416,7 @@ function MonitoringAndSensorsTab({
 
   const [expandedRows, setExpandedRows] = useState([]);
 
-  // if any of the "USGS Sensors", "Harmful Algal Blooms", or "Past Water Conditions" switches
+  // if any of the "USGS Sensors", "Potential Harmful Algal Blooms", or "Past Water Conditions" switches
   // are turned on, or if all switches are turned off, keep the "Water Monitoring
   // Locations" switch in sync
   useEffect(() => {
@@ -709,7 +709,7 @@ function MonitoringAndSensorsTab({
               </span>
               <span>
                 {waterwayIcon({ color: '#6c95ce' })}
-                &nbsp;Harmful Algal Blooms (HABs)&nbsp;
+                &nbsp;Potential Harmful Algal Blooms (HABs)&nbsp;
               </span>
             </div>
 
@@ -833,7 +833,7 @@ function MonitoringAndSensorsTab({
                         onChange={handleHarmfulAlgalBloomsToggle}
                         disabled={cyanWaterbodies.length === 0}
                       />
-                      <span>Harmful Algal Blooms (HABs)</span>
+                      <span>Potential Harmful Algal Blooms (HABs)</span>
                     </label>
                   </td>
                   <td>{cyanWaterbodies.length}</td>

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -1920,7 +1920,7 @@ function MonitoringReportContent() {
 
   const noSiteView = (
     <Page>
-      <NavBar title="Monitoring Report" />
+      <NavBar title="Water Monitoring Report" />
 
       <div css={containerStyles}>
         <div css={pageErrorBoxStyles}>
@@ -1950,7 +1950,7 @@ function MonitoringReportContent() {
 
   const twoColumnView = (
     <Page>
-      <NavBar title="Monitoring Report" />
+      <NavBar title="Water Monitoring Report" />
       <div css={containerStyles} data-content="container">
         <WindowSize>
           {({ width, height }) => {

--- a/app/client/src/components/shared/MapLegend.js
+++ b/app/client/src/components/shared/MapLegend.js
@@ -320,7 +320,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
         <div css={imageContainerStyles}>
           {waterwayIcon({ color: '#6c95ce' })}
         </div>
-        <span css={labelStyles}>CyAN Satellite Imagery</span>
+        <span css={labelStyles}>Potential Harmful Algal Blooms (HABs)</span>
       </div>
     </li>
   );

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -785,15 +785,17 @@ function WaterbodyInfo({
           },
           {
             label: 'Permit Components',
-            value: attributes.PermitComponents
-              ? attributes.PermitComponents.split(', ')
-                  .sort()
-                  .map((term: string) => (
-                    <GlossaryTerm key={term} term={term}>
-                      {term}
-                    </GlossaryTerm>
-                  ))
-              : 'Not Specified',
+            value: attributes.PermitComponents ? (
+              attributes.PermitComponents.split(', ')
+                .sort()
+                .map((term: string) => (
+                  <GlossaryTerm key={term} term={term}>
+                    {term}
+                  </GlossaryTerm>
+                ))
+            ) : (
+              <GlossaryTerm term="Not Specified">Not Specified</GlossaryTerm>
+            ),
           },
           {
             label: 'Significant Effluent Violation within the last 3 years',

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1591,8 +1591,8 @@ function CyanDailyContent({
     return (
       <>
         <p css={subheadingStyles}>
-          Cyanobacteria Concentration Histogram and Maximum for Selected Date:{' '}
-          {formatDate(epochDate)}
+          Blue-Green Algae Concentration Histogram and Maximum for Selected
+          Date: {formatDate(epochDate)}
         </p>
 
         {histogramData && (
@@ -1623,7 +1623,7 @@ function CyanDailyContent({
               {
                 label: (
                   <>
-                    <HelpTooltip label="Maximum detected cyanobacteria concentration in the satellite image area shown on map." />
+                    <HelpTooltip label="Maximum detected blue-green algae concentration in the satellite image area shown on map." />
                     &nbsp;&nbsp; Maximum Value
                   </>
                 ),
@@ -2112,9 +2112,9 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                 <StackedColumnChart
                   categories={barChartData.categories}
                   exportFilename="CyAN_StackedBarChart"
-                  legendTitle="Cyanobacteria Concentration Categories:"
+                  legendTitle="Blue-Green Algae Concentration Categories:"
                   series={barChartData.series}
-                  title={`Daily Cyanobacteria Estimates for ${attributes.GNIS_NAME}`}
+                  title={`Daily Blue-Green Algae Estimates for ${attributes.GNIS_NAME}`}
                   subtitle={`
                     Total Satellite Image Area: ${pixelArea}
                     <br />
@@ -2207,12 +2207,14 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
             <>
               <p>
                 Daily data are a snapshot of{' '}
-                <GlossaryTerm term="Cyanobacteria">cyanobacteria</GlossaryTerm>{' '}
-                (historically referred to as blue-green algae) at the time of
-                detection. These are provisional satellite derived measures of
-                cyanobacteria, which may contain errors. Information can be used
-                to identify potential problems related to cyanobacteria in
-                larger lakes and reservoirs within the contiguous United States.
+                <GlossaryTerm term="Blue-Green Algae">
+                  blue-green algae
+                </GlossaryTerm>{' '}
+                at the time of detection. These are provisional satellite
+                derived measures of blue-green algae, which may contain errors.
+                Information can be used to identify potential problems related
+                to blue-green algae in larger lakes and reservoirs within the
+                contiguous United States.
               </p>
 
               <h3>Data Issues include:</h3>
@@ -2235,15 +2237,15 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                 </li>
                 <li>
                   <b>Rivers:</b> large flowing waterways are not masked and can
-                  have a cyanobacteria response that is not validated.
+                  have a blue-green algae response that is not validated.
                 </li>
                 <li>
                   A resolvable waterbody is considered to have, at minimum, a
                   3x3 raster cell matrix size (900x900m), with the center pixel
                   being considered valid. Smaller or irregularly shaped
                   waterbodies (i.e., those not having the minimum 900x900m size)
-                  may be evident in the data, and their cyanobacteria responses
-                  are suspect and open to interpretation. See{' '}
+                  may be evident in the data, and their blue-green algae
+                  responses are suspect and open to interpretation. See{' '}
                   <a href={`#near-shore-response-${attributes.FID}`}>
                     “Near-shore response”
                   </a>{' '}
@@ -2275,7 +2277,7 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                   aria-hidden="true"
                 />
               </HelpTooltip>
-              Download Cyanobacteria Data
+              Download Blue-Green Algae Data
             </a>
           </p>
           <p>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1577,13 +1577,15 @@ function CyanDailyContent({
   if (!data) {
     return (
       <p css={marginBoxStyles(infoBoxStyles)}>
-        There is no CyAN data available for the selected date.
+        There is no potential harmful algal bloom data available for the
+        selected date.
       </p>
     );
   } else if (!sum(...data.measurements)) {
     return (
       <p css={marginBoxStyles(infoBoxStyles)}>
-        There is no measureable CyAN data available for the selected date.
+        There is no measureable potential harmful algal bloom data available for
+        the selected date.
       </p>
     );
   } else {
@@ -2178,8 +2180,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
 
                 {imageStatus === 'failure' && (
                   <p css={marginBoxStyles(errorBoxStyles)}>
-                    There was an error retrieving the CyAN satellite image for
-                    the selected day.
+                    There was an error retrieving the potential harmful algal
+                    bloom satellite imagery for the selected day.
                   </p>
                 )}
 
@@ -2191,8 +2193,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
               </>
             ) : (
               <p css={marginBoxStyles(infoBoxStyles)}>
-                There is no measureable CyAN data from the past week for the{' '}
-                {attributes.GNIS_NAME} waterbody.
+                There is no measureable potential harmful algal bloom data from
+                the past week for the {attributes.GNIS_NAME} waterbody.
               </p>
             )}
           </>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2750,7 +2750,7 @@ function MonitoringLocationsContent({
               className="fas fa-file-alt"
               aria-hidden="true"
             />
-            View Monitoring Report
+            View Water Monitoring Report
           </a>
           &nbsp;&nbsp;
           <small css={modifiedDisclaimerStyles}>(opens new browser tab)</small>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2157,8 +2157,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                     <HelpTooltip
                       label={
                         <>
-                          Adjust the slider handle to view the day's CyAN
-                          satellite imagery on the map.
+                          Adjust the slider handle to view the day's blue-green
+                          algae satellite imagery on the map.
                           <br />
                           Data for the previous day typically becomes available
                           between 9 - 11am EST.

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -8,7 +8,7 @@ export const echoError =
 
 // cyan.epa.gov
 export const cyanError =
-  'CyAN data is temporarily unavailable, please try again later.';
+  'Potential Harmful Algal Bloom (HAB) data is temporarily unavailable, please try again later.';
 
 // labs.waterdata.usgs.gov - Monitoring Location Service
 export const streamgagesError =

--- a/app/client/src/utils/hooks/cyanWaterbodies.ts
+++ b/app/client/src/utils/hooks/cyanWaterbodies.ts
@@ -200,7 +200,9 @@ function buildLayer(
         attributes: { OBJECTID: 1 },
       }),
     ],
-    title: `${type === 'surrounding' ? 'Surrounding ' : ''}CyAN Waterbodies`,
+    title: `${
+      type === 'surrounding' ? 'Surrounding ' : ''
+    }Potential Harmful Algal Blooms (HABs)`,
   });
 
   const cyanImages = new MediaLayer({
@@ -212,12 +214,16 @@ function buildLayer(
     spatialReference: {
       wkid: 102100,
     },
-    title: `${type === 'surrounding' ? 'Surrounding ' : ''}CyAN Images`,
+    title: `${
+      type === 'surrounding' ? 'Surrounding ' : ''
+    }Potential Harmful Algal Bloom Images`,
   });
 
   const newCyanLayer = new GroupLayer({
     id: type === 'enclosed' ? `cyanLayer` : `surroundingCyanLayer`,
-    title: `${type === 'surrounding' ? 'Surrounding ' : ''}CyAN Waterbodies`,
+    title: `${
+      type === 'surrounding' ? 'Surrounding ' : ''
+    }Potential Harmful Algal Blooms (HABs)`,
     listMode: type === 'enclosed' ? 'hide-children' : 'hide',
     visible: type === 'enclosed',
   });

--- a/app/cypress/e2e/community.Monitoring.cy.ts
+++ b/app/cypress/e2e/community.Monitoring.cy.ts
@@ -143,12 +143,12 @@ describe('Monitoring Tab', () => {
       'not.exist',
     );
 
-    cy.findAllByText('Daily Cyanobacteria Estimates for Lake Jackson', {
+    cy.findAllByText('Daily Blue-Green Algae Estimates for Lake Jackson', {
       exact: false,
     }).should('be.visible');
 
     cy.findAllByText(
-      'Cyanobacteria Concentration Histogram and Maximum for Selected Date:',
+      'Blue-Green Algae Concentration Histogram and Maximum for Selected Date:',
       { exact: false },
     ).should('be.visible');
   });

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -13,7 +13,7 @@
       "title": "Assessment, Total Maximum Daily Load Tracking and Implementation System (ATTAINS)"
     },
     {
-      "description": "The Cyanobacteria Assessment Network (CyAN) data provides access to <span data-glossary-term data-term='cyanobacteria'>cyanobacterial</span> bloom satellite data for over 2,000 of the largest lakes and reservoirs across the United States.",
+      "description": "The Cyanobacteria Assessment Network (CyAN) data provides access to <span data-glossary-term data-term='Blue-Green Algae'>blue-green algal</span> bloom satellite data for over 2,000 of the largest lakes and reservoirs across the United States.",
       "extraContent": null,
       "id": "cyan",
       "linkHref": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -79,7 +79,7 @@
       "linkHref": "https://www.waterqualitydata.us/",
       "linkLabel": "WQP Data/System",
       "shortName": "WQP",
-      "siteLocation": "Information from this database can be found on the Community page under the Overview tab under Water Monitoring Locations, Past Water Conditions, and on the Water Monitoring tab under Past Water Conditions, as well as on the Monitoring Report pages.",
+      "siteLocation": "Information from this database can be found on the Community page under the Overview tab under Water Monitoring Locations, Past Water Conditions, and on the Water Monitoring tab under Past Water Conditions, as well as on the Water Monitoring Report pages.",
       "title": "Water Quality Portal (WQP)"
     },
     {

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -19,7 +19,7 @@
       "linkHref": "https://www.epa.gov/water-research/cyanobacteria-assessment-network-application-cyan-app",
       "linkLabel": "CyAN Data/System",
       "shortName": "CyAN",
-      "siteLocation": "Information from CyAN can be found on the Community Page in the Water Monitoring tab under Current Water Conditions, CyAN Satellite Imagery.",
+      "siteLocation": "Information from CyAN can be found on the Community Page in the Water Monitoring tab under Current Water Conditions, Potential Harmful Algal Blooms (HABs).",
       "title": "Cyanobacteria Assessment Network (CyAN)"
     },
     {


### PR DESCRIPTION
## Related Issues:
* [HMW-555](https://jira.epa.gov/browse/HMW-555) - Changed "Harmful Algal Blooms", "CyAN Waterbodies" and "CyAN Satellite Imagery" to "Potential Harmful Algal Blooms".
* [HMW-560](https://jira.epa.gov/browse/HMW-560) - Changed "cyanobacteria" to "blue-green algae" and linked "blue-green algae" to the glossary.
* [HMW-563](https://jira.epa.gov/browse/HMW-563) - Linked "Not Specified" to the glossary. Note: I skipped the usage on the plan summary page, since the context is different.
* [HMW-567](https://jira.epa.gov/browse/HMW-567) - Changed "Monitoring Report" to "Water Monitoring Report". 

## Steps To Test:
1. Navigate to http://localhost:3000/community/lake%20okeechobee/overview
2. Verify the legend, layer list and surrounding features widgets all display "Potential Harmful Algal Blooms (HABs)".
3. Verify content on right side has "Potential Harmful Algal Blooms" and "blue-green algae" text changes. 
4. Expand one of the "Past Water Conditions" items.
5. Verify the link says "View Water Monitoring Report" and click the link.
6. Verify the new tab is titled as "Water Monitoring Report".
7. Navigate to http://localhost:3000/community/dc/overview
8. Go to dischargers tab
9. Filter to just "Not Specified"
10. Verify "Not Specified" is linked to the glossary, except for the one that shows up in the accordion header.

## TODO:
- [ ] I sent an email to Kiki asking about whether the "Not Specified" on the plan summary needs to be linked to the glossary or if we need to do something else there.
- [ ] I updated the text reference in the cypress tests. One of those tests was failing because the cyan web service is failing. I just left it alone, since there may still be some issues on the CyAN side.
