### PR TITLE
Feature/594 modal scroll behavior

### DIFF
--- a/app/client/src/components/shared/Modal.tsx
+++ b/app/client/src/components/shared/Modal.tsx
@@ -20,9 +20,10 @@ const cancelButtonStyles = css`
 `;
 
 const closeButtonStyles = css`
+  border-radius: 6px;
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 6px;
+  right: 6px;
   padding: 0;
   border: none;
   width: 1.5rem;
@@ -48,10 +49,17 @@ const confirmButtonStyles = css`
   }
 `;
 
-const contentStyles = (maxWidth: string) => css`
+const contentStyles = (
+  maxWidth: string = '100%',
+  maxHeight: string = '100%',
+) => css`
   background-color: white;
-  max-width: ${maxWidth};
+  border-radius: 6px;
+  max-height: min(80%, ${maxHeight});
+  max-width: min(90%, ${maxWidth});
+  overflow-y: auto;
   padding: 1.5rem;
+  padding-top: calc(1.5rem + 6px);
   position: relative;
   width: 100%;
 
@@ -64,6 +72,7 @@ const contentStyles = (maxWidth: string) => css`
 
     &:first-of-type {
       margin-top: 0;
+    }
   }
 `;
 
@@ -102,7 +111,6 @@ const overlayStyles = css`
   left: 0;
   right: 0;
   bottom: 0;
-  overflow-y: auto;
   z-index: 1000;
 `;
 


### PR DESCRIPTION
## Related Issues:
* [HMW-594](https://jira.epa.gov/browse/HMW-594)

## Main Changes:
* Previously, when scrolling the modal, the entire overlay would scroll, and the modal would fill the whole screen height. Now, the modal only fills up to 80% of the viewport height, and the scrollbar has been moved inside the modal. This way, there is still space around the modal on a mobile device to click outside and close (pressing the close button can be difficult).
* Added a maximum width percentage.
* Added a light border radius to the modal content and the close button.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/monitoring, then select the _Past Water Conditions_ section.
2. Expand the location with the highest number of measurements, **ANA21**, then open the characteristic modal for the **Physical** group.
3. Ensure the content scrolls vertically (reduce the browser window height if necessary).
4. Test the same behavior on a mobile device, if possible (I've tested on an iPhone).