### PR TITLE
Bugfix/634 disappearing modal

### DIFF
--- a/app/client/src/components/shared/Modal.tsx
+++ b/app/client/src/components/shared/Modal.tsx
@@ -20,7 +20,10 @@ const cancelButtonStyles = css`
 `;
 
 const closeButtonStyles = css`
+  align-items: center;
   border-radius: 6px;
+  display: flex;
+  justify-content: center;
   position: absolute;
   top: 6px;
   right: 6px;

--- a/app/client/src/components/shared/VirtualizedList.tsx
+++ b/app/client/src/components/shared/VirtualizedList.tsx
@@ -4,20 +4,20 @@ import throttle from 'lodash/throttle';
 import uniqueId from 'lodash/uniqueId';
 // utils
 import { useOnScreen } from 'utils/hooks';
+import type { CSSProperties, ReactNode } from 'react';
 
 type RowRendererProps = {
+  data: {
+    listId: string;
+    renderer: ({ index }: { index: number }) => ReactNode;
+    resizeObserver: ResizeObserver;
+  };
   index: number;
-  listId: string;
-  renderer: Function;
-  resizeObserver: ResizeObserver;
+  style: CSSProperties;
 };
 
-function RowRenderer({
-  index,
-  listId,
-  renderer,
-  resizeObserver,
-}: RowRendererProps) {
+function RowRenderer({ data, index, style }: RowRendererProps) {
+  const { listId, renderer, resizeObserver } = data;
   const rowRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -36,15 +36,17 @@ function RowRenderer({
   );
 
   return (
-    <div id={`${listId}-row-${index}`} ref={callbackRef}>
-      {renderer({ index })}
+    <div style={{ ...style, overflow: 'hidden' }}>
+      <div id={`${listId}-row-${index}`} ref={callbackRef}>
+        {renderer({ index })}
+      </div>
     </div>
   );
 }
 
 type Props = {
   items: Array<Object>;
-  renderer: Function;
+  renderer: ({ index }: { index: number }) => ReactNode;
 };
 
 function VirtualizedListInner({ items, renderer }: Props) {
@@ -102,10 +104,19 @@ function VirtualizedListInner({ items, renderer }: Props) {
     };
   }, []);
 
+  const itemData = useMemo(() => {
+    return {
+      listId,
+      renderer,
+      resizeObserver,
+    };
+  }, [listId, renderer, resizeObserver]);
+
   return (
     <VariableSizeList
       height={window.innerHeight}
       itemCount={items.length}
+      itemData={itemData}
       itemSize={getSize}
       width="100%"
       ref={innerRef}
@@ -116,16 +127,7 @@ function VirtualizedListInner({ items, renderer }: Props) {
         display: 'inline-block',
       }}
     >
-      {({ index, style }) => (
-        <div style={{ ...style, overflow: 'hidden' }}>
-          <RowRenderer
-            listId={listId}
-            index={index}
-            renderer={renderer}
-            resizeObserver={resizeObserver}
-          />
-        </div>
-      )}
+      {RowRenderer}
     </VariableSizeList>
   );
 }

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -144,6 +144,7 @@ function labelValue(
 /*
 ## Styles
 */
+
 const linkSectionStyles = css`
   p {
     padding-bottom: 1.5em;
@@ -2169,8 +2170,8 @@ function CyanContent({ feature, mapView, services }: CyanContentProps) {
                     Total Satellite Image Area: ${pixelArea}
                     <br />
                     ${formatDate(dates[0])} - ${formatDate(
-                      dates[dates.length - 1],
-                    )}
+                    dates[dates.length - 1],
+                  )}
                   `}
                   yTitle={`
                   Percent of Satellite Image Area
@@ -2835,7 +2836,9 @@ function MonitoringLocationsContent({
                                 Characteristics
                               </GlossaryTerm>
                             </th>
-                            <th>Number of Measurements</th>
+                            <th style={{ width: '8em' }}>
+                              Number of Measurements
+                            </th>
                           </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
## Related Issues:
* [HMW-634](https://jira.epa.gov/browse/HMW-634)

## Main Changes:
* Fixed the issue of the characteristics (monitoring locations) modal disappearing.
* Adjusted the style of the table in the modal, setting a fixed width on the "Number of Measurements" column.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/overview, then open the "Water Monitoring Locations" panel.
2. Expand one of the _Past Water Conditions_ accordion items, and de-select some of the checkboxes.
3. In the Surrounding Features widget, toggle on the surrounding Past Water Conditions layer, then verify that the checkboxes in the accordion are still unchecked.
4. Pan the map as far as possible in one mousedown, then quickly open a characteristic modal upon release. Verify that the modal does not disappear when the map loads new surrounding monitoring locations.
5. Repeat all of the above on the Monitoring tab.
6. With a characteristic modal open, resize the screen and confirm the "Number of Measurements" column stays consistent.
