### PR TITLE
bugfix/631 document links missing

### DIFF
--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
@@ -272,7 +272,7 @@ function DocumentsTable({
               accessor: 'documentName',
               Header: 'Document',
               width: docNameWidth,
-              Render: (cell) => {
+              Cell: (cell) => {
                 const { documentFileName, documentURL } = cell.row.original;
                 return (
                   <DocumentLink
@@ -287,7 +287,7 @@ function DocumentsTable({
               accessor: 'agencyCode',
               Header: 'Agency Code',
               width: 125,
-              Render: (cell) => {
+              Cell: (cell) => {
                 if (cell.value === 'S') return 'State';
                 if (cell.value === 'E') return 'EPA';
                 return cell.value;

--- a/app/cypress/e2e/state.cy.ts
+++ b/app/cypress/e2e/state.cy.ts
@@ -1,4 +1,4 @@
-// Ignore uncaught exceptions related to the ResizeObserver - loop limit exceeded error. 
+// Ignore uncaught exceptions related to the ResizeObserver - loop limit exceeded error.
 // We can safely ignore this. https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
 Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from
@@ -220,6 +220,9 @@ describe('State page Water Overview tab', () => {
   it(`Clicking "<state name> Documents" opens the documents content`, () => {
     const title = 'Alaska Documents';
     const text = 'Documents Related to Integrated Report';
+    const firstTableLinkText =
+      'Consolidated Assessment and Listing Methodology 2021 Rev. (PDF)';
+    const secondTableLinkText = '2015 NPR-A Estuary Report (PDF)';
 
     // verify text is not visible
     cy.findByText(text).should('not.exist');
@@ -227,6 +230,32 @@ describe('State page Water Overview tab', () => {
     // open accordion and check text is visible
     cy.get('.hmw-accordion').contains(title).click();
     cy.findByText(text).should('be.visible');
+
+    // check for links in first table
+    cy.findByText(firstTableLinkText).should(
+      'have.attr',
+      'href',
+      `https://attains.epa.gov/attains-public/api/documents/cycles/12064/209190`,
+    );
+    cy.findByText(firstTableLinkText).should('have.attr', 'target', '_blank');
+    cy.findByText(firstTableLinkText).should(
+      'have.attr',
+      'rel',
+      'noopener noreferrer',
+    );
+
+    // check for links in second table
+    cy.findByText(secondTableLinkText).should(
+      'have.attr',
+      'href',
+      `https://attains.epa.gov/attains-public/api/documents/surveys/AKDECWQ/2015/136021`,
+    );
+    cy.findByText(secondTableLinkText).should('have.attr', 'target', '_blank');
+    cy.findByText(secondTableLinkText).should(
+      'have.attr',
+      'rel',
+      'noopener noreferrer',
+    );
 
     // close accordion and verify text is not visible
     cy.get('.hmw-accordion').contains(title).click();

--- a/app/cypress/e2e/tribe.cy.ts
+++ b/app/cypress/e2e/tribe.cy.ts
@@ -156,27 +156,33 @@ describe('Tribe page Water Quality Overview sub tabs', () => {
 
   it('Clicking Map and List buttons show correct content', () => {
     // verify map is visible and the list view is hidden
-    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should('be.visible');
+    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should(
+      'be.visible',
+    );
     cy.findByText('Alaska Lake').should('not.exist');
 
     // click "List" tab
     cy.findByRole('button', { name: 'List' }).click();
 
     // verify the map is hidden and the list view is visible
-    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should('not.exist');
+    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should(
+      'not.exist',
+    );
     cy.findAllByText('Alaska Lake').should('be.visible');
 
     // click "Map" tab
     cy.findByRole('button', { name: 'Map' }).click();
 
     // verify map is visible and the list view is hidden
-    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should('be.visible');
+    cy.findByRole('button', { name: 'Open Basemaps and Layers' }).should(
+      'be.visible',
+    );
     cy.findByText('Alaska Lake').should('not.exist');
   });
 });
 
 describe('Tribe page Water Overview', () => {
-  Cypress.on("uncaught:exception", (_err, _runnable) => {
+  Cypress.on('uncaught:exception', (_err, _runnable) => {
     // returning false here prevents Cypress from
     // failing the test
     debugger;
@@ -189,8 +195,7 @@ describe('Tribe page Water Overview', () => {
 
   it(`Do not display "Drinking Water Information" when water sub-tab clicked on`, () => {
     cy.findByText('Drinking Water').click();
-    cy.findAllByText(/Drinking Water Information for/)
-      .should('not.be.visible');
+    cy.findAllByText(/Drinking Water Information for/).should('not.be.visible');
   });
 
   it(`Clicking "Expand All/Collapse All" expands/collapses the state documents menu`, () => {
@@ -209,6 +214,7 @@ describe('Tribe page Water Overview', () => {
   it(`Clicking "<tribe name> Documents" opens the documents content`, () => {
     const title = 'Red Lake Band of Chippewa Indians, Minnesota Documents';
     const text = 'Documents Related to Assessment';
+    const linkText = 'Red Lake Nation Assessment Methodology (DOCX)';
 
     // verify text is not visible
     cy.findByText(text).should('not.exist');
@@ -216,6 +222,15 @@ describe('Tribe page Water Overview', () => {
     // open accordion and check text is visible
     cy.get('.hmw-accordion').contains(title).click();
     cy.findByText(text).should('be.visible');
+
+    // check for links in table
+    cy.findByText(linkText).should(
+      'have.attr',
+      'href',
+      `https://attains.epa.gov/attains-public/api/documents/cycles/12864/210250`,
+    );
+    cy.findByText(linkText).should('have.attr', 'target', '_blank');
+    cy.findByText(linkText).should('have.attr', 'rel', 'noopener noreferrer');
 
     // close accordion and verify text is not visible
     cy.get('.hmw-accordion').contains(title).click();


### PR DESCRIPTION
## Related Issues:
* [HMW-631](https://jira.epa.gov/browse/HMW-631)

## Main Changes:
* Fixed issue of links not rendering on the State/Tribe pages. I think this issue has likely been around for a while. I'm surprised we didn't notice it before.

## Steps To Test:
1. Navigate to http://localhost:3000/state/AL/water-quality-overview
2. Expand the "Documents" section
3. Verify links are rendered and work
4. Navigaet to http://localhost:3000/tribe/CPNWATER
5. Repeat steps 2 and 3.
6. Run the updated cypress tests around the documents section (note: most of the changes in the cypress files were from prettier)
