### PR TITLE
fix(#646): fixed incorrectly decoded symbol in mapping file

### DIFF
--- a/app/server/app/public/data/state/stateNationalUses.json
+++ b/app/server/app/public/data/state/stateNationalUses.json
@@ -3327,7 +3327,7 @@
     "orgId": "MA_DEP",
     "name": "Primary Contact Recreation",
     "category": "Recreation",
-    "surveyuseCode": "Recreation ?Çô Primary Contact"
+    "surveyuseCode": "Recreation – Primary Contact"
   },
   {
     "region": 1,
@@ -3354,7 +3354,7 @@
     "orgId": "MA_DEP",
     "name": "Secondary Contact Recreation",
     "category": "Recreation",
-    "surveyuseCode": "Recreation ?Çô Secondary Contact"
+    "surveyuseCode": "Recreation – Secondary Contact"
   },
   {
     "region": 1,


### PR DESCRIPTION
## Related Issues:
* [HMW-646](https://jira.epa.gov/browse/HMW-646)

## Main Changes:
* Updated two of the Massachusetts entries in the `stateNationalUses` mapping file to use dashes with the right encoding.
  * For MA surveys in particular, the dash in "Recreation – Primary Contact" and "Recreation – Secondary Contact" is not a regular dash. The `stateNationalUses.json` file appeared to account for this, but I believe the encoding was off, or it was lost when being transformed to upper case.

## Steps To Test:
1. Head to http://localhost:3000/state/MA/water-quality-overview, then select _Rivers and Streams_ from the **Water Type** select input.
2. Confirm the "Overall water quality" pie chart and data becomes visible and is accurate.
3. Select _Secondary Contact Recreation_ from the **Use** select input, then repeat step 2.
