### PR TITLE
Feature/626 627 630 glossary links trib error

### DIFF
--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -42,6 +42,7 @@ import { fetchCheck } from 'utils/fetchUtils';
 import {
   getOrganizationLabel,
   getTypeFromAttributes,
+  mapRestorationPlanToGlossary,
 } from 'utils/mapFunctions';
 import { chunkArrayCharLength } from 'utils/utils';
 // styles
@@ -479,20 +480,6 @@ function Actions() {
     setInfoHeight(node.getBoundingClientRect().height);
   }, []);
 
-  const planType =
-    actionTypeCode === 'TMDL' ||
-    actionTypeCode === '4B Restoration Approach' ||
-    actionTypeCode === 'Alternative Restoration Approach' ? (
-      <>
-        Restoration Plan:{' '}
-        <GlossaryTerm term={actionTypeCode}>{actionTypeCode}</GlossaryTerm>
-      </>
-    ) : actionTypeCode === 'Protection Approach' ? (
-      <GlossaryTerm term={actionTypeCode}>{actionTypeCode}</GlossaryTerm>
-    ) : (
-      actionTypeCode
-    );
-
   const infoBox = (
     <div css={boxStyles} ref={measuredRef}>
       <h2 css={boxHeadingStyles}>
@@ -523,7 +510,7 @@ function Actions() {
 
       <div css={inlineBoxStyles}>
         <h3>Type:&nbsp;</h3>
-        <p>{planType}</p>
+        <p>{mapRestorationPlanToGlossary(actionTypeCode, true)}</p>
       </div>
 
       <div css={inlineBoxStyles}>

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -24,6 +24,7 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
 import { getUrlFromMarkup } from 'components/shared/Regex';
 import { useWaterbodyOnMap } from 'utils/hooks';
+import { mapRestorationPlanToGlossary } from 'utils/mapFunctions';
 // errors
 import {
   restoreNonpointSourceError,
@@ -346,36 +347,6 @@ function Restore() {
                         }
                       >
                         {sortedAttainsPlanData.map((item, index) => {
-                          let planType = item.actionTypeCode;
-                          if (planType === 'TMDL') {
-                            planType = (
-                              <>
-                                Restoration Plan:{' '}
-                                <GlossaryTerm term="TMDL">TMDL</GlossaryTerm>
-                              </>
-                            );
-                          }
-                          if (planType === '4B Restoration Approach') {
-                            planType = (
-                              <>
-                                Restoration Plan:{' '}
-                                <GlossaryTerm term="4B Restoration Approach">
-                                  4B Restoration Approach
-                                </GlossaryTerm>
-                              </>
-                            );
-                          }
-                          if (planType === 'Alternative Restoration Approach') {
-                            planType = (
-                              <>
-                                Restoration Plan:{' '}
-                                <GlossaryTerm term="Alternative Restoration Approach">
-                                  Alternative Restoration Approach
-                                </GlossaryTerm>
-                              </>
-                            );
-                          }
-
                           return (
                             <AccordionItem
                               key={index}
@@ -388,7 +359,10 @@ function Restore() {
                                 rows={[
                                   {
                                     label: 'Plan Type',
-                                    value: planType,
+                                    value: mapRestorationPlanToGlossary(
+                                      item.actionTypeCode,
+                                      true,
+                                    ),
                                   },
                                   {
                                     label: 'Status',

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -35,6 +35,7 @@ import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
 import { fetchCheck, fetchPost } from 'utils/fetchUtils';
+import { mapRestorationPlanToGlossary } from 'utils/mapFunctions';
 import { titleCaseWithExceptions } from 'utils/utils';
 // styles
 import { colors } from 'styles/index';
@@ -1415,7 +1416,11 @@ function WaterbodyReport() {
                                             </>
                                           )}
                                         </td>
-                                        <td>{action.type}</td>
+                                        <td>
+                                          {mapRestorationPlanToGlossary(
+                                            action.type,
+                                          )}
+                                        </td>
                                         <td css={dateCellStyles}>
                                           {action.date}
                                         </td>

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -38,6 +38,7 @@ import {
   isFeatureLayer,
   isMediaLayer,
   isUniqueValueRenderer,
+  mapRestorationPlanToGlossary,
 } from 'utils/mapFunctions';
 import { fetchCheck, fetchParseCsv, proxyFetch } from 'utils/fetchUtils';
 import {
@@ -1180,7 +1181,9 @@ function WaterbodyInfo({
                                   </>
                                 )}
                               </td>
-                              <td>{action.type}</td>
+                              <td>
+                                {mapRestorationPlanToGlossary(action.type)}
+                              </td>
                               <td css={dateStyles}>{action.date}</td>
                             </tr>
                           );

--- a/app/client/src/components/shared/WaterbodyList.js
+++ b/app/client/src/components/shared/WaterbodyList.js
@@ -26,6 +26,8 @@ import {
 } from 'contexts/LookupFiles';
 // errors
 import { huc12SummaryError } from 'config/errorMessages';
+// styles
+import { colors } from 'styles/index';
 
 const paragraphStyles = css`
   margin-bottom: 0.5em;
@@ -67,6 +69,18 @@ const modifiedInfoBoxStyles = css`
   ${infoBoxStyles};
   margin-bottom: 1em;
   text-align: center;
+`;
+
+const noMapDataWarningStyles = css`
+  font-size: 0.875rem;
+
+  i {
+    background-color: ${colors.black()};
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    color: ${colors.yellow()};
+    font-size: 0.95rem;
+    margin-right: 5px;
+  }
 `;
 
 type Props = {
@@ -149,7 +163,10 @@ function WaterbodyList({ waterbodies, title, fieldName }: Props) {
                   {graphic.limited && (
                     <>
                       <br />
-                      [Waterbody not visible on map.]
+                      <span css={noMapDataWarningStyles}>
+                        <i className="fas fa-exclamation-triangle" />
+                        <strong>[Waterbody not visible on map.]</strong>
+                      </span>
                     </>
                   )}
                 </>

--- a/app/client/src/config/errorMessages.js
+++ b/app/client/src/config/errorMessages.js
@@ -120,9 +120,9 @@ export const grpaError =
 
 // for where ATTAINS usesStateSummaryService response is an internal error or missing data for a state
 export const usesStateSummaryServiceInvalidResponse = (source, name) =>
-  `There is no ${source}-level assessment data available${
+  `${source}-level assessment data ${
     name && ' for ' + name
-  }.`; // add conditional check for stateName as it is sometimes undefined
+  } is temporarily unavailable, please try again later.`;
 
 // attains state document service
 export const stateDocumentError = (stateName, type) =>

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -8,6 +8,7 @@ import SimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import SimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 import Popup from '@arcgis/core/widgets/Popup';
 // components
+import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { MapPopup } from 'components/shared/WaterbodyInfo';
 import { colors } from 'styles';
 // utilities
@@ -1148,3 +1149,23 @@ export const getMappedParameter = (
 
   return filteredFields;
 };
+
+// takes an action type code (plan) and renders it as a
+// glossary term if applicable
+export function mapRestorationPlanToGlossary(
+  planType: string,
+  showLabel = false,
+) {
+  return planType === 'TMDL' ||
+    planType === '4B Restoration Approach' ||
+    planType === 'Advance Restoration Plan (ARP)' ? (
+    <>
+      {showLabel && 'Restoration Plan: '}
+      <GlossaryTerm term={planType}>{planType}</GlossaryTerm>
+    </>
+  ) : planType === 'Protection Approach' ? (
+    <GlossaryTerm term={planType}>{planType}</GlossaryTerm>
+  ) : (
+    planType
+  );
+}


### PR DESCRIPTION
## Related Issues:
* [HMW-626](https://jira.epa.gov/browse/HMW-626)
* [HMW-627](https://jira.epa.gov/browse/HMW-627)
* [HMW-630](https://jira.epa.gov/browse/HMW-630)

## Main Changes:
* Updated the `Alternative Restoration Approach` glossary links to `Advance Restoration Plan (ARP)`. I also centralized the logic for this. 
* Changed the `There is no Tribe data...` message to a `...temporarily unavailable...` message.
* Updated the `Waterbody not visible on map` message to be more prominent.

## Steps To Test:
### HMW-626
1. Navigate to http://localhost:3000/community/030300030110/restore
2. Click on the `Restoration Plans` sub tab
3. Expand the accordion item
4. Verify `Advance Restoration Plan (ARP)` is visible and linked to the glossary
5. Click the left most waterbody on the map
6. Repeat step 4
7. Navigate to http://localhost:3000/waterbody-report/21NC01WQ/NC17-12a/2022
8. Repeat step 4
9. Navigate to http://localhost:3000/plan-summary/21NC01WQ/NC_5alt_HaskettCreek
10. Repeat step 4

### HMW-627
1. Comment out lines 432 and 435 in the `StateTribal.Tabs.WaterQualityOverview.js` file
11. In dev tools network tab, block the `attains.epa.gov/attains-public/api/usesStateSummary?organizationId=UTEMTN` url
12. Navigate to http://localhost:3000/tribe/UTEMTN
13. Verify the `Tribe-level assessment data for Ute Mountain Ute Tribe is temporarily unavailable, please try again later.` message is displayed

### HMW-630
1. Navigate to http://localhost:3000/community/annapolis,%20md/swimming
14. Verify the `Waterbody not visible on map` message has an icon next to it and has bold text

