### PR TITLE
Feature/632 tribe search issue

### DIFF
--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -284,7 +284,7 @@ function LocationSearch({ route, label }: Props) {
       sources: [
         {
           layer: new FeatureLayer({
-            url: 'https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/19',
+            url: services.data.wbdUnconstrained,
             listMode: 'hide',
           }),
           searchFields: ['name', 'huc12'],

--- a/app/server/app/public/data/config/services-attains.json
+++ b/app/server/app/public/data/config/services-attains.json
@@ -1,6 +1,7 @@
 {
   "locatorUrl": "//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
   "wbd": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/6",
+  "wbdUnconstrained": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/19",
   "counties": "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties/FeatureServer/0",
   "stateBoundaries": "https://enviroatlas.epa.gov/arcgis/rest/services/Supplemental/Reference_Boundaries/MapServer",
   "mappedWater": "https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer",
@@ -279,6 +280,11 @@
       "urlLookup": "wbd",
       "wildcardUrl": "{urlLookup}*",
       "name": "Attains_Assessment - map server (watershed boundary dataset)"
+    },
+    {
+      "urlLookup": "wbdUnconstrained",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "Attains_Assessment - map server (watershed boundary dataset unconstrained)"
     },
     {
       "urlLookup": "counties",

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -1,6 +1,7 @@
 {
   "locatorUrl": "//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
   "wbd": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/6",
+  "wbdUnconstrained": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/19",
   "counties": "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties/FeatureServer/0",
   "stateBoundaries": "https://enviroatlas.epa.gov/arcgis/rest/services/Supplemental/Reference_Boundaries/MapServer",
   "mappedWater": "https://watersgeo.epa.gov/arcgis/rest/services/NHDPlus/NHDPlus/MapServer",
@@ -279,6 +280,11 @@
       "urlLookup": "wbd",
       "wildcardUrl": "{urlLookup}*",
       "name": "Attains_Assessment - map server (watershed boundary dataset)"
+    },
+    {
+      "urlLookup": "wbdUnconstrained",
+      "wildcardUrl": "{urlLookup}*",
+      "name": "Attains_Assessment - map server (watershed boundary dataset unconstrained)"
     },
     {
       "urlLookup": "counties",


### PR DESCRIPTION
## Related Issues:
* [HMW-632](https://jira.epa.gov/browse/HMW-632)

## Main Changes:
* Fixed an issue where the search widget was doing a "starts with" query, instead of a "includes". 
  * The source that bumps up against the Esri geocoder does an includes query, but all other sources use a starts with query.
  * Unfortunately, Esri doesn't provide a good way to change the query. I ended up going with a hacky solution, where I intercept the requests and then update the query to be `LIKE '%<text>%'`, instead of `LIKE '<text>%'`. 
* Updated the url of the watershed search source to come from S3 config.

## Steps To Test:
1. Navigate to http://localhost:3000/
2. Type "Chippewa" into the search box
3. Verify the results includes items like "Minnesota Chippewa", be sure to scroll through the tribal and watershed sections
4. Navigate to http://localhost:3000/tribe/FONDULAC
5. Verify the page still works
