### PR TITLE
Bugfix/647 print map issue

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -24,6 +24,7 @@
         "glossary-panel": "github:Eastern-Research-Group/glossary",
         "highcharts": "11.1.0",
         "highcharts-react-official": "3.2.1",
+        "html-to-image": "1.11.11",
         "papaparse": "5.4.1",
         "pdf-lib": "1.17.1",
         "react": "17.0.2",
@@ -10996,6 +10997,11 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.3",
@@ -28946,6 +28952,11 @@
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
         }
       }
+    },
+    "html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "html-webpack-plugin": {
       "version": "5.5.3",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -74,6 +74,7 @@
     "glossary-panel": "github:Eastern-Research-Group/glossary",
     "highcharts": "11.1.0",
     "highcharts-react-official": "3.2.1",
+    "html-to-image": "1.11.11",
     "papaparse": "5.4.1",
     "pdf-lib": "1.17.1",
     "react": "17.0.2",

--- a/app/client/src/components/shared/MapLegend.js
+++ b/app/client/src/components/shared/MapLegend.js
@@ -575,17 +575,19 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
   // jsx
   const healthIndexLegend = (
     <li className="hmw-legend__item">
-      <div className="hmw-legend__symbol" css={legendItemStyles}>
-        <GradientIcon
-          id="health-index-gradient"
-          stops={[
-            { label: '1', color: 'rgb(10, 8, 145)' },
-            { label: '0.75', color: 'rgb(30, 61, 181)' },
-            { label: '0.5', color: 'rgb(54, 140, 225)' },
-            { label: '0.25', color: 'rgb(124, 187, 234)' },
-            { label: '0', color: 'rgb(180, 238, 239)' },
-          ]}
-        />
+      <div css={legendItemStyles}>
+        <div className="hmw-legend__symbol">
+          <GradientIcon
+            id="health-index-gradient"
+            stops={[
+              { label: '1', color: 'rgb(10, 8, 145)' },
+              { label: '0.75', color: 'rgb(30, 61, 181)' },
+              { label: '0.5', color: 'rgb(54, 140, 225)' },
+              { label: '0.25', color: 'rgb(124, 187, 234)' },
+              { label: '0', color: 'rgb(180, 238, 239)' },
+            ]}
+          />
+        </div>
         <span className="hmw-legend__info" css={labelStyles}>
           State Watershed Health Index Layer
         </span>

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -45,6 +45,10 @@
   box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
 }
 
+.esri-legend__symbol {
+  margin: unset;
+}
+
 .esri-print__header-title {
   font-size: 1.25em;
   font-weight: 500;

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -937,8 +937,8 @@ export function GradientIcon({
 }) {
   const divisions = stops.length - 1;
   return (
-    <div css={{ display: 'flex', margin: 'auto' }}>
-      <div css={{ margin: '15px 0' }}>
+    <div style={{ display: 'flex', margin: 'auto' }}>
+      <div style={{ margin: '15px 0' }}>
         <svg width={50} height={25 * divisions + 20}>
           <defs>
             <linearGradient


### PR DESCRIPTION
## Related Issues:
* [HMW-647](https://jira.epa.gov/browse/HMW-647)

## Main Changes:
* Fixed issues with print map widget. 
  * These issues came out of implementing the same widget in AirKeeper. I used AirKeeper as a reference for implementing these fixes.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Turn on all of the layers in the layer list
3. Open the add data widget
4. Add the `USA Current Wildfires` layer
    * On production this layer results in `USA Current Wildfires` being displayed 3 times. Once in the main title and in both sub titles.
5. Add the following URL as a URL layer: https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/NOAA_METAR_current_wind_speed_direction_v1/FeatureServer
    * This one came from AirKeeper. On production this results in a `Failed to convert svg to png` error.
6. Print the map
7. Verify the legend in the resulting pdf matches the layer list (note: order may be a little different).

