### PR TITLE
Bugfix/618 Flickering in Monitoring List

### DIFF
--- a/app/client/src/components/shared/VirtualizedList.tsx
+++ b/app/client/src/components/shared/VirtualizedList.tsx
@@ -117,7 +117,7 @@ function VirtualizedListInner({ items, renderer }: Props) {
       }}
     >
       {({ index, style }) => (
-        <div style={style}>
+        <div style={{ ...style, overflow: 'hidden' }}>
           <RowRenderer
             listId={listId}
             index={index}


### PR DESCRIPTION
## Related Issues:
* [HMW-618](https://jira.epa.gov/browse/HMW-618)

## Main Changes:
* Fixed flickering that would occur in a specific case when using the `VirtualizedList` component. A `ResizeObserver` was being repeatedly triggered due to slight row overflow; hiding the overflow solved the issue. Because the `ResizeObserver` is present, no content should actually be hidden, I believe it was being re-triggered by a scrollbar while already resizing.

## Steps To Test:
1. Go to https://jira.epa.gov/browse/HMW-618, then open the _Water Monitoring Locations_ panel.
2. In the "Filter by Characteristics" drop-down, select a characteristic associated with only 1 location.
3. Open the browser developer tools, then adjust the width so that the content viewport is **1087px** wide.
4. Verify no scrollbar appears in the monitoring location's panel.
5. Test other widths and confirm the same.