### PR TITLE
Feature/628 update switch empty values

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -33,7 +33,7 @@ import { CommunityTabsContext } from 'contexts/CommunityTabs';
 import { useLayers } from 'contexts/Layers';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utilities
-import { formatNumber } from 'utils/utils';
+import { countOrNotAvailable, formatNumber } from 'utils/utils';
 import { getMappedParameter, plotIssues } from 'utils/mapFunctions';
 import { useDischargers, useWaterbodyOnMap } from 'utils/hooks';
 // errors
@@ -479,7 +479,7 @@ function IdentifiedIssues() {
 
   function getImpairedWatersPercent() {
     if (cipSummary.status === 'failure') return 'N/A';
-    return nullPollutedWaterbodies ? 'N/A %' : `${pollutedPercent ?? 0}%`;
+    return nullPollutedWaterbodies ? '0%' : `${pollutedPercent ?? 0}%`;
   }
 
   // Reset the dischargers layer filter when leaving the tab
@@ -559,9 +559,7 @@ function IdentifiedIssues() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {dischargersStatus === 'failure'
-                  ? 'N/A'
-                  : dischargers.length.toLocaleString()}
+                {countOrNotAvailable(dischargers, dischargersStatus)}
               </span>
               <p css={keyMetricLabelStyles}>Permitted Dischargers</p>
               <Switch
@@ -837,7 +835,10 @@ function IdentifiedIssues() {
                               </div>
                             </td>
                             <td>
-                              {violatingDischargers.length.toLocaleString()}
+                              {countOrNotAvailable(
+                                violatingDischargers,
+                                dischargersStatus,
+                              )}
                             </td>
                           </tr>
                           <tr>
@@ -855,7 +856,10 @@ function IdentifiedIssues() {
                               </label>
                             </td>
                             <td>
-                              {compliantDischargers.length.toLocaleString()}
+                              {countOrNotAvailable(
+                                compliantDischargers,
+                                dischargersStatus,
+                              )}
                             </td>
                           </tr>
                         </tbody>

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -45,6 +45,7 @@ import {
   useStreamgages,
   useWaterbodyOnMap,
 } from 'utils/hooks';
+import { countOrNotAvailable } from 'utils/utils';
 // data
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
 // errors
@@ -316,7 +317,11 @@ function Monitoring() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {totalCurrentWaterConditions || 'N/A'}
+                {countOrNotAvailable(
+                  totalCurrentWaterConditions,
+                  usgsStreamgages.status,
+                  cyanWaterbodies.status,
+                )}
               </span>
               <p css={keyMetricLabelStyles}>Current Water Conditions</p>
               <Switch
@@ -336,7 +341,10 @@ function Monitoring() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {monitoringLocations.data?.length || 'N/A'}
+                {countOrNotAvailable(
+                  monitoringLocations.data,
+                  monitoringLocations.status,
+                )}
               </span>
               <p css={keyMetricLabelStyles}>Past Water Conditions</p>
               <Switch
@@ -564,7 +572,7 @@ function CurrentConditionsTab({
                     <span>USGS Sensors</span>
                   </label>
                 </td>
-                <td>{streamgages.length}</td>
+                <td>{countOrNotAvailable(streamgages, streamgagesStatus)}</td>
               </tr>
               <tr>
                 <td>
@@ -586,7 +594,9 @@ function CurrentConditionsTab({
                     </GlossaryTerm>
                   </div>
                 </td>
-                <td>{cyanWaterbodies.length ?? 'N/A'}</td>
+                <td>
+                  {countOrNotAvailable(cyanWaterbodies, cyanWaterbodiesStatus)}
+                </td>
               </tr>
             </tbody>
           </table>

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -47,6 +47,7 @@ import {
   useWaterbodyOnMap,
 } from 'utils/hooks';
 import { getUniqueWaterbodies } from 'utils/mapFunctions';
+import { countOrNotAvailable } from 'utils/utils';
 // errors
 import {
   cyanError,
@@ -228,9 +229,7 @@ function Overview() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {Boolean(totalWaterbodies) && cipSummary.status === 'success'
-                  ? totalWaterbodies.toLocaleString()
-                  : 'N/A'}
+                {countOrNotAvailable(totalWaterbodies, cipSummary.status)}
               </span>
               <p css={keyMetricLabelStyles}>Waterbodies</p>
               <div>
@@ -255,7 +254,12 @@ function Overview() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {totalMonitoringAndSensors ?? 'N/A'}
+                {countOrNotAvailable(
+                  totalMonitoringAndSensors,
+                  cyanWaterbodiesStatus,
+                  monitoringLocationsStatus,
+                  streamgagesStatus,
+                )}
               </span>
               <p css={keyMetricLabelStyles}>Water Monitoring Locations</p>
               <div>
@@ -278,7 +282,7 @@ function Overview() {
           ) : (
             <label css={switchContainerStyles}>
               <span css={keyMetricNumberStyles}>
-                {totalPermittedDischargers ?? 'N/A'}
+                {countOrNotAvailable(dischargers, dischargersStatus)}
               </span>
               <p css={keyMetricLabelStyles}>Permitted Dischargers</p>
               <div>
@@ -847,7 +851,7 @@ function MonitoringAndSensorsTab({
                       <span>USGS Sensors</span>
                     </label>
                   </td>
-                  <td>{streamgages.length}</td>
+                  <td>{countOrNotAvailable(streamgages, streamgagesStatus)}</td>
                 </tr>
                 <tr>
                   <td>
@@ -863,7 +867,12 @@ function MonitoringAndSensorsTab({
                       <span>Past Water Conditions</span>
                     </label>
                   </td>
-                  <td>{monitoringLocations.length}</td>
+                  <td>
+                    {countOrNotAvailable(
+                      monitoringLocations,
+                      monitoringLocationsStatus,
+                    )}
+                  </td>
                 </tr>
                 <tr>
                   <td>
@@ -882,7 +891,12 @@ function MonitoringAndSensorsTab({
                       </GlossaryTerm>
                     </div>
                   </td>
-                  <td>{cyanWaterbodies.length}</td>
+                  <td>
+                    {countOrNotAvailable(
+                      cyanWaterbodies,
+                      cyanWaterbodiesStatus,
+                    )}
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -25,6 +25,7 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { getUrlFromMarkup } from 'components/shared/Regex';
 import { useWaterbodyOnMap } from 'utils/hooks';
 import { mapRestorationPlanToGlossary } from 'utils/mapFunctions';
+import { countOrNotAvailable } from 'utils/utils';
 // errors
 import {
   restoreNonpointSourceError,
@@ -81,9 +82,7 @@ function Restore() {
             <LoadingSpinner />
           ) : (
             <span css={keyMetricNumberStyles}>
-              {grts.status === 'failure'
-                ? 'N/A'
-                : sortedGrtsData.length.toLocaleString()}
+              {countOrNotAvailable(sortedGrtsData, grts.status)}
             </span>
           )}
           <p css={keyMetricLabelStyles}>Projects</p>
@@ -93,9 +92,7 @@ function Restore() {
             <LoadingSpinner />
           ) : (
             <span css={keyMetricNumberStyles}>
-              {attainsPlans.status === 'failure'
-                ? 'N/A'
-                : sortedAttainsPlanData.length.toLocaleString()}
+              {countOrNotAvailable(sortedAttainsPlanData, attainsPlans.status)}
             </span>
           )}
           <p css={keyMetricLabelStyles}>Plans</p>

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -71,7 +71,10 @@ import {
   getPopupTitle,
   getPopupContent,
 } from 'utils/mapFunctions';
-import { browserIsCompatibleWithArcGIS } from 'utils/utils';
+import {
+  browserIsCompatibleWithArcGIS,
+  countOrNotAvailable,
+} from 'utils/utils';
 // errors
 import {
   esriMapLoadingFailure,
@@ -367,10 +370,7 @@ function TribalMapList({
             waterbodies.status === 'failure') && (
             <Fragment>
               <span css={keyMetricNumberStyles}>
-                {Boolean(waterbodies.data.length) &&
-                waterbodies.status === 'success'
-                  ? waterbodies.data.length.toLocaleString()
-                  : 'N/A'}
+                {countOrNotAvailable(waterbodies.data, waterbodies.status)}
               </span>
               <p css={keyMetricLabelStyles}>Waterbodies</p>
               <div css={switchContainerStyles}>
@@ -400,9 +400,10 @@ function TribalMapList({
           ) : (
             <>
               <span css={keyMetricNumberStyles}>
-                {Boolean(monitoringLocations.length)
-                  ? monitoringLocations.length
-                  : 'N/A'}
+                {countOrNotAvailable(
+                  monitoringLocations,
+                  monitoringLocationsStatus,
+                )}
               </span>
               <p css={keyMetricLabelStyles}>Water Monitoring Locations</p>
               <div css={switchContainerStyles}>

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -62,7 +62,6 @@ type State = {
   waterbodyData: Array<Object>,
   linesData: Array<Object>,
   areasData: Array<Object>,
-  cyanWaterbodies: { status: Status, data: Array<Object> | null },
   pointsData: Array<Object>,
   orphanFeatures: Array<Object>,
   waterbodyCountMismatch: boolean,
@@ -135,7 +134,6 @@ export class LocationSearchProvider extends Component<Props, State> {
     linesData: null,
     areasData: null,
     pointsData: null,
-    cyanWaterbodies: { status: 'idle', data: null },
     orphanFeatures: { status: 'fetching', features: [] },
     waterbodyCountMismatch: null,
     FIPS: { status: 'fetching', stateCode: '', countyCode: '' },
@@ -284,9 +282,6 @@ export class LocationSearchProvider extends Component<Props, State> {
     setPointsData: (pointsData) => {
       this.setState({ pointsData });
     },
-    setCyanWaterbodies: (cyanWaterbodies) => {
-      this.setState({ cyanWaterbodies });
-    },
     setGrts: (grts) => {
       this.setState({ grts });
     },
@@ -380,7 +375,6 @@ export class LocationSearchProvider extends Component<Props, State> {
         pointsData: null,
         linesData: null,
         areasData: null,
-        cyanWaterbodies: { status: 'idle', data: null },
         orphanFeatures: { status: 'fetching', features: [] },
         waterbodyCountMismatch: null,
         countyBoundaries: '',
@@ -416,7 +410,6 @@ export class LocationSearchProvider extends Component<Props, State> {
         pointsData: [],
         linesData: [],
         areasData: [],
-        cyanWaterbodies: { status: 'success', data: [] },
         orphanFeatures: { status: 'fetching', features: [] },
         waterbodyCountMismatch: null,
         countyBoundaries: '',

--- a/app/client/src/utils/utils.ts
+++ b/app/client/src/utils/utils.ts
@@ -1,5 +1,6 @@
 // types
 import type { KeyboardEvent, MouseEvent } from 'react';
+import type { FetchStatus } from 'types';
 
 // utility function to split up an array into chunks of a designated length
 export function chunkArray(array: any, chunkLength: number): Array<Array<any>> {
@@ -44,6 +45,19 @@ export function containsScriptTag(string: string) {
     string.includes('</script>') ||
     string.includes('<script/>')
   );
+}
+
+/**
+ * Return the string "N/A" if the provided status is not "success",
+ * otherwise return `countOrData` if it is a number or the length if it is an array.
+ */
+export function countOrNotAvailable(
+  countOrData: number | unknown[] | null,
+  ...statuses: FetchStatus[]
+) {
+  if (!statuses.some((status) => status === 'success')) return 'N/A';
+  if (typeof countOrData === 'number') return countOrData.toLocaleString();
+  return (countOrData?.length ?? 0).toLocaleString();
 }
 
 export function formatNumber(number: number, digits: number = 0) {


### PR DESCRIPTION
## Related Issues:
* [HMW-628](https://jira.epa.gov/browse/HMW-628)

## Main Changes:
* Updated toggle switch values to show 0 instead of "N/A" when the count is zero. "N/A" is still shown if there is a service error.

## Steps To Test:
1. Block the following URLs:
  a. attains.epa.gov
  b. www.waterqualitydata.us/data/summary/monitoringlocation/
  c. echodata.epa.gov/echo/cwa_rest_services.metadata
  d. waterservices.usgs.gov
  e. services.arcgis.com/cJ9YHowT8TU7DUyn/arcgis/rest/services/waterbodies_9/FeatureServer/0/query
  f. sdwis.epa.gov
  g. ordspub.epa.gov/ords/grts_rest/grts_rest_apex/grts_rest_apex/GetProjectsByHUC12
2. Navigate through the tabs of the Community page and verify "N/A" is shown in place of the counts above/beside toggle switches and lists.
3. Unblock the URLs.
4. Go to http://localhost:3000/community/160600091002/overview.
5. Click through the tabs and confirm all counts show 0.
