### PR TITLE
Feature/589 state loading and text changes

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -191,7 +191,11 @@ function createAccordionItem(
             value: item.pws_type,
           },
           {
-            label: 'Drinking Water Health Based Violations',
+            label: (
+              <GlossaryTerm term="Drinking Water Health-based Violations">
+                Drinking Water Health Based Violations
+              </GlossaryTerm>
+            ),
             value: item.violations === 'Y' ? 'Yes' : 'No',
           },
           {

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -426,7 +426,7 @@ function DrinkingWater() {
 
         if (checkForDuplicates.length === 0) {
           // deepclone item to prevent changing the underlying service data
-          const mergedItem = Object.assign({}, item);
+          const mergedItem = { ...item };
           mergedItem.water_type_calc = 'Ground Water & Surface Water';
           if (bothDisplayed) {
             displayedWithdrawers.push(mergedItem);

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -193,7 +193,7 @@ function createAccordionItem(
           {
             label: (
               <GlossaryTerm term="Drinking Water Health-based Violations">
-                Drinking Water Health Based Violations
+                Drinking Water Health-based Violations
               </GlossaryTerm>
             ),
             value: item.violations === 'Y' ? 'Yes' : 'No',

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
@@ -444,7 +444,9 @@ function SiteSpecific({
             <div css={accordionContentStyles}>
               <DisclaimerModal>
                 <p>
-                  The impairments listed below do not necessarily affect the <strong>{useSelected}</strong> use but are present in the water and may apply to other Uses.
+                  The impairments listed below do not necessarily affect the{' '}
+                  <strong>{useSelected}</strong> use but are present in the
+                  water and may apply to other Uses.
                 </p>
               </DisclaimerModal>
               <ul>{parameters}</ul>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
@@ -11,6 +11,7 @@ import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import DynamicExitDisclaimer from 'components/shared/DynamicExitDisclaimer';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
+import { DisclaimerModal } from 'components/shared/Modal';
 // styled components
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 // contexts
@@ -441,6 +442,11 @@ function SiteSpecific({
             }
           >
             <div css={accordionContentStyles}>
+              <DisclaimerModal>
+                <p>
+                  The impairments listed below do not necessarily affect the <strong>{useSelected}</strong> use but are present in the water and may apply to other Uses.
+                </p>
+              </DisclaimerModal>
               <ul>{parameters}</ul>
             </div>
           </AccordionItem>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
@@ -445,7 +445,7 @@ function SiteSpecific({
               <DisclaimerModal>
                 <p>
                   The impairments listed below do not necessarily affect the{' '}
-                  <strong>{useSelected}</strong> use but are present in the
+                  <strong>{useSelected}</strong> Use but are present in the
                   water and may apply to other Uses.
                 </p>
               </DisclaimerModal>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -397,8 +397,9 @@ function StateTribal() {
       <TabLinks />
 
       <div css={containerStyles} className="container" data-content="state">
-        {(states.status === 'fetching' ||
-          tribes.status === 'fetching') && <LoadingSpinner />}
+        {(states.status === 'fetching' || tribes.status === 'fetching') && (
+          <LoadingSpinner />
+        )}
 
         {states.status === 'failure' && (
           <div css={modifiedErrorBoxStyles}>

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -397,8 +397,8 @@ function StateTribal() {
       <TabLinks />
 
       <div css={containerStyles} className="container" data-content="state">
-        {states.status === 'fetching' ||
-          (tribes.status === 'fetching' && <LoadingSpinner />)}
+        {(states.status === 'fetching' ||
+          tribes.status === 'fetching') && <LoadingSpinner />}
 
         {states.status === 'failure' && (
           <div css={modifiedErrorBoxStyles}>

--- a/app/client/src/components/shared/WaterSystemSummary.js
+++ b/app/client/src/components/shared/WaterSystemSummary.js
@@ -374,7 +374,7 @@ function WaterSystemSummary({ state }: Props) {
         <small>(opens new browser tab)</small>. GPRA results are for{' '}
         <strong>Community Water Systems</strong> for{' '}
         <GlossaryTerm term="Drinking Water Health-based Violations">
-          Drinking Water Health Based Violations
+          Drinking Water Health-based Violations
         </GlossaryTerm>{' '}
         only. Drinking water data are submitted quarterly by the Primacy
         Agencies and these summary metrics are then posted by EPA.

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1219,7 +1219,7 @@ function WaterbodyInfo({
   if (type === 'Congressional District') {
     content = congressionalDistrictContent();
   }
-  if (type === 'CyAN') {
+  if (type === 'Blue-Green Algae') {
     content = (
       <CyanContent
         feature={feature}

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -796,7 +796,7 @@ export function getPopupContent({
 
     // CyAN waterbody
     else if ('GNIS_NAME' in attributes) {
-      type = 'CyAN';
+      type = 'Blue-Green Algae';
     }
 
     // usgs streamgage or monitoring location

--- a/app/cypress/e2e/national.cy.ts
+++ b/app/cypress/e2e/national.cy.ts
@@ -126,7 +126,7 @@ describe('National Drinking Water tab', () => {
   });
 
   it('Clicking a Glossary Term opens the Glossary panel', () => {
-    cy.findByText(/Drinking Water Health Based Violations/).click();
+    cy.findAllByText(/Drinking Water Health-based Violations/).filter(':visible').click();
     cy.findByText(/Violations of maximum contaminant levels/).should(
       'be.visible',
     );


### PR DESCRIPTION
## Related Issues / Main Changes:
* [HMW-584](https://jira.epa.gov/browse/HMW-584) - Added a disclaimer to the `Top reasons for impairment...` section on the state/tribal page.
* [HMW-587](https://jira.epa.gov/browse/HMW-587) - Linked `Drinking Water Health based Violations` to the glossary.
* [HMW-588](https://jira.epa.gov/browse/HMW-588) - Changed CyAN map popup title to `Blue-Green Algae`.
* [HMW-589](https://jira.epa.gov/browse/HMW-589) - Fixed a bug where the loading spinner on the State & Tribal landing page was not being displayed.


## Steps To Test:
1. Navigate to http://localhost:3000/state/WV/water-quality-overview
2. Click on Drinking Water Tab, select the `Rivers and Streams` water type and expand the `Top Reasons for Impairment...` section
3. Verify a disclaimer button is visible and the text matches the ticket
4. Navigate to http://localhost:3000/community/lake%20okeechobee/drinking-water
5. Expand one of the accordion items
6. Verify the `Drinking Water Health based Violations` item is linked to the glossary
7. Go to the Water Monitoring tab
8. Click a CyAN waterbody on the map
9. Verify the popup title is `Blue-Green Algae`
10. Navigate to http://localhost:3000/state-and-tribal
11. Turn on throttling on the network tab of the chrome developer tools
12. Refresh the page
13. Verify a loading spinner is displayed where the state/tribe selection box is

