### PR TITLE
feature/545_detailed-uses-more-separation

### DIFF
--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -613,6 +613,7 @@ function WaterbodyInfo({
                   <tr>
                     <th>What is this water used for?</th>
                     <th>Condition</th>
+                    <th>Detailed Uses</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -626,6 +627,29 @@ function WaterbodyInfo({
                     return (
                       <tr key={useField.value}>
                         <td>
+                          <GlossaryTerm term={useField.term}>
+                            {useField.label}
+                          </GlossaryTerm>
+                        </td>
+                        <td>
+                          <GlossaryTerm
+                            term={
+                              value === 'Good'
+                                ? 'Good Waters'
+                                : value === 'Impaired' ||
+                                  value === 'Impaired (Issues Identified)'
+                                ? 'Impaired Waters'
+                                : 'Condition Unknown'
+                            }
+                          >
+                            {value}
+                          </GlossaryTerm>
+                        </td>
+                        <td
+                          css={css`
+                            text-align: center;
+                          `}
+                        >
                           <Modal
                             label={`Detailed Uses for ${useField.label}`}
                             maxWidth="35rem"
@@ -634,14 +658,14 @@ function WaterbodyInfo({
                               <button
                                 aria-label={`View detailed uses for ${useField.label}`}
                                 css={modifiedIconButtonStyles}
+                                onClick={() => {
+                                  setSelectedUseField(useField);
+                                  fetchDetailedUses();
+                                }}
                               >
                                 <i
                                   aria-hidden
                                   className="fas fa-info-circle"
-                                  onClick={() => {
-                                    setSelectedUseField(useField);
-                                    fetchDetailedUses();
-                                  }}
                                 ></i>
                               </button>
                             }
@@ -707,27 +731,6 @@ function WaterbodyInfo({
                                 </table>
                               )}
                           </Modal>
-                          <GlossaryTerm term={useField.term}>
-                            {useField.label}
-                          </GlossaryTerm>
-                        </td>
-                        <td
-                          css={css`
-                            width: 165px;
-                          `}
-                        >
-                          <GlossaryTerm
-                            term={
-                              value === 'Good'
-                                ? 'Good Waters'
-                                : value === 'Impaired' ||
-                                  value === 'Impaired (Issues Identified)'
-                                ? 'Impaired Waters'
-                                : 'Condition Unknown'
-                            }
-                          >
-                            {value}
-                          </GlossaryTerm>
                         </td>
                       </tr>
                     );

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -174,17 +174,17 @@ const popupTitleStyles = css`
   background-color: #f0f6f9;
 `;
 
-const measurementTableStyles = css`
+const measurementTableStyles = (align: string = 'right') => css`
   ${modifiedTableStyles};
 
   th:last-of-type,
   td:last-of-type {
-    text-align: right;
+    text-align: ${align};
   }
 `;
 
 const modalTableStyles = css`
-  ${measurementTableStyles};
+  ${measurementTableStyles()};
   margin-bottom: 0;
 
   th {
@@ -608,7 +608,7 @@ function WaterbodyInfo({
             )}
 
             {applicableFields.length > 0 && (
-              <table css={measurementTableStyles} className="table">
+              <table css={measurementTableStyles('center')} className="table">
                 <thead>
                   <tr>
                     <th>What is this water used for?</th>
@@ -645,11 +645,7 @@ function WaterbodyInfo({
                             {value}
                           </GlossaryTerm>
                         </td>
-                        <td
-                          css={css`
-                            text-align: center;
-                          `}
-                        >
+                        <td>
                           <Modal
                             label={`Detailed Uses for ${useField.label}`}
                             maxWidth="35rem"
@@ -657,6 +653,7 @@ function WaterbodyInfo({
                             triggerElm={
                               <button
                                 aria-label={`View detailed uses for ${useField.label}`}
+                                title={`View detailed uses for ${useField.label}`}
                                 css={modifiedIconButtonStyles}
                                 onClick={() => {
                                   setSelectedUseField(useField);
@@ -2615,7 +2612,7 @@ function MonitoringLocationsContent({
       {Object.keys(groups).length > 0 && (
         <table
           aria-label="Characteristic Groups Summary"
-          css={measurementTableStyles}
+          css={measurementTableStyles()}
           className="table"
         >
           <thead>
@@ -2874,7 +2871,7 @@ function UsgsStreamgagesContent({
         />
       </div>
 
-      <table css={measurementTableStyles} className="table">
+      <table css={measurementTableStyles()} className="table">
         <thead>
           <tr>
             <th>Category</th>


### PR DESCRIPTION
## Related Issues:
* [HMW-545](https://jira.epa.gov/browse/HMW-545)

## Main Changes:
* Moved the detailed uses button to it's own column for more separation.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Expand some waterbodies
3. Verify the "Detailed Uses" buttons are in their own column
4. Test on various screen sizes 

