### PR TITLE
Bugfix/640 source menu close on click

### DIFF
--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -454,6 +454,7 @@ function StateTribal() {
                     ev.relatedTarget?.tagName !== 'LI'
                   ) {
                     setSourcesVisible(false);
+                    setSourceCursor(-1);
                   }
                 }}
               >

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -448,6 +448,14 @@ function StateTribal() {
                   `esri-search-multiple-sources esri-search__container ` +
                   `${sourcesVisible ? 'esri-search--sources' : ''} `
                 }
+                onBlur={(ev) => {
+                  if (
+                    !ev.currentTarget.contains(ev.relatedTarget) ||
+                    ev.relatedTarget?.tagName !== 'LI'
+                  ) {
+                    setSourcesVisible(false);
+                  }
+                }}
               >
                 <div
                   css={searchSourceButtonStyles}

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -775,6 +775,14 @@ function LocationSearch({ route, label }: Props) {
                   : ''
               }`
             }
+            onBlur={(ev) => {
+              if (
+                !ev.currentTarget.contains(ev.relatedTarget) ||
+                ev.relatedTarget?.tagName !== 'LI'
+              ) {
+                setSourcesVisible(false);
+              }
+            }}
           >
             <div
               role="button"

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -781,6 +781,7 @@ function LocationSearch({ route, label }: Props) {
                 ev.relatedTarget?.tagName !== 'LI'
               ) {
                 setSourcesVisible(false);
+                setSourceCursor(-1);
               }
             }}
           >


### PR DESCRIPTION
## Related Issues:
* [HMW-640](https://jira.epa.gov/browse/HMW-640)

## Main Changes:
* Added a blur handler to the outermost containers around the "source" selection menus, used in the `LocationSearch` component and on the **State & Tribal** page, which closes the menu when clicked or tabbed outside.
  * I started to refactor the select menu into its own component, like in Expert Query, but the location search menu is dug in pretty deep. I figured that could be saved for refactoring during "the re-write", or even just a separate PR.

## Steps To Test:
1. Go to the home page, open the source menu of the search input, then click outside the menu. Confirm the menu closes.
2. Open the source menu, then press the `Tab` key, and confirm the menu closes.
3. Verify that it is still possible to select an item from the source menu, using either the mouse or the `Enter` key.
4. Repeat steps 1-3 for the search inputs on the **Community** and **State & Tribal** pages.