### PR TITLE
Feature/598 line graph disclaimer

### DIFF
--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -21,6 +21,7 @@ import DateSlider from 'components/shared/DateSlider';
 import MapErrorBoundary from 'components/shared/ErrorBoundary.MapErrorBoundary';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { HelpTooltip, Tooltip } from 'components/shared/HelpTooltip';
+import { DisclaimerModal } from 'components/shared/Modal';
 import { GradientLegend, VisxGraph } from 'components/shared/VisxGraph';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import Map from 'components/shared/Map';
@@ -191,6 +192,23 @@ const containerStyles = css`
     margin-top: 0.125rem;
     margin-bottom: 0.875rem;
     border-top-color: #aebac3;
+  }
+`;
+
+const disclaimerButtonStyles = css`
+  margin-left: 1em;
+`;
+
+const disclaimerModalStyles = css`
+  li {
+    padding-bottom: 0.5em;
+  }
+
+  ul {
+    list-style-type: lower-alpha;
+    margin: 0;
+    padding-bottom: 0;
+    padding-top: 0.5em;
   }
 `;
 
@@ -749,7 +767,7 @@ function pointDatum(msmt, colors, depths) {
     x: msmt.date,
     y: msmt.measurement || Number.EPSILON,
     activityTypeCode: msmt.activityTypeCode,
-    color: msmt.depth !== null ? colors[depths.indexOf(msmt.depth)] : '#000000',
+    color: msmt.depth !== null ? colors[depths.indexOf(msmt.depth)] : '#4d4d4d',
     depth: msmt.depth,
     depthUnit: msmt.depthUnit,
   };
@@ -1311,6 +1329,39 @@ function CharacteristicChartSection({
                   <label htmlFor={`${charcName}-line`}>Line Graph</label>
                 </span>
               </span>
+            </div>
+            <div css={disclaimerButtonStyles}>
+              <DisclaimerModal>
+                <div css={disclaimerModalStyles}>
+                  <p>
+                    When multiple samples or measurements are available for the
+                    same day for a single characteristic, the line shown is
+                    drawn through the average of the results. Multiple samples
+                    or measurements for a single characteristic may be available
+                    for the same day if:
+                    <ul>
+                      <li>
+                        Multiple were taken over time that day (e.g. in the
+                        morning, afternoon, and at night).
+                      </li>
+                      <li>
+                        Multiple were taken at the same relative time but at
+                        varying depths (e.g. the surface, middle or bottom of a
+                        lake).
+                      </li>
+                      <li>
+                        Quality control samples or measurements were also taken.
+                      </li>
+                    </ul>
+                    Quality control data, such as blanks or replicates
+                    identified via the <i>Activity Type Code</i>, are not
+                    included in this chart but will still be available in the
+                    data download. Therefore, the averaging is only performed
+                    across depth or time within a single day, and for
+                    visualization purposes only.
+                  </p>
+                </div>
+              </DisclaimerModal>
             </div>
             <ChartContainer
               lineData={chartData.lineData}
@@ -2329,7 +2380,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
   const [mapLoading, setMapLoading] = useState(true);
 
   const getSharedLayers = useSharedLayers();
-  const { homeWidget, mapView, resetData } = useContext(LocationSearchContext);
+  const { homeWidget, mapView } = useContext(LocationSearchContext);
 
   const {
     monitoringLocationsLayer,
@@ -2394,13 +2445,6 @@ function SiteMap({ layout, siteStatus, widthRef }) {
     monitoringLocationsLayer,
     siteStatus,
   ]);
-
-  // Function for resetting the LocationSearch context when the map is removed
-  useEffect(() => {
-    return function cleanup() {
-      resetData();
-    };
-  }, [resetData]);
 
   // Scrolls to the map when switching layouts
   useEffect(() => {

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -195,10 +195,6 @@ const containerStyles = css`
   }
 `;
 
-const disclaimerButtonStyles = css`
-  margin-left: 1em;
-`;
-
 const disclaimerModalStyles = css`
   li {
     padding-bottom: 0.5em;
@@ -319,7 +315,7 @@ const leftColumnStyles = css`
 
 const legendContainerStyles = css`
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   margin-top: 1em;
 `;
 
@@ -1330,39 +1326,6 @@ function CharacteristicChartSection({
                 </span>
               </span>
             </div>
-            <div css={disclaimerButtonStyles}>
-              <DisclaimerModal>
-                <div css={disclaimerModalStyles}>
-                  <p>
-                    When multiple samples or measurements are available for the
-                    same day for a single characteristic, the line shown is
-                    drawn through the average of the results. Multiple samples
-                    or measurements for a single characteristic may be available
-                    for the same day if:
-                    <ul>
-                      <li>
-                        Multiple were taken over time that day (e.g. in the
-                        morning, afternoon, and at night).
-                      </li>
-                      <li>
-                        Multiple were taken at the same relative time but at
-                        varying depths (e.g. the surface, middle or bottom of a
-                        lake).
-                      </li>
-                      <li>
-                        Quality control samples or measurements were also taken.
-                      </li>
-                    </ul>
-                    Quality control data, such as blanks or replicates
-                    identified via the <i>Activity Type Code</i>, are not
-                    included in this chart but will still be available in the
-                    data download. Therefore, the averaging is only performed
-                    across depth or time within a single day, and for
-                    visualization purposes only.
-                  </p>
-                </div>
-              </DisclaimerModal>
-            </div>
             <ChartContainer
               lineData={chartData.lineData}
               lineVisible={lineGraphVisible}
@@ -1606,12 +1569,46 @@ function ChartContainer({
         yTitle={yTitle}
       />
       <div css={legendContainerStyles}>
-        {pointsVisible && pointLegendValues.length > 0 && (
+        {pointsVisible && pointLegendValues.length > 0 ? (
           <GradientLegend
             colors={pointLegendColors}
             keys={pointLegendValues}
             title={legendTitle}
           />
+        ) : (
+          <div />
+        )}
+        {lineVisible ? (
+          <DisclaimerModal>
+            <div css={disclaimerModalStyles}>
+              <p>
+                When multiple samples or measurements are available for the same
+                day for a single characteristic, the line shown is drawn through
+                the average of the results. Multiple samples or measurements for
+                a single characteristic may be available for the same day if:
+                <ul>
+                  <li>
+                    Multiple were taken over time that day (e.g. in the morning,
+                    afternoon, and at night).
+                  </li>
+                  <li>
+                    Multiple were taken at the same relative time but at varying
+                    depths (e.g. the surface, middle or bottom of a lake).
+                  </li>
+                  <li>
+                    Quality control samples or measurements were also taken.
+                  </li>
+                </ul>
+                Quality control data, such as blanks or replicates identified
+                via the <i>Activity Type Code</i>, are not included in this
+                chart but will still be available in the data download.
+                Therefore, the averaging is only performed across depth or time
+                within a single day, and for visualization purposes only.
+              </p>
+            </div>
+          </DisclaimerModal>
+        ) : (
+          <div />
         )}
       </div>
     </div>
@@ -2348,6 +2345,13 @@ function MonitoringReportContent() {
 }
 
 function MonitoringReport() {
+  const { resetData } = useContext(LocationSearchContext);
+  useEffect(() => {
+    return function cleanup() {
+      resetData();
+    };
+  }, [resetData]);
+
   return (
     <LayersProvider>
       <FullscreenProvider>
@@ -2380,7 +2384,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
   const [mapLoading, setMapLoading] = useState(true);
 
   const getSharedLayers = useSharedLayers();
-  const { homeWidget, mapView } = useContext(LocationSearchContext);
+  const { homeWidget, mapView, setBasemap } = useContext(LocationSearchContext);
 
   const {
     monitoringLocationsLayer,
@@ -2398,8 +2402,9 @@ function SiteMap({ layout, siteStatus, widthRef }) {
 
     return function cleanup() {
       mapView.map.basemap = 'gray-vector';
+      setBasemap('gray-vector');
     };
-  }, [mapView]);
+  }, [mapView, setBasemap]);
 
   // Initialize the layers
   useEffect(() => {


### PR DESCRIPTION
## Related Issues:
* [HMW-598](https://jira.epa.gov/browse/HMW-598)

## Main Changes:
* Added a disclaimer modal when a line graph is shown on the Monitoring Report page, detailing the process used to average points on the same day.
* Fixed a context issue where the chart and download sections didn't display when switching from a single-column view to a two-column view.
* Fixed an issue where the basemap wasn't being properly reset when leaving the page.
* Lightened the default scatter plot glyph color.

## Steps To Test:
1. Go http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-ANA0082/ and select "line graph" under **Chart Type**.
2. Verify the modal displays as expected, and contains the proper disclaimer.
3. Resize the containing window until the number of columns changes. Confirm the chart and download sections remain populated.
4. In the same browser tab, click to the Community page, and confirm the "gray-vector" basemap is in place.