### PR TITLE
Feature/573 characteristics filter

### DIFF
--- a/app/client/public/periodOfRecordWorker.js
+++ b/app/client/public/periodOfRecordWorker.js
@@ -70,6 +70,7 @@ function structureByUniqueId(recordsByYear) {
       dataBySite[id][year] = recordsByYear[year][id];
     });
   }
+  if (minYear > maxYear) minYear = 0;
   return { minYear, maxYear, sites: dataBySite };
 }
 

--- a/app/client/public/periodOfRecordWorker.js
+++ b/app/client/public/periodOfRecordWorker.js
@@ -70,7 +70,7 @@ function structureByUniqueId(recordsByYear) {
       dataBySite[id][year] = recordsByYear[year][id];
     });
   }
-  return { minYear, maxYear, annualData: dataBySite };
+  return { minYear, maxYear, sites: dataBySite };
 }
 
 // This makes sure the listener isn't set twice
@@ -99,12 +99,16 @@ if ('function' === typeof importScripts) {
         if (records.length) {
           const recordsByYear = structureByYear(records, mappings);
           const recordsById = structureByUniqueId(recordsByYear);
-          postMessage(JSON.stringify(recordsById));
+          postMessage(JSON.stringify({ status: 'success', data: recordsById }));
         }
       })
       .catch((_err) => {
-        const noData = { minYear: 0, maxYear: 0, annualData: {} };
-        postMessage(JSON.stringify(noData));
+        postMessage(
+          JSON.stringify({
+            status: 'failure',
+            data: { minYear: 0, maxYear: 0, sites: {} },
+          }),
+        );
       });
   };
 }

--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -433,9 +433,6 @@ function CommunityTabs() {
     // overview panel
     setDischargerPermitComponents(null);
 
-    // monitoring panel
-    setMonitoringGroups(null);
-
     // identified issues panel
     setShowAllPolluted(true);
     setParameterToggleObject({});

--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -15,7 +15,10 @@ import Switch from 'components/shared/Switch';
 import { PinIcon } from 'components/shared/Icons';
 // contexts
 import { CommunityTabsContext } from 'contexts/CommunityTabs';
-import { LocationSearchContext } from 'contexts/locationSearch';
+import {
+  initialMonitoringGroups,
+  LocationSearchContext,
+} from 'contexts/locationSearch';
 // config
 import { tabs } from 'config/communityConfig.js';
 // styles
@@ -432,6 +435,9 @@ function CommunityTabs() {
   const resetTabSpecificData = () => {
     // overview panel
     setDischargerPermitComponents(null);
+
+    // monitoring panel
+    setMonitoringGroups(initialMonitoringGroups());
 
     // identified issues panel
     setShowAllPolluted(true);

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -697,13 +697,14 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
 
   const {
     huc12,
-    monitoringCharacteristicsStatus,
+    monitoringPeriodOfRecordStatus,
     monitoringYearsRange,
     selectedMonitoringYearsRange,
     setMonitoringFeatureUpdates,
     setSelectedMonitoringYearsRange,
     watershed,
   } = useContext(LocationSearchContext);
+  const annualRecordsReady = monitoringPeriodOfRecordStatus === 'success';
 
   const { monitoringLocationsLayer } = useLayers();
   const { monitoringLocations } = useFetchedDataState();
@@ -813,13 +814,13 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
         }
       }
 
-      if (selectedMonitoringYearsRange) {
+      if (annualRecordsReady) {
         filter += `&startDateLo=01-01-${selectedMonitoringYearsRange[0]}&startDateHi=12-31-${selectedMonitoringYearsRange[1]}`;
       }
 
       setCharGroupFilters(filter);
     },
-    [setCharGroupFilters, selectedMonitoringYearsRange],
+    [setCharGroupFilters, annualRecordsReady, selectedMonitoringYearsRange],
   );
 
   const [displayedLocations, setDisplayedLocations] = useState([]);
@@ -830,11 +831,11 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
 
     const { toggledLocations, allLocations } = filterLocations(
       monitoringGroups,
-      selectedMonitoringYearsRange,
+      annualRecordsReady ? selectedMonitoringYearsRange : null,
     );
 
     // Add filtered data that's relevent to map popups
-    if (selectedMonitoringYearsRange) {
+    if (annualRecordsReady) {
       updateFeatures(toggledLocations);
     }
 
@@ -858,6 +859,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
     setCurrentLocations(allLocations);
     setDisplayedLocations(toggledLocations);
   }, [
+    annualRecordsReady,
     monitoringGroups,
     monitoringLocationsLayer,
     selectedMonitoringYearsRange,
@@ -1091,7 +1093,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
             </div>
 
             <div css={sliderContainerStyles}>
-              {monitoringCharacteristicsStatus === 'failure' && (
+              {monitoringPeriodOfRecordStatus === 'failure' && (
                 <div css={modifiedErrorBoxStyles}>
                   <p>
                     Annual Past Water Conditions data is temporarily
@@ -1099,10 +1101,10 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   </p>
                 </div>
               )}
-              {monitoringCharacteristicsStatus === 'pending' && (
+              {monitoringPeriodOfRecordStatus === 'pending' && (
                 <LoadingSpinner />
               )}
-              {monitoringCharacteristicsStatus === 'success' && (
+              {monitoringPeriodOfRecordStatus === 'success' && (
                 <DateSlider
                   max={monitoringYearsRange[1]}
                   min={monitoringYearsRange[0]}
@@ -1272,7 +1274,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   {selectedCharacteristicOptions.length > 0 &&
                     'with the selected characteristics '}
                   in the <em>{watershed}</em> watershed
-                  {selectedMonitoringYearsRange && (
+                  {annualRecordsReady && (
                     <>
                       {' '}
                       from <strong>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -1266,7 +1266,8 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                 <span data-testid="monitoring-accordion-title">
                   <strong>{displayedLocationsCount.toLocaleString()}</strong> of{' '}
                   <strong>{totalLocationsCount.toLocaleString()}</strong> water
-                  monitoring sample locations
+                  monitoring sample{' '}
+                  {totalLocationsCount === 1 ? 'location' : 'locations'}
                   {selectedCharacteristics.length > 0 &&
                     ' with the selected characteristic'}
                   {selectedCharacteristics.length > 1 && 's'} in the{' '}

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -586,9 +586,8 @@ function CurrentConditionsTab({
             title={
               <>
                 <strong>{filteredLocations.length}</strong> of{' '}
-                <strong>{sortedLocations.length}</strong>{' '}
-                {sortedLocations.length === 1 ? 'location' : 'locations'} with
-                data in the <em>{watershed}</em> watershed.
+                <strong>{sortedLocations.length}</strong> locations with data in
+                the <em>{watershed}</em> watershed.
               </>
             }
             onSortChange={handleSortChange}
@@ -1266,8 +1265,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                 <span data-testid="monitoring-accordion-title">
                   <strong>{displayedLocationsCount.toLocaleString()}</strong> of{' '}
                   <strong>{totalLocationsCount.toLocaleString()}</strong> water
-                  monitoring sample{' '}
-                  {totalLocationsCount === 1 ? 'location' : 'locations'}
+                  monitoring sample locations
                   {selectedCharacteristics.length > 0 &&
                     ' with the selected characteristic'}
                   {selectedCharacteristics.length > 1 && 's'} in the{' '}

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -924,10 +924,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
   // Filter the displayed locations by selected characteristics
   const filteredMonitoringLocations = sortedMonitoringLocations.filter(
     (location) => {
-      if (
-        !selectedCharacteristicOptions.length ||
-        monitoringCharacteristicsStatus !== 'success'
-      ) {
+      if (!selectedCharacteristicOptions.length) {
         return true;
       }
       for (let characteristic of Object.keys(location.totalsByCharacteristic)) {
@@ -1266,29 +1263,33 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
               </tfoot>
             </table>
 
-            <CharacteristicsSelect
-              selected={selectedCharacteristicOptions}
-              onChange={setSelectedCharacteristicOptions}
-            />
             <AccordionList
               title={
-                selectedMonitoringYearsRange ? (
-                  <span data-testid="monitoring-accordion-title">
-                    <strong>{displayedLocationsCount.toLocaleString()}</strong>{' '}
-                    of <strong>{totalLocationsCount.toLocaleString()}</strong>{' '}
-                    water monitoring sample locations in the{' '}
-                    <em>{watershed}</em> watershed from{' '}
-                    <strong>{selectedMonitoringYearsRange[0]}</strong> to{' '}
-                    <strong>{selectedMonitoringYearsRange[1]}</strong>.
-                  </span>
-                ) : (
-                  <span data-testid="monitoring-accordion-title">
-                    <strong>{displayedLocationsCount.toLocaleString()}</strong>{' '}
-                    of <strong>{totalLocationsCount.toLocaleString()}</strong>{' '}
-                    water monitoring sample locations in the{' '}
-                    <em>{watershed}</em> watershed.
-                  </span>
-                )
+                <span data-testid="monitoring-accordion-title">
+                  <strong>{displayedLocationsCount.toLocaleString()}</strong> of{' '}
+                  <strong>{totalLocationsCount.toLocaleString()}</strong> water
+                  monitoring sample locations{' '}
+                  {selectedCharacteristicOptions.length > 0 &&
+                    'with the selected characteristics '}
+                  in the <em>{watershed}</em> watershed
+                  {selectedMonitoringYearsRange && (
+                    <>
+                      {' '}
+                      from <strong>
+                        {selectedMonitoringYearsRange[0]}
+                      </strong> to{' '}
+                      <strong>{selectedMonitoringYearsRange[1]}</strong>
+                    </>
+                  )}
+                  .
+                </span>
+              }
+              extraListHeaderContent={
+                <CharacteristicsSelect
+                  label="Filter by Characteristic:"
+                  selected={selectedCharacteristicOptions}
+                  onChange={setSelectedCharacteristicOptions}
+                />
               }
               onSortChange={handleSortChange}
               onExpandCollapse={handleExpandCollapse}

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -698,19 +698,17 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
 
   const {
     huc12,
-    monitoringGroups,
     monitoringCharacteristicsStatus,
     monitoringYearsRange,
     selectedMonitoringYearsRange,
     setMonitoringFeatureUpdates,
-    setMonitoringGroups,
     setSelectedMonitoringYearsRange,
     watershed,
   } = useContext(LocationSearchContext);
 
   const { monitoringLocationsLayer } = useLayers();
   const { monitoringLocations } = useFetchedDataState();
-  useMonitoringGroups('huc12', huc12);
+  const { monitoringGroups, setMonitoringGroups } = useMonitoringGroups(huc12);
 
   const updateFeatures = useCallback(
     (locations) => {

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -408,9 +408,7 @@ function MonitoringAndSensorsTab({
   setCyanDisplayed,
   updateVisibleLayers,
 }) {
-  const { mapView, monitoringCharacteristicsStatus, watershed } = useContext(
-    LocationSearchContext,
-  );
+  const { mapView, watershed } = useContext(LocationSearchContext);
 
   const { cyanLayer, monitoringLocationsLayer, usgsStreamgagesLayer } =
     useLayers();
@@ -492,8 +490,7 @@ function MonitoringAndSensorsTab({
     .filter((item) => {
       if (
         item.monitoringType !== 'Past Water Conditions' ||
-        !selectedCharacteristicOptions.length ||
-        monitoringCharacteristicsStatus !== 'success'
+        !selectedCharacteristicOptions.length
       ) {
         return true;
       }
@@ -862,17 +859,31 @@ function MonitoringAndSensorsTab({
               </tbody>
             </table>
 
-            <CharacteristicsSelect
-              selected={selectedCharacteristicOptions}
-              onChange={setSelectedCharacteristicOptions}
-            />
             <AccordionList
               title={
                 <>
                   <strong>{filteredMonitoringAndSensors.length}</strong> of{' '}
                   <strong>{allMonitoringAndSensors.length}</strong> locations
                   with data in the <em>{watershed}</em> watershed.
+                  {selectedCharacteristicOptions.length > 0 && (
+                    <>
+                      <br />
+                      <small>
+                        (Past Water Conditions filtered by one or more
+                        characteristics)
+                      </small>
+                    </>
+                  )}
                 </>
+              }
+              extraListHeaderContent={
+                monitoringLocationsDisplayed && (
+                  <CharacteristicsSelect
+                    label="Filter Past Water Conditions by Characteristic:"
+                    selected={selectedCharacteristicOptions}
+                    onChange={setSelectedCharacteristicOptions}
+                  />
+                )
               }
               onSortChange={handleSortChange}
               onExpandCollapse={handleExpandCollapse}

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -8,6 +8,7 @@ import {
   AccordionList,
   AccordionItem,
 } from 'components/shared/AccordionMapHighlight';
+import CharacteristicsSelect from 'components/shared/CharacteristicsSelect';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import {
@@ -407,7 +408,9 @@ function MonitoringAndSensorsTab({
   setCyanDisplayed,
   updateVisibleLayers,
 }) {
-  const { mapView, watershed } = useContext(LocationSearchContext);
+  const { mapView, monitoringCharacteristicsStatus, watershed } = useContext(
+    LocationSearchContext,
+  );
 
   const { cyanLayer, monitoringLocationsLayer, usgsStreamgagesLayer } =
     useLayers();
@@ -462,8 +465,14 @@ function MonitoringAndSensorsTab({
     },
   );
 
-  const filteredMonitoringAndSensors = sortedMonitoringAndSensors.filter(
-    (item) => {
+  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
+    useState([]);
+
+  const selectedCharacteristics = selectedCharacteristicOptions.map(
+    (charc) => charc.value,
+  );
+  const filteredMonitoringAndSensors = sortedMonitoringAndSensors
+    .filter((item) => {
       const displayedTypes = [];
 
       if (usgsStreamgagesDisplayed) {
@@ -479,8 +488,20 @@ function MonitoringAndSensorsTab({
       }
 
       return displayedTypes.includes(item.monitoringType);
-    },
-  );
+    })
+    .filter((item) => {
+      if (
+        item.monitoringType !== 'Past Water Conditions' ||
+        !selectedCharacteristicOptions.length ||
+        monitoringCharacteristicsStatus !== 'success'
+      ) {
+        return true;
+      }
+      for (let characteristic of Object.keys(item.totalsByCharacteristic)) {
+        if (selectedCharacteristics.includes(characteristic)) return true;
+      }
+      return false;
+    });
 
   const handleUsgsSensorsToggle = useCallback(
     (checked) => {
@@ -841,6 +862,10 @@ function MonitoringAndSensorsTab({
               </tbody>
             </table>
 
+            <CharacteristicsSelect
+              selected={selectedCharacteristicOptions}
+              onChange={setSelectedCharacteristicOptions}
+            />
             <AccordionList
               title={
                 <>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -892,10 +892,7 @@ function MonitoringAndSensorsTab({
               title={
                 <>
                   <strong>{filteredMonitoringAndSensors.length}</strong> of{' '}
-                  <strong>{allMonitoringAndSensors.length}</strong>{' '}
-                  {allMonitoringAndSensors.length === 1
-                    ? 'location'
-                    : 'locations'}{' '}
+                  <strong>{allMonitoringAndSensors.length}</strong> locations{' '}
                   with data in the <em>{watershed}</em> watershed.
                   {selectedCharacteristics.length > 0 && (
                     <>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -892,7 +892,10 @@ function MonitoringAndSensorsTab({
               title={
                 <>
                   <strong>{filteredMonitoringAndSensors.length}</strong> of{' '}
-                  <strong>{allMonitoringAndSensors.length}</strong> locations
+                  <strong>{allMonitoringAndSensors.length}</strong>{' '}
+                  {allMonitoringAndSensors.length === 1
+                    ? 'location'
+                    : 'locations'}{' '}
                   with data in the <em>{watershed}</em> watershed.
                   {selectedCharacteristics.length > 0 && (
                     <>

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -2100,7 +2100,10 @@ function MonitoringReportContent() {
     `&organization=${encodeURIComponent(orgId)}` +
     `&siteid=${encodeURIComponent(siteId)}`;
 
-  useMonitoringLocationsLayers(siteFilter);
+  useMonitoringLocationsLayers({
+    filter: siteFilter,
+    includeAnnualData: false,
+  });
 
   const { monitoringLocations, monitoringLocationsStatus } =
     useMonitoringLocations();

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -1,20 +1,14 @@
 // @flow
 
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { css } from 'styled-components/macro';
 import { useWindowSize } from '@reach/window-size';
 import Select, { createFilter } from 'react-select';
-import { VariableSizeList } from 'react-window';
 import * as query from '@arcgis/core/rest/query';
 // components
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
+import MenuList from 'components/shared/MenuList';
 import Modal from 'components/shared/Modal';
 import StateMap from 'components/shared/StateMap';
 import WaterbodyListVirtualized from 'components/shared/WaterbodyListVirtualized';
@@ -1160,66 +1154,6 @@ function AdvancedSearch() {
       )}
     </div>
   );
-}
-
-function MenuList({ ...props }) {
-  const { width } = useWindowSize();
-  const listRef = useRef();
-
-  // keeps track of the size of the virtualized items. This handles
-  // items where the text wraps
-  const sizeMap = useRef({});
-  const setSize = useCallback((index: number, size: number) => {
-    sizeMap.current = { ...sizeMap.current, [index]: size };
-    listRef.current.resetAfterIndex(index);
-  }, []);
-  const getSize = (index: number) => sizeMap.current[index] || 70;
-
-  // use the default style dropdown if there is no data
-  if (!props.children.length || props.children.length === 0) {
-    return props.children;
-  }
-
-  return (
-    <VariableSizeList
-      ref={listRef}
-      width="100%"
-      height={props.maxHeight}
-      itemCount={props.children.length}
-      itemSize={getSize}
-    >
-      {({ index, style }) => (
-        <div style={{ ...style, overflowX: 'hidden' }}>
-          <MenuItem
-            index={index}
-            width={width}
-            setSize={setSize}
-            value={props.children[index]}
-          />
-        </div>
-      )}
-    </VariableSizeList>
-  );
-}
-
-type MenuItemProps = {
-  index: number,
-  width: number,
-  setSize: (index: number, size: number) => void,
-  value: string,
-};
-
-function MenuItem({ index, width, setSize, value }: MenuItemProps) {
-  const rowRef = useRef();
-
-  // keep track of the height of the rows to autosize rows
-  useEffect(() => {
-    if (!rowRef?.current) return;
-
-    setSize(index, rowRef.current.getBoundingClientRect().height);
-  }, [setSize, index, width]);
-
-  return <div ref={rowRef}>{value}</div>;
 }
 
 export default function AdvancedSearchContainer() {

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -85,7 +85,8 @@ function retrieveFeatures({
       .executeForIds(url, queryParams)
       .then((objectIds) => {
         // this block sometimes still executes when the request is aborted
-        if (queryParams.signal?.aborted) reject({ name: 'AbortError' });
+        if (queryParams.signal?.aborted)
+          reject(new DOMException('The query was aborted.', 'AbortError'));
         // set the features value of the data to an empty array if no objectIds
         // were returned.
         if (!objectIds) {

--- a/app/client/src/components/shared/Accordion.tsx
+++ b/app/client/src/components/shared/Accordion.tsx
@@ -10,13 +10,18 @@ const accordionListContainerStyles = css`
   border-bottom: 1px solid #d8dfe2;
 `;
 
-const accordionOptionsContainerStyles = (includeTopMargin: boolean, displayTitleInFlex: boolean) => css`
+const accordionOptionsContainerStyles = (
+  includeTopMargin: boolean,
+  displayTitleInFlex: boolean,
+) => css`
   display: flex;
   justify-content: flex-end;
   width: 100%;
   margin-bottom: 0;
   ${includeTopMargin ? 'margin-top: 0.625rem;' : ''}
-  ${displayTitleInFlex ? 'justify-content: space-between; align-items: center;' : ''}
+  ${displayTitleInFlex
+    ? 'justify-content: space-between; align-items: center;'
+    : ''}
 `;
 
 const columnsStyles = css`
@@ -96,6 +101,7 @@ type AccordionListProps = {
   onSortChange?: Function;
   onExpandCollapse?: Function;
   contentExpandCollapse?: ReactNode;
+  extraListHeaderContent?: ReactNode;
 };
 
 function AccordionList({
@@ -109,6 +115,7 @@ function AccordionList({
   onSortChange = () => {},
   onExpandCollapse = () => {},
   contentExpandCollapse,
+  extraListHeaderContent,
 }: AccordionListProps) {
   const [sortBy, setSortBy] = useState(
     sortOptions.length > 0 ? sortOptions[0] : null,
@@ -135,7 +142,12 @@ function AccordionList({
         <div css={listHeaderStyles(includeSort || !!title)}>
           {title && !displayTitleInFlex && <p css={titleStyles}>{title}</p>}
           <div css={columnsStyles}>
-            <div css={accordionOptionsContainerStyles(includeSort && !!title, displayTitleInFlex)}>
+            <div
+              css={accordionOptionsContainerStyles(
+                includeSort && !!title,
+                displayTitleInFlex,
+              )}
+            >
               {title && displayTitleInFlex && <p css={titleStyles}>{title}</p>}
 
               {includeSort && (
@@ -178,6 +190,12 @@ function AccordionList({
               )}
             </div>
           </div>
+          {extraListHeaderContent && (
+            <>
+              <hr />
+              {extraListHeaderContent}
+            </>
+          )}
         </div>
       )}
 

--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -265,7 +265,7 @@ function SavePanel({ visible }: Props) {
   const monitoringYearsRange = useContext(LocationSearchContext)
     .monitoringYearsRange as MonitoringYearsRange | null;
   const monitoringWorkerData = useContext(LocationSearchContext)
-    .monitoringWorkerData as MonitoringWorkerData;
+    .monitoringAnnualRecords.data as MonitoringWorkerData;
   const parameterToggleObject = useContext(LocationSearchContext)
     .parameterToggleObject as ParameterToggleObject;
   const upstreamWatershedResponse = useContext(LocationSearchContext)

--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -33,7 +33,6 @@ import {
   Huc12SummaryData,
   MonitoringLocationGroups,
   MonitoringYearsRange,
-  MonitoringWorkerData,
   ParameterToggleObject,
 } from 'types/index';
 import { LayerType, ServiceMetaDataType } from 'types/arcGisOnline';
@@ -262,10 +261,10 @@ function SavePanel({ visible }: Props) {
     .mapView as __esri.MapView | null;
   const monitoringGroups = useContext(LocationSearchContext)
     .monitoringGroups as MonitoringLocationGroups | null;
+  const selectedMonitoringYearsRange = useContext(LocationSearchContext)
+    .selectedMonitoringYearsRange as MonitoringYearsRange | null;
   const monitoringYearsRange = useContext(LocationSearchContext)
-    .monitoringYearsRange as MonitoringYearsRange | null;
-  const monitoringWorkerData = useContext(LocationSearchContext)
-    .monitoringAnnualRecords.data as MonitoringWorkerData;
+    .monitoringYearsRange as MonitoringYearsRange;
   const parameterToggleObject = useContext(LocationSearchContext)
     .parameterToggleObject as ParameterToggleObject;
   const upstreamWatershedResponse = useContext(LocationSearchContext)
@@ -558,7 +557,7 @@ function SavePanel({ visible }: Props) {
   }
 
   // Saves the data to ArcGIS Online
-  async function handleSaveAgo(ev: MouseEvent<HTMLButtonElement>) {
+  async function handleSaveAgo(_ev: MouseEvent<HTMLButtonElement>) {
     if (!mapView || !saveLayersList) return;
 
     // check if user provided a name
@@ -644,20 +643,20 @@ function SavePanel({ visible }: Props) {
       if (
         value.id === 'monitoringLocationsLayer' &&
         monitoringGroups &&
-        monitoringYearsRange
+        selectedMonitoringYearsRange
       ) {
         const monitoringGroupsFiltered = Object.values(monitoringGroups).some(
           (a) => !a.toggled,
         );
         const yearsFiltered =
-          monitoringYearsRange &&
-          (monitoringYearsRange[0] !== monitoringWorkerData.minYear ||
-            monitoringYearsRange[1] !== monitoringWorkerData.maxYear);
+          selectedMonitoringYearsRange &&
+          (selectedMonitoringYearsRange[0] !== monitoringYearsRange[0] ||
+            selectedMonitoringYearsRange[1] !== monitoringYearsRange[1]);
         if (monitoringGroupsFiltered || yearsFiltered) {
           const filters: string[] = [];
           if (yearsFiltered) {
             filters.push(
-              `years ${monitoringYearsRange[0]} - ${monitoringYearsRange[1]}`,
+              `years ${selectedMonitoringYearsRange[0]} - ${selectedMonitoringYearsRange[1]}`,
             );
           }
 

--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -30,6 +30,7 @@ import {
 // types
 import {
   DischargerPermitComponents,
+  FetchStatus,
   Huc12SummaryData,
   MonitoringLocationGroups,
   MonitoringYearsRange,
@@ -259,10 +260,12 @@ function SavePanel({ visible }: Props) {
     .dischargerPermitComponents as DischargerPermitComponents | null;
   const mapView = useContext(LocationSearchContext)
     .mapView as __esri.MapView | null;
+  const monitoringPeriodOfRecordStatus = useContext(LocationSearchContext)
+    .monitoringPeriodOfRecordStatus as FetchStatus;
   const monitoringGroups = useContext(LocationSearchContext)
     .monitoringGroups as MonitoringLocationGroups | null;
   const selectedMonitoringYearsRange = useContext(LocationSearchContext)
-    .selectedMonitoringYearsRange as MonitoringYearsRange | null;
+    .selectedMonitoringYearsRange as MonitoringYearsRange;
   const monitoringYearsRange = useContext(LocationSearchContext)
     .monitoringYearsRange as MonitoringYearsRange;
   const parameterToggleObject = useContext(LocationSearchContext)
@@ -643,15 +646,14 @@ function SavePanel({ visible }: Props) {
       if (
         value.id === 'monitoringLocationsLayer' &&
         monitoringGroups &&
-        selectedMonitoringYearsRange
+        monitoringPeriodOfRecordStatus === 'success'
       ) {
         const monitoringGroupsFiltered = Object.values(monitoringGroups).some(
           (a) => !a.toggled,
         );
         const yearsFiltered =
-          selectedMonitoringYearsRange &&
-          (selectedMonitoringYearsRange[0] !== monitoringYearsRange[0] ||
-            selectedMonitoringYearsRange[1] !== monitoringYearsRange[1]);
+          selectedMonitoringYearsRange[0] !== monitoringYearsRange[0] ||
+          selectedMonitoringYearsRange[1] !== monitoringYearsRange[1];
         if (monitoringGroupsFiltered || yearsFiltered) {
           const filters: string[] = [];
           if (yearsFiltered) {

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -1,5 +1,5 @@
 import uniqueId from 'lodash/uniqueId';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import Select from 'react-select';
 import { css } from 'styled-components/macro';
 // components

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -1,0 +1,58 @@
+import { useContext, useMemo } from 'react';
+import Select from 'react-select';
+// components
+import MenuList from 'components/shared/MenuList';
+// contexts
+import { LocationSearchContext } from 'contexts/locationSearch';
+// utils
+import { useMonitoringLocations } from 'utils/hooks';
+
+export default CharacteristicsSelect;
+export function CharacteristicsSelect({
+  selected,
+  onChange,
+}: CharacteristicsSelectProps) {
+  const { monitoringCharacteristicsStatus } = useContext(LocationSearchContext);
+  const { monitoringLocations } = useMonitoringLocations();
+
+  // Gather all available characteristics from the periodOfRecord data
+  const allCharacteristicOptions = useMemo(() => {
+    if (monitoringCharacteristicsStatus !== 'success') return [];
+
+    const uniqueCharacteristics = new Set<string>();
+    monitoringLocations.forEach((location) => {
+      const siteData = location.dataByYear;
+      Object.values(siteData).forEach((yearData) => {
+        Object.keys(yearData.totalsByCharacteristic).forEach((characteristic) =>
+          uniqueCharacteristics.add(characteristic),
+        );
+      });
+    });
+    return Array.from(uniqueCharacteristics)
+      .sort((a, b) => a.localeCompare(b))
+      .map((charc) => ({ label: charc, value: charc }));
+  }, [monitoringCharacteristicsStatus, monitoringLocations]);
+
+  return (
+    <Select
+      components={{ MenuList }}
+      isDisabled={monitoringCharacteristicsStatus === 'failure'}
+      isLoading={monitoringCharacteristicsStatus === 'pending'}
+      isMulti
+      onChange={onChange}
+      options={allCharacteristicOptions}
+      placeholder="Select a characteristic..."
+      value={selected}
+    />
+  );
+}
+
+type CharacteristicsSelectProps = {
+  selected: Option[];
+  onChange: (selected: readonly Option[]) => void;
+};
+
+type Option = {
+  label: string;
+  value: string;
+};

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -1,5 +1,7 @@
-import { useContext, useMemo } from 'react';
+import uniqueId from 'lodash/uniqueId';
+import { useContext, useMemo, useState } from 'react';
 import Select from 'react-select';
+import { css } from 'styled-components/macro';
 // components
 import MenuList from 'components/shared/MenuList';
 // contexts
@@ -9,11 +11,14 @@ import { useMonitoringLocations } from 'utils/hooks';
 
 export default CharacteristicsSelect;
 export function CharacteristicsSelect({
+  label,
   selected,
   onChange,
 }: CharacteristicsSelectProps) {
   const { monitoringCharacteristicsStatus } = useContext(LocationSearchContext);
   const { monitoringLocations } = useMonitoringLocations();
+
+  const [inputId] = useState(uniqueId('characteristic-select-'));
 
   // Gather all available characteristics from the periodOfRecord data
   const allCharacteristicOptions = useMemo(() => {
@@ -34,20 +39,28 @@ export function CharacteristicsSelect({
   }, [monitoringCharacteristicsStatus, monitoringLocations]);
 
   return (
-    <Select
-      components={{ MenuList }}
-      isDisabled={monitoringCharacteristicsStatus === 'failure'}
-      isLoading={monitoringCharacteristicsStatus === 'pending'}
-      isMulti
-      onChange={onChange}
-      options={allCharacteristicOptions}
-      placeholder="Select a characteristic..."
-      value={selected}
-    />
+    <div css={selectContainerStyles}>
+      <label css={selectLabelStyles} htmlFor={inputId}>
+        {label}
+      </label>
+      <Select
+        components={{ MenuList }}
+        css={selectStyles}
+        inputId={inputId}
+        isDisabled={monitoringCharacteristicsStatus === 'failure'}
+        isLoading={monitoringCharacteristicsStatus === 'pending'}
+        isMulti
+        onChange={onChange}
+        options={allCharacteristicOptions}
+        placeholder="Select a characteristic..."
+        value={selected}
+      />
+    </div>
   );
 }
 
 type CharacteristicsSelectProps = {
+  label: string;
   selected: Option[];
   onChange: (selected: readonly Option[]) => void;
 };
@@ -56,3 +69,17 @@ type Option = {
   label: string;
   value: string;
 };
+
+const selectContainerStyles = css`
+  width: 100%;
+`;
+
+const selectLabelStyles = css`
+  margin-bottom: 0.125rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+`;
+
+const selectStyles = css`
+  width: 100%;
+`;

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -1,5 +1,5 @@
 import uniqueId from 'lodash/uniqueId';
-import { useContext, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import Select from 'react-select';
 import { css } from 'styled-components/macro';
 // components
@@ -15,14 +15,14 @@ export function CharacteristicsSelect({
   selected,
   onChange,
 }: CharacteristicsSelectProps) {
-  const { monitoringCharacteristicsStatus } = useContext(LocationSearchContext);
+  const { monitoringPeriodOfRecordStatus } = useContext(LocationSearchContext);
   const { monitoringLocations } = useMonitoringLocations();
 
   const [inputId] = useState(uniqueId('characteristic-select-'));
 
   // Gather all available characteristics from the periodOfRecord data
   const allCharacteristicOptions = useMemo(() => {
-    if (monitoringCharacteristicsStatus !== 'success') return [];
+    if (monitoringPeriodOfRecordStatus !== 'success') return [];
 
     const uniqueCharacteristics = new Set<string>();
     monitoringLocations.forEach((location) => {
@@ -36,7 +36,13 @@ export function CharacteristicsSelect({
     return Array.from(uniqueCharacteristics)
       .sort((a, b) => a.localeCompare(b))
       .map((charc) => ({ label: charc, value: charc }));
-  }, [monitoringCharacteristicsStatus, monitoringLocations]);
+  }, [monitoringPeriodOfRecordStatus, monitoringLocations]);
+
+  useEffect(() => {
+    return function cleanup() {
+      onChange([]);
+    };
+  }, [onChange]);
 
   return (
     <div css={selectContainerStyles}>
@@ -47,8 +53,8 @@ export function CharacteristicsSelect({
         components={{ MenuList }}
         css={selectStyles}
         inputId={inputId}
-        isDisabled={monitoringCharacteristicsStatus === 'failure'}
-        isLoading={monitoringCharacteristicsStatus === 'pending'}
+        isDisabled={monitoringPeriodOfRecordStatus === 'failure'}
+        isLoading={monitoringPeriodOfRecordStatus === 'pending'}
         isMulti
         onChange={onChange}
         options={allCharacteristicOptions}

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -38,11 +38,9 @@ export function CharacteristicsSelect({
       .map((charc) => ({ label: charc, value: charc }));
   }, [monitoringPeriodOfRecordStatus, monitoringLocations]);
 
-  useEffect(() => {
-    return function cleanup() {
-      onChange([]);
-    };
-  }, [onChange]);
+  const selectedOptions = useMemo(() => {
+    return selected.map((s) => ({ label: s, value: s }));
+  }, [selected]);
 
   return (
     <div css={selectContainerStyles}>
@@ -56,10 +54,10 @@ export function CharacteristicsSelect({
         isDisabled={monitoringPeriodOfRecordStatus === 'failure'}
         isLoading={monitoringPeriodOfRecordStatus === 'pending'}
         isMulti
-        onChange={onChange}
+        onChange={(options) => onChange(options.map((option) => option.value))}
         options={allCharacteristicOptions}
         placeholder="Select a characteristic..."
-        value={selected}
+        value={selectedOptions}
       />
     </div>
   );
@@ -67,13 +65,8 @@ export function CharacteristicsSelect({
 
 type CharacteristicsSelectProps = {
   label: string;
-  selected: Option[];
-  onChange: (selected: readonly Option[]) => void;
-};
-
-type Option = {
-  label: string;
-  value: string;
+  selected: string[];
+  onChange: (selected: string[]) => void;
 };
 
 const selectContainerStyles = css`

--- a/app/client/src/components/shared/DateSlider.tsx
+++ b/app/client/src/components/shared/DateSlider.tsx
@@ -1,12 +1,19 @@
-import { ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { css } from 'styled-components/macro';
 import { useRanger } from 'react-ranger';
 import { v4 as uuid } from 'uuid';
 // components
 import { textBoxStyles } from 'components/shared/MessageBoxes';
 
-function getTicks(yearsArray: number[], maxTicks: number) {  
-  if(yearsArray.length <= maxTicks) return yearsArray; 
+function getTicks(yearsArray: number[], maxTicks: number) {
+  if (yearsArray.length <= maxTicks) return yearsArray;
 
   const tickList = [];
   const length = yearsArray.length;
@@ -149,7 +156,7 @@ function DateSlider({
     setMinYear(min);
     setMaxYear(max);
   }, [min, max]);
-  
+
   const [sliderWidth, setSliderWidth] = useState(0);
   const sliderRef = useRef<HTMLDivElement>(null);
   const observer = useMemo(
@@ -160,7 +167,7 @@ function DateSlider({
           setSliderWidth(width);
         }
       }),
-    []
+    [],
   );
   useLayoutEffect(() => {
     if (!sliderRef?.current) return;
@@ -170,10 +177,12 @@ function DateSlider({
     };
   }, [observer, sliderRef]);
 
-
-  const yearsArray = [...Array(max - min + 1).keys()].map(x => x + min);
-  const tickList = getTicks(yearsArray, sliderWidth < 80 ? 1 : sliderWidth < 300 ? 2 : 4);
-  if(tickList.slice(-1)[0] !== max) tickList.push(max);
+  const yearsArray = [...Array(max - min + 1).keys()].map((x) => x + min);
+  const tickList = getTicks(
+    yearsArray,
+    sliderWidth < 80 ? 1 : sliderWidth < 300 ? 2 : 4,
+  );
+  if (tickList.slice(-1)[0] !== max) tickList.push(max);
 
   const { getTrackProps, segments, ticks, handles } = useRanger({
     min: minYear,

--- a/app/client/src/components/shared/DateSlider.tsx
+++ b/app/client/src/components/shared/DateSlider.tsx
@@ -178,10 +178,10 @@ function DateSlider({
   }, [observer, sliderRef]);
 
   const yearsArray = [...Array(max - min + 1).keys()].map((x) => x + min);
-  const tickList = getTicks(
-    yearsArray,
-    sliderWidth < 80 ? 1 : sliderWidth < 300 ? 2 : 4,
-  );
+  let maxTicks = 4;
+  if (sliderWidth < 80) maxTicks = 1;
+  else if (sliderWidth < 300) maxTicks = 2;
+  const tickList = getTicks(yearsArray, maxTicks);
   if (tickList.slice(-1)[0] !== max) tickList.push(max);
 
   const { getTrackProps, segments, ticks, handles } = useRanger({

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -176,7 +176,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
   useCyanWaterbodiesLayers();
   useDischargersLayers();
-  useMonitoringLocationsLayers(huc12 ? `huc=${huc12}` : null);
+  useMonitoringLocationsLayers({ filter: huc12 ? `huc=${huc12}` : null });
   useStreamgageLayers();
 
   const stateNationalUses = useStateNationalUsesContext();

--- a/app/client/src/components/shared/MenuList.tsx
+++ b/app/client/src/components/shared/MenuList.tsx
@@ -1,0 +1,67 @@
+import { useWindowSize } from '@reach/window-size';
+import { useCallback, useEffect, useRef } from 'react';
+import { VariableSizeList } from 'react-window';
+// types
+import type { MenuListProps } from 'react-select';
+
+export default MenuList;
+export function MenuList(props: MenuListProps) {
+  const { children, maxHeight } = props;
+  const { width } = useWindowSize();
+  const listRef = useRef<VariableSizeList | null>(null);
+
+  // keeps track of the size of the virtualized items. This handles
+  // items where the text wraps
+  const sizeMap = useRef<{ [index: number]: number }>({});
+  const setSize = useCallback((index: number, size: number) => {
+    sizeMap.current = { ...sizeMap.current, [index]: size };
+    listRef.current?.resetAfterIndex(index);
+  }, []);
+  const getSize = (index: number) => sizeMap.current[index] || 70;
+
+  // use the default style dropdown if there is no data
+  if (!Array.isArray(children) || children.length === 0) {
+    return children;
+  }
+
+  return (
+    <VariableSizeList
+      ref={listRef}
+      width="100%"
+      height={maxHeight}
+      itemCount={children.length}
+      itemSize={getSize}
+    >
+      {({ index, style }) => (
+        <div style={{ ...style, overflowX: 'hidden' }}>
+          <MenuItem
+            index={index}
+            width={width}
+            setSize={setSize}
+            value={children[index]}
+          />
+        </div>
+      )}
+    </VariableSizeList>
+  );
+}
+
+type MenuItemProps = {
+  index: number;
+  width: number;
+  setSize: (index: number, size: number) => void;
+  value: string;
+};
+
+function MenuItem({ index, width, setSize, value }: MenuItemProps) {
+  const rowRef = useRef<HTMLDivElement | null>(null);
+
+  // keep track of the height of the rows to autosize rows
+  useEffect(() => {
+    if (!rowRef?.current) return;
+
+    setSize(index, rowRef.current.getBoundingClientRect().height);
+  }, [setSize, index, width]);
+
+  return <div ref={rowRef}>{value}</div>;
+}

--- a/app/client/src/components/shared/MenuList.tsx
+++ b/app/client/src/components/shared/MenuList.tsx
@@ -1,11 +1,12 @@
 import { useWindowSize } from '@reach/window-size';
 import { useCallback, useEffect, useRef } from 'react';
 import { VariableSizeList } from 'react-window';
+import { components } from 'react-select';
 // types
 import type { MenuListProps } from 'react-select';
 
 export default MenuList;
-export function MenuList(props: MenuListProps) {
+export function MenuList<T>(props: MenuListProps<T>) {
   const { children, maxHeight } = props;
   const { width } = useWindowSize();
   const listRef = useRef<VariableSizeList | null>(null);
@@ -21,7 +22,7 @@ export function MenuList(props: MenuListProps) {
 
   // use the default style dropdown if there is no data
   if (!Array.isArray(children) || children.length === 0) {
-    return children;
+    return <components.MenuList {...props}>{children}</components.MenuList>;
   }
 
   return (

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -20,6 +20,7 @@ import {
   AccordionList,
   AccordionItem,
 } from 'components/shared/AccordionMapHighlight';
+import CharacteristicsSelect from 'components/shared/CharacteristicsSelect';
 import {
   keyMetricsStyles,
   keyMetricStyles,
@@ -958,20 +959,50 @@ function MonitoringTab({ activeState }: MonitoringTabProps) {
     );
   });
 
+  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
+    useState([]);
+
+  const selectedCharacteristics = selectedCharacteristicOptions.map(
+    (charc) => charc.value,
+  );
+
+  // Filter the displayed locations by selected characteristics
+  const filteredMonitoringAndSensors = sortedMonitoringAndSensors.filter(
+    (location) => {
+      if (!selectedCharacteristicOptions.length) return true;
+      for (let characteristic of Object.keys(location.totalsByCharacteristic)) {
+        if (selectedCharacteristics.includes(characteristic)) return true;
+      }
+      return false;
+    },
+  );
+
   const [expandedRows, setExpandedRows] = useState([]);
 
   return (
     <AccordionList
       title={
         <>
-          <strong>{sortedMonitoringAndSensors.length}</strong> locations with
-          data in the <em>{activeState.label}</em> watershed.
+          <strong>{filteredMonitoringAndSensors.length}</strong> locations with{' '}
+          {selectedCharacteristicOptions.length > 0
+            ? 'the selected characteristics'
+            : 'data'}{' '}
+          in the <em>{activeState.label}</em> watershed.
         </>
+      }
+      extraListHeaderContent={
+        <CharacteristicsSelect
+          label="Filter by Characteristic:"
+          selected={selectedCharacteristicOptions}
+          onChange={setSelectedCharacteristicOptions}
+        />
       }
       onSortChange={({ value }) => setMonitoringLocationsSortedBy(value)}
       onExpandCollapse={(allExpanded) => {
         if (allExpanded) {
-          setExpandedRows([...Array(sortedMonitoringAndSensors.length).keys()]);
+          setExpandedRows([
+            ...Array(filteredMonitoringAndSensors.length).keys(),
+          ]);
         } else {
           setExpandedRows([]);
         }
@@ -995,7 +1026,7 @@ function MonitoringTab({ activeState }: MonitoringTabProps) {
         },
       ]}
     >
-      {sortedMonitoringAndSensors.map((item, index) => {
+      {filteredMonitoringAndSensors.map((item, index) => {
         const feature = {
           geometry: {
             type: 'point',

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -1022,8 +1022,7 @@ function MonitoringTab({
       title={
         <>
           <strong>{sortedMonitoringAndSensors.length}</strong> of{' '}
-          <strong>{monitoringLocations.length}</strong>{' '}
-          {monitoringLocations.length === 1 ? 'location' : 'locations'} with{' '}
+          <strong>{monitoringLocations.length}</strong> locations with{' '}
           {selectedCharacteristics.length > 0
             ? 'the selected characteristic'
             : 'data'}

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -347,6 +347,9 @@ function TribalMapList({
       monitoringLocationsLayer.definitionExpression = '';
     }
   }
+
+  const [selectedTab, setSelectedTab] = useState(0);
+
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
   if (!browserIsCompatibleWithArcGIS()) {
     return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
@@ -546,7 +549,7 @@ function TribalMapList({
 
       {displayMode === 'list' && listShown && (
         <div css={modifiedTabStyles(mapListHeight)}>
-          <Tabs>
+          <Tabs onChange={setSelectedTab} defaultIndex={selectedTab}>
             <TabList>
               <Tab css={largeTabStyles}>Waterbodies</Tab>
               <Tab css={largeTabStyles}>Water Monitoring Locations</Tab>

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -1019,7 +1019,8 @@ function MonitoringTab({
       title={
         <>
           <strong>{sortedMonitoringAndSensors.length}</strong> of{' '}
-          <strong>{monitoringLocations.length}</strong> locations with{' '}
+          <strong>{monitoringLocations.length}</strong>{' '}
+          {monitoringLocations.length === 1 ? 'location' : 'locations'} with{' '}
           {selectedCharacteristics.length > 0
             ? 'the selected characteristic'
             : 'data'}

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -607,7 +607,7 @@ function TribalMap({
   }, [activeState]);
 
   const { monitoringLocationsLayer, surroundingMonitoringLocationsLayer } =
-    useMonitoringLocationsLayers(monitoringLocationsFilter);
+    useMonitoringLocationsLayers({ filter: monitoringLocationsFilter });
 
   const { surroundingUsgsStreamgagesLayer } = useStreamgageLayers();
   const { surroundingDischargersLayer } = useDischargersLayers();

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -82,6 +82,8 @@ import {
 } from 'config/errorMessages';
 // styles
 import { tabsStyles } from 'components/shared/ContentTabs';
+// types
+import type { MonitoringLocationAttributes } from 'types';
 
 const mapPadding = 20;
 
@@ -334,6 +336,17 @@ function TribalMapList({
     setListShown(true);
   }, [width]);
 
+  const [selectedCharacteristics, setSelectedCharacteristics] = useState([]);
+
+  // Reset data if the user switches locations
+  const [prevState, setPrevState] = useState(activeState);
+  if (activeState !== prevState) {
+    setPrevState(activeState);
+    setSelectedCharacteristics([]);
+    if (monitoringLocationsLayer) {
+      monitoringLocationsLayer.definitionExpression = '';
+    }
+  }
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
   if (!browserIsCompatibleWithArcGIS()) {
     return <div css={errorBoxStyles}>{esriMapLoadingFailure}</div>;
@@ -562,7 +575,11 @@ function TribalMapList({
                 )}
               </TabPanel>
               <TabPanel>
-                <MonitoringTab activeState={activeState} />
+                <MonitoringTab
+                  activeState={activeState}
+                  selectedCharacteristics={selectedCharacteristics}
+                  setSelectedCharacteristics={setSelectedCharacteristics}
+                />
               </TabPanel>
             </TabPanels>
           </Tabs>
@@ -935,47 +952,65 @@ function TribalMap({
 
 type MonitoringTabProps = {
   activeState: Object,
+  monitoringLocations: MonitoringLocationAttributes[],
+  selectedCharacteristics: string[],
+  setSelectedCharacteristics: (selected: string[]) => void,
 };
 
-function MonitoringTab({ activeState }: MonitoringTabProps) {
+function MonitoringTab({
+  activeState,
+  selectedCharacteristics,
+  setSelectedCharacteristics,
+}: MonitoringTabProps) {
   const services = useServicesContext();
 
   const { monitoringLocations } = useMonitoringLocations();
+  const { monitoringLocationsLayer } = useLayers();
 
   // sort the monitoring locations
   const [monitoringLocationsSortedBy, setMonitoringLocationsSortedBy] =
     useState('locationName');
-  const sortedMonitoringAndSensors = [...monitoringLocations].sort((a, b) => {
-    if (monitoringLocationsSortedBy === 'totalMeasurements') {
-      return (b.totalMeasurements || 0) - (a.totalMeasurements || 0);
-    }
-
-    if (monitoringLocationsSortedBy === 'siteId') {
-      return a.siteId.localeCompare(b.siteId);
-    }
-
-    return a[monitoringLocationsSortedBy].localeCompare(
-      b[monitoringLocationsSortedBy],
-    );
-  });
-
-  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
-    useState([]);
-
-  const selectedCharacteristics = selectedCharacteristicOptions.map(
-    (charc) => charc.value,
-  );
 
   // Filter the displayed locations by selected characteristics
-  const filteredMonitoringAndSensors = sortedMonitoringAndSensors.filter(
-    (location) => {
-      if (!selectedCharacteristicOptions.length) return true;
-      for (let characteristic of Object.keys(location.totalsByCharacteristic)) {
-        if (selectedCharacteristics.includes(characteristic)) return true;
+  const filteredMonitoringLocations = monitoringLocations.filter((location) => {
+    if (!selectedCharacteristics.length) return true;
+    for (let characteristic of Object.keys(location.totalsByCharacteristic)) {
+      if (selectedCharacteristics.includes(characteristic)) return true;
+    }
+    return false;
+  });
+
+  const sortedMonitoringAndSensors = [...filteredMonitoringLocations].sort(
+    (a, b) => {
+      if (monitoringLocationsSortedBy === 'totalMeasurements') {
+        return (b.totalMeasurements || 0) - (a.totalMeasurements || 0);
       }
-      return false;
+
+      if (monitoringLocationsSortedBy === 'siteId') {
+        return a.siteId.localeCompare(b.siteId);
+      }
+
+      return a[monitoringLocationsSortedBy].localeCompare(
+        b[monitoringLocationsSortedBy],
+      );
     },
   );
+
+  // Update the filters on the layer
+  const locationIds = filteredMonitoringLocations.map(
+    (location) => location.uniqueId,
+  );
+  let definitionExpression = '';
+  if (locationIds.length === 0) definitionExpression = '1=0';
+  else if (locationIds.length !== monitoringLocations.length) {
+    definitionExpression = `uniqueId IN ('${locationIds.join("','")}')`;
+  }
+  if (
+    monitoringLocationsLayer &&
+    definitionExpression !== monitoringLocationsLayer.definitionExpression
+  ) {
+    monitoringLocationsLayer.definitionExpression = definitionExpression;
+  }
 
   const [expandedRows, setExpandedRows] = useState([]);
 
@@ -983,26 +1018,26 @@ function MonitoringTab({ activeState }: MonitoringTabProps) {
     <AccordionList
       title={
         <>
-          <strong>{filteredMonitoringAndSensors.length}</strong> locations with{' '}
-          {selectedCharacteristicOptions.length > 0
-            ? 'the selected characteristics'
-            : 'data'}{' '}
-          in the <em>{activeState.label}</em> watershed.
+          <strong>{sortedMonitoringAndSensors.length}</strong> of{' '}
+          <strong>{monitoringLocations.length}</strong> locations with{' '}
+          {selectedCharacteristics.length > 0
+            ? 'the selected characteristic'
+            : 'data'}
+          {selectedCharacteristics.length > 1 && 's'} in the{' '}
+          <em>{activeState.label}</em> watershed.
         </>
       }
       extraListHeaderContent={
         <CharacteristicsSelect
           label="Filter by Characteristic:"
-          selected={selectedCharacteristicOptions}
-          onChange={setSelectedCharacteristicOptions}
+          selected={selectedCharacteristics}
+          onChange={setSelectedCharacteristics}
         />
       }
       onSortChange={({ value }) => setMonitoringLocationsSortedBy(value)}
       onExpandCollapse={(allExpanded) => {
         if (allExpanded) {
-          setExpandedRows([
-            ...Array(filteredMonitoringAndSensors.length).keys(),
-          ]);
+          setExpandedRows([...Array(sortedMonitoringAndSensors.length).keys()]);
         } else {
           setExpandedRows([]);
         }
@@ -1026,7 +1061,7 @@ function MonitoringTab({ activeState }: MonitoringTabProps) {
         },
       ]}
     >
-      {filteredMonitoringAndSensors.map((item, index) => {
+      {sortedMonitoringAndSensors.map((item, index) => {
         const feature = {
           geometry: {
             type: 'point',

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2427,7 +2427,6 @@ function MonitoringLocationsContent({
   }, [attributes]);
 
   const {
-    dataByYear,
     locationLatitude,
     locationLongitude,
     locationName,
@@ -2442,8 +2441,6 @@ function MonitoringLocationsContent({
     totalMeasurements,
     timeframe,
   } = parsed;
-
-  const hasAnnualData = Object.keys(dataByYear).length > 0;
 
   const [groups, setGroups] = useState(() => {
     const { newGroups } = buildGroups(checkIfGroupInMapping, totalsByGroup);
@@ -2483,13 +2480,13 @@ function MonitoringLocationsContent({
         }
       }
 
-      if (hasAnnualData) {
+      if (timeframe) {
         filter += `&startDateLo=01-01-${timeframe[0]}&startDateHi=12-31-${timeframe[1]}`;
       }
 
       setCharGroupFilters(filter);
     },
-    [hasAnnualData, setCharGroupFilters, selectAll, timeframe],
+    [setCharGroupFilters, selectAll, timeframe],
   );
 
   useEffect(() => {
@@ -2618,7 +2615,7 @@ function MonitoringLocationsContent({
               value: (
                 <>
                   {Number(totalSamples).toLocaleString()}
-                  {hasAnnualData ? <small>(all time)</small> : null}
+                  {timeframe ? <small>(all time)</small> : null}
                 </>
               ),
             },
@@ -2631,7 +2628,7 @@ function MonitoringLocationsContent({
               value: (
                 <>
                   {Number(totalMeasurements).toLocaleString()}
-                  {hasAnnualData && (
+                  {timeframe && (
                     <small>
                       ({timeframe[0]} - {timeframe[1]})
                     </small>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2427,6 +2427,7 @@ function MonitoringLocationsContent({
   }, [attributes]);
 
   const {
+    dataByYear,
     locationLatitude,
     locationLongitude,
     locationName,
@@ -2441,6 +2442,8 @@ function MonitoringLocationsContent({
     totalMeasurements,
     timeframe,
   } = parsed;
+
+  const hasAnnualData = Object.keys(dataByYear).length > 0;
 
   const [groups, setGroups] = useState(() => {
     const { newGroups } = buildGroups(checkIfGroupInMapping, totalsByGroup);
@@ -2480,13 +2483,13 @@ function MonitoringLocationsContent({
         }
       }
 
-      if (timeframe) {
+      if (hasAnnualData) {
         filter += `&startDateLo=01-01-${timeframe[0]}&startDateHi=12-31-${timeframe[1]}`;
       }
 
       setCharGroupFilters(filter);
     },
-    [setCharGroupFilters, selectAll, timeframe],
+    [hasAnnualData, setCharGroupFilters, selectAll, timeframe],
   );
 
   useEffect(() => {
@@ -2615,7 +2618,7 @@ function MonitoringLocationsContent({
               value: (
                 <>
                   {Number(totalSamples).toLocaleString()}
-                  {timeframe ? <small>(all time)</small> : null}
+                  {hasAnnualData ? <small>(all time)</small> : null}
                 </>
               ),
             },
@@ -2628,7 +2631,7 @@ function MonitoringLocationsContent({
               value: (
                 <>
                   {Number(totalMeasurements).toLocaleString()}
-                  {timeframe && (
+                  {hasAnnualData && (
                     <small>
                       ({timeframe[0]} - {timeframe[1]})
                     </small>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2415,7 +2415,11 @@ function MonitoringLocationsContent({
   const attributes: MonitoringLocationAttributes = feature.attributes;
   const layer = feature.layer;
   const parsed = useMemo(() => {
-    const structuredProps = ['totalsByGroup', 'timeframe'];
+    const structuredProps = [
+      'totalsByCharacteristic',
+      'totalsByGroup',
+      'timeframe',
+    ];
     return parseAttributes<MonitoringLocationAttributes>(
       structuredProps,
       attributes,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -13,8 +13,8 @@ import type {
   ParameterToggleObject,
 } from 'types';
 
-const initialMonitoringGroups = characteristicGroupMappings.reduce(
-  (groups, next) => {
+export const initialMonitoringGroups = () => {
+  return characteristicGroupMappings.reduce((groups, next) => {
     groups[next.label] = {
       label: next.label,
       characteristicGroups: [...next.groupNames],
@@ -22,9 +22,8 @@ const initialMonitoringGroups = characteristicGroupMappings.reduce(
       toggled: true,
     };
     return groups;
-  },
-  {},
-);
+  }, {});
+};
 
 export const LocationSearchContext = createContext();
 
@@ -150,7 +149,7 @@ export class LocationSearchProvider extends Component<Props, State> {
 
     // monitoring panel
     monitoringCharacteristicsStatus: 'idle',
-    monitoringGroups: initialMonitoringGroups,
+    monitoringGroups: initialMonitoringGroups(),
     monitoringFeatureUpdates: null,
     monitoringYearsRange: [0, 0],
     selectedMonitoringYearsRange: null,
@@ -388,7 +387,7 @@ export class LocationSearchProvider extends Component<Props, State> {
         hucBoundaries: '',
         dischargerPermitComponents: null,
         monitoringCharacteristicsStatus: 'idle',
-        monitoringGroups: initialMonitoringGroups,
+        monitoringGroups: initialMonitoringGroups(),
         monitoringFeatureUpdates: null,
         monitoringYearsRange: [0, 0],
         selectedMonitoringYearsRange: null,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -4,6 +4,7 @@ import React, { Component, createContext } from 'react';
 import type { ReactNode } from 'react';
 import type {
   DischargerPermitComponents,
+  FetchStatus,
   Huc12SummaryData,
   MonitoringLocationGroups,
   MonitoringYearsRange,
@@ -16,7 +17,7 @@ export const LocationSearchContext = createContext();
 export const initialWorkerData = {
   minYear: null,
   maxYear: null,
-  annualData: {},
+  sites: {},
 };
 
 type Props = {
@@ -70,7 +71,7 @@ type State = {
   monitoringGroups: MonitoringLocationGroups | null,
   monitoringFeatureUpdates: ?Object,
   monitoringYearsRange: MonitoringYearsRange | null,
-  monitoringWorkerData: MonitoringWorkerData,
+  monitoringAnnualRecords: { status: FetchStatus, data: MonitoringWorkerData },
 
   // identified issues panel
   showAllPolluted: boolean,
@@ -142,7 +143,7 @@ export class LocationSearchProvider extends Component<Props, State> {
     monitoringGroups: null,
     monitoringFeatureUpdates: null,
     monitoringYearsRange: null,
-    monitoringWorkerData: initialWorkerData,
+    monitoringAnnualRecords: { status: 'idle', data: initialWorkerData },
 
     // identified issues panel
     showAllPolluted: true,
@@ -300,8 +301,8 @@ export class LocationSearchProvider extends Component<Props, State> {
     setMonitoringYearsRange: (monitoringYearsRange) => {
       this.setState({ monitoringYearsRange });
     },
-    setMonitoringWorkerData: (monitoringWorkerData) => {
-      this.setState({ monitoringWorkerData });
+    setMonitoringAnnualRecords: (monitoringAnnualRecords) => {
+      this.setState({ monitoringAnnualRecords });
     },
     setShowAllPolluted: (showAllPolluted) => {
       this.setState({ showAllPolluted });
@@ -376,7 +377,7 @@ export class LocationSearchProvider extends Component<Props, State> {
         monitoringGroups: null,
         monitoringFeatureUpdates: null,
         monitoringYearsRange: null,
-        monitoringWorkerData: initialWorkerData,
+        monitoringAnnualRecords: { status: 'idle', data: initialWorkerData },
         nonprofits: { status: 'fetching', data: [] },
         grts: { status: 'fetching', data: [] },
         attainsPlans: { status: 'fetching', data: {} },

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -1,5 +1,7 @@
 import Color from '@arcgis/core/Color';
 import React, { Component, createContext } from 'react';
+// config
+import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
 // types
 import type { ReactNode } from 'react';
 import type {
@@ -8,17 +10,23 @@ import type {
   Huc12SummaryData,
   MonitoringLocationGroups,
   MonitoringYearsRange,
-  MonitoringWorkerData,
   ParameterToggleObject,
 } from 'types';
 
-export const LocationSearchContext = createContext();
+const initialMonitoringGroups = characteristicGroupMappings.reduce(
+  (groups, next) => {
+    groups[next.label] = {
+      label: next.label,
+      characteristicGroups: [...next.groupNames],
+      stations: [],
+      toggled: true,
+    };
+    return groups;
+  },
+  {},
+);
 
-export const initialWorkerData = {
-  minYear: null,
-  maxYear: null,
-  sites: {},
-};
+export const LocationSearchContext = createContext();
 
 type Props = {
   children: ReactNode,
@@ -68,10 +76,11 @@ type State = {
   dischargerPermitComponents: DischargerPermitComponents | null,
 
   // monitoring panel
-  monitoringGroups: MonitoringLocationGroups | null,
+  monitoringCharacteristicsStatus: FetchStatus,
+  monitoringGroups: MonitoringLocationGroups,
   monitoringFeatureUpdates: ?Object,
-  monitoringYearsRange: MonitoringYearsRange | null,
-  monitoringAnnualRecords: { status: FetchStatus, data: MonitoringWorkerData },
+  monitoringYearsRange: MonitoringYearsRange,
+  selectedMonitoringYearsRange: MonitoringYearsRange | null,
 
   // identified issues panel
   showAllPolluted: boolean,
@@ -140,10 +149,11 @@ export class LocationSearchProvider extends Component<Props, State> {
     dischargerPermitComponents: null,
 
     // monitoring panel
-    monitoringGroups: null,
+    monitoringCharacteristicsStatus: 'idle',
+    monitoringGroups: initialMonitoringGroups,
     monitoringFeatureUpdates: null,
-    monitoringYearsRange: null,
-    monitoringAnnualRecords: { status: 'idle', data: initialWorkerData },
+    monitoringYearsRange: [0, 0],
+    selectedMonitoringYearsRange: null,
 
     // identified issues panel
     showAllPolluted: true,
@@ -292,6 +302,9 @@ export class LocationSearchProvider extends Component<Props, State> {
     setDischargerPermitComponents: (dischargerPermitComponents) => {
       this.setState({ dischargerPermitComponents });
     },
+    setMonitoringCharacteristicsStatus: (monitoringCharacteristicsStatus) => {
+      this.setState({ monitoringCharacteristicsStatus });
+    },
     setMonitoringGroups: (monitoringGroups) => {
       this.setState({ monitoringGroups });
     },
@@ -301,8 +314,8 @@ export class LocationSearchProvider extends Component<Props, State> {
     setMonitoringYearsRange: (monitoringYearsRange) => {
       this.setState({ monitoringYearsRange });
     },
-    setMonitoringAnnualRecords: (monitoringAnnualRecords) => {
-      this.setState({ monitoringAnnualRecords });
+    setSelectedMonitoringYearsRange: (selectedMonitoringYearsRange) => {
+      this.setState({ selectedMonitoringYearsRange });
     },
     setShowAllPolluted: (showAllPolluted) => {
       this.setState({ showAllPolluted });
@@ -374,10 +387,11 @@ export class LocationSearchProvider extends Component<Props, State> {
         atHucBoundaries: false,
         hucBoundaries: '',
         dischargerPermitComponents: null,
-        monitoringGroups: null,
+        monitoringCharacteristicsStatus: 'idle',
+        monitoringGroups: initialMonitoringGroups,
         monitoringFeatureUpdates: null,
-        monitoringYearsRange: null,
-        monitoringAnnualRecords: { status: 'idle', data: initialWorkerData },
+        monitoringYearsRange: [0, 0],
+        selectedMonitoringYearsRange: null,
         nonprofits: { status: 'fetching', data: [] },
         grts: { status: 'fetching', data: [] },
         attainsPlans: { status: 'fetching', data: {} },

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -75,11 +75,11 @@ type State = {
   dischargerPermitComponents: DischargerPermitComponents | null,
 
   // monitoring panel
-  monitoringCharacteristicsStatus: FetchStatus,
+  monitoringPeriodOfRecordStatus: FetchStatus,
   monitoringGroups: MonitoringLocationGroups,
   monitoringFeatureUpdates: ?Object,
   monitoringYearsRange: MonitoringYearsRange,
-  selectedMonitoringYearsRange: MonitoringYearsRange | null,
+  selectedMonitoringYearsRange: MonitoringYearsRange,
 
   // identified issues panel
   showAllPolluted: boolean,
@@ -148,11 +148,11 @@ export class LocationSearchProvider extends Component<Props, State> {
     dischargerPermitComponents: null,
 
     // monitoring panel
-    monitoringCharacteristicsStatus: 'idle',
+    monitoringPeriodOfRecordStatus: 'idle',
     monitoringGroups: initialMonitoringGroups(),
     monitoringFeatureUpdates: null,
     monitoringYearsRange: [0, 0],
-    selectedMonitoringYearsRange: null,
+    selectedMonitoringYearsRange: [0, 0],
 
     // identified issues panel
     showAllPolluted: true,
@@ -301,8 +301,8 @@ export class LocationSearchProvider extends Component<Props, State> {
     setDischargerPermitComponents: (dischargerPermitComponents) => {
       this.setState({ dischargerPermitComponents });
     },
-    setMonitoringCharacteristicsStatus: (monitoringCharacteristicsStatus) => {
-      this.setState({ monitoringCharacteristicsStatus });
+    setMonitoringPeriodOfRecordStatus: (monitoringPeriodOfRecordStatus) => {
+      this.setState({ monitoringPeriodOfRecordStatus });
     },
     setMonitoringGroups: (monitoringGroups) => {
       this.setState({ monitoringGroups });
@@ -386,11 +386,11 @@ export class LocationSearchProvider extends Component<Props, State> {
         atHucBoundaries: false,
         hucBoundaries: '',
         dischargerPermitComponents: null,
-        monitoringCharacteristicsStatus: 'idle',
+        monitoringPeriodOfRecordStatus: 'idle',
         monitoringGroups: initialMonitoringGroups(),
         monitoringFeatureUpdates: null,
         monitoringYearsRange: [0, 0],
-        selectedMonitoringYearsRange: null,
+        selectedMonitoringYearsRange: [0, 0],
         nonprofits: { status: 'fetching', data: [] },
         grts: { status: 'fetching', data: [] },
         attainsPlans: { status: 'fetching', data: {} },

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -118,9 +118,11 @@ export interface Feature {
 }
 
 interface FetchEmptyState {
-  status: 'empty' | 'idle' | 'fetching' | 'failure' | 'pending';
+  status: FetchEmptyStatus;
   data: {} | [] | null;
 }
+
+type FetchEmptyStatus = 'empty' | 'idle' | 'fetching' | 'failure' | 'pending';
 
 export interface FetchSuccessState<Type> {
   status: 'success';
@@ -128,6 +130,8 @@ export interface FetchSuccessState<Type> {
 }
 
 export type FetchState<Type> = FetchEmptyState | FetchSuccessState<Type>;
+
+export type FetchStatus = FetchEmptyStatus | 'success';
 
 export interface ExtendedGraphic extends __esri.Graphic {
   originalGeometry?: __esri.Geometry;
@@ -292,7 +296,11 @@ export type MonitoringYearsRange = number[] | null;
 export type MonitoringWorkerData = {
   minYear: number;
   maxYear: number;
-  annualData: any;
+  sites: {
+    [siteId: string]: {
+      [year: string]: AnnualStationData;
+    };
+  };
 };
 
 export interface NonProfitAttributes {

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -243,12 +243,13 @@ export interface MonitoringLocationAttributes {
   locationUrl: string;
   locationUrlPartial: string;
   state: string;
-  dataByYear: { [year: string | number]: AnnualStationData } | null;
+  dataByYear: { [year: string | number]: AnnualStationData };
   providerName: string;
   totalSamples: number;
   totalMeasurements: number;
-  totalsByGroup: { [groups: string]: number };
-  totalsByLabel: { [label: string]: number } | null;
+  totalsByCharacteristic: { [characteristic: string]: number };
+  totalsByGroup: { [group: string]: number };
+  totalsByLabel: { [label: string]: number };
   timeframe: [number, number] | null;
   uniqueId: string;
 }

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -250,7 +250,7 @@ export interface MonitoringLocationAttributes {
   totalsByCharacteristic: { [characteristic: string]: number };
   totalsByGroup: { [group: string]: number };
   totalsByLabel: { [label: string]: number };
-  timeframe: [number, number];
+  timeframe: [number, number] | null;
   uniqueId: string;
 }
 

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -292,7 +292,7 @@ export interface MonitoringLocationsData {
   type: 'FeatureCollection';
 }
 
-export type MonitoringYearsRange = number[] | null;
+export type MonitoringYearsRange = [number, number];
 
 export type MonitoringWorkerData = {
   minYear: number;

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -250,7 +250,7 @@ export interface MonitoringLocationAttributes {
   totalsByCharacteristic: { [characteristic: string]: number };
   totalsByGroup: { [group: string]: number };
   totalsByLabel: { [label: string]: number };
-  timeframe: [number, number] | null;
+  timeframe: [number, number];
   uniqueId: string;
 }
 

--- a/app/client/src/utils/hooks/monitoringLocations.tsx
+++ b/app/client/src/utils/hooks/monitoringLocations.tsx
@@ -87,15 +87,15 @@ export function useMonitoringLocations() {
 }
 
 export function useMonitoringGroups(
-  param?: 'huc12' | 'siteId',
   filter?: string,
+  param: 'huc12' | 'siteId' = 'huc12',
 ) {
   const { monitoringGroups, setMonitoringGroups } = useContext(
     LocationSearchContext,
   );
   const { monitoringLocations } = useFetchedDataState();
 
-  const monitoringAnnualRecords = usePeriodOfRecordData(param, filter);
+  const monitoringAnnualRecords = usePeriodOfRecordData(filter, param);
 
   // Add the stations historical data to the `dataByYear` property,
   const addAnnualData = useCallback(
@@ -144,12 +144,15 @@ export function useMonitoringGroups(
     );
   }, [addAnnualData, monitoringLocations, setMonitoringGroups]);
 
-  return monitoringGroups;
+  return { monitoringGroups, setMonitoringGroups };
 }
 
 // Passes parsing of historical CSV data to a Web Worker,
 // which itself utilizes an external service
-function usePeriodOfRecordData(param?: 'huc12' | 'siteId', filter?: string) {
+function usePeriodOfRecordData(
+  filter?: string,
+  param: 'huc12' | 'siteId' = 'huc12',
+) {
   const {
     setMonitoringCharacteristicsStatus,
     setMonitoringYearsRange,

--- a/app/client/src/utils/hooks/monitoringLocations.tsx
+++ b/app/client/src/utils/hooks/monitoringLocations.tsx
@@ -446,7 +446,11 @@ function buildLayer(
       title: getTitle,
       content: (feature: Feature) => {
         // Parse non-scalar variables
-        const structuredProps = ['totalsByGroup', 'timeframe'];
+        const structuredProps = [
+          'totalsByCharacteristic',
+          'totalsByGroup',
+          'timeframe',
+        ];
         feature.graphic.attributes = parseAttributes(
           structuredProps,
           feature.graphic.attributes,
@@ -578,7 +582,7 @@ function transformServiceData(
       totalsByLabel: parseStationLabelTotals(
         station.properties.characteristicGroupResultCount,
       ),
-      timeframe: [0, 0],
+      timeframe: null,
       // create a unique id, so we can check if the monitoring station has
       // already been added to the display (since a monitoring station id
       // isn't universally unique)

--- a/app/client/src/utils/hooks/monitoringLocations.tsx
+++ b/app/client/src/utils/hooks/monitoringLocations.tsx
@@ -111,9 +111,8 @@ export function useMonitoringGroups() {
 
 // Passes parsing of historical CSV data to a Web Worker,
 // which itself utilizes an external service
-export function useMonitoringPeriodOfRecord() {
+export function useMonitoringPeriodOfRecord(filter: string | null) {
   const {
-    huc12,
     setMonitoringCharacteristicsStatus,
     setMonitoringYearsRange,
     setSelectedMonitoringYearsRange,
@@ -142,11 +141,10 @@ export function useMonitoringPeriodOfRecord() {
 
   // Craft the URL
   let url: string | null = null;
-  if (services.status === 'success' && huc12) {
+  if (services.status === 'success' && filter) {
     url =
       `${services.data.waterQualityPortal.monitoringLocation}search?` +
-      `&mimeType=csv&dataProfile=periodOfRecord&summaryYears=all`;
-    url += `&huc=${huc12}`;
+      `&mimeType=csv&dataProfile=periodOfRecord&summaryYears=all&${filter}`;
   }
 
   const recordsWorker = useRef<Worker | null>(null);
@@ -235,7 +233,7 @@ function useUpdateData(localFilter: string | null) {
   }, [fetchedDataDispatch, localFilter, services]);
 
   // Add annual characteristic data to the local data
-  const annualData = useMonitoringPeriodOfRecord();
+  const annualData = useMonitoringPeriodOfRecord(localFilter);
   useEffect(() => {
     if (!localData?.length) return;
     if (annualData.status !== 'success') return;

--- a/app/client/src/utils/hooks/monitoringLocations.tsx
+++ b/app/client/src/utils/hooks/monitoringLocations.tsx
@@ -113,7 +113,7 @@ export function useMonitoringGroups() {
 // which itself utilizes an external service
 export function useMonitoringPeriodOfRecord(filter: string | null) {
   const {
-    setMonitoringCharacteristicsStatus,
+    setMonitoringPeriodOfRecordStatus,
     setMonitoringYearsRange,
     setSelectedMonitoringYearsRange,
   } = useContext(LocationSearchContext);
@@ -131,10 +131,10 @@ export function useMonitoringPeriodOfRecord(filter: string | null) {
     const { minYear, maxYear } = monitoringAnnualRecords.data;
     setMonitoringYearsRange([minYear, maxYear]);
     setSelectedMonitoringYearsRange([minYear, maxYear]);
-    setMonitoringCharacteristicsStatus(monitoringAnnualRecords.status); // Share the status
+    setMonitoringPeriodOfRecordStatus(monitoringAnnualRecords.status); // Share the status
   }, [
     monitoringAnnualRecords,
-    setMonitoringCharacteristicsStatus,
+    setMonitoringPeriodOfRecordStatus,
     setMonitoringYearsRange,
     setSelectedMonitoringYearsRange,
   ]);
@@ -568,7 +568,7 @@ function transformServiceData(
       totalsByLabel: parseStationLabelTotals(
         station.properties.characteristicGroupResultCount,
       ),
-      timeframe: null,
+      timeframe: [0, 0],
       // create a unique id, so we can check if the monitoring station has
       // already been added to the display (since a monitoring station id
       // isn't universally unique)


### PR DESCRIPTION
## Related Issues:
* [HMW-573](https://jira.epa.gov/browse/HMW-573)

## Main Changes:
* Added a multi-selectable characteristic filter to the _Past Water Conditions_ accordion lists. This input's options are drawn from the WQP `periodOfRecord` summary service, so is not immediately active.
* Moved the point of fetching `periodOfRecord` data up into the `useMonitoringLocationsLayers` hook. There is an option to disable, which is used on the Monitoring Report page. While the service may still be used on that page in [HMW-572](https://jira.epa.gov/browse/HMW-572), it will likely be on an as-needed basis.
* Updated some state items to use sensible defaults instead of `null` (much more feasible now due to the amount of TypeScript).

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/monitoring.
2. In the _Past Water Conditions_ tab, select a characteristic from the **Filter by Characteristic** input, and confirm the change is reflected in the list.
3. Go to the Monitoring Report page of several of those list items and confirm the selected characteristic is indeed present.
4. On the Community page, ensure that the date slider continues to filter locations alongside the characteristic filter.
5. Go to the _Water Monitoring Locations_ section of the Overview tab.
6. Confirm the characteristic filter is present.
7. Toggle of the Past Water Conditions, then confirm the characteristic filter is no longer visible.
8. Go to http://localhost:3000/community/Portland,%20OR,%20USA/monitoring, and verify the toggle table and list items are still populated before the date slider and characteristic input are ready.
9. Confirm the filter works properly for the list view on tribal pages, e.g. http://localhost:3000/tribe/UTEMTN.