### PR TITLE
Increased characteristics modal max width, close icon

### DIFF
--- a/app/client/src/components/shared/Modal.tsx
+++ b/app/client/src/components/shared/Modal.tsx
@@ -158,7 +158,7 @@ export default function Modal({
               title={closeTitle ?? 'Close'}
               onClick={close}
             >
-              ×
+              <i className="fas fa-times" aria-hidden="true" />
             </button>
 
             {children}

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2805,7 +2805,7 @@ function MonitoringLocationsContent({
                   <td>
                     <Modal
                       label={`Detailed Uses for ${key}`}
-                      maxWidth="35rem"
+                      maxWidth="36em"
                       triggerElm={
                         <button
                           aria-label={`View detailed uses for ${key}`}


### PR DESCRIPTION
## Related Issues:
* [HMW-601](https://jira.epa.gov/browse/HMW-601)

## Main Changes:
* Increased the width of the characteristics modal by 1 unit: previously, when the scrollbar shown, the "View Water Monitoring Report" info box text wrapped so a single period was on the second line.
* Changed the modal close button to an icon, rather than an "x", due to spacing.

## Steps To Test:
1. View a characteristics modal for a location with enough characteristics to overflow (and a scrollbar to appear). Ensure the info box text does not wrap.