### PR TITLE
Feature/650 add ga4 support

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -433,6 +433,7 @@
       ];
 
       // Configure analytics destinations for non-production environments.
+      // Production will use the analytics injected by the EPA template.
       let trackingId;
       if (window.location.hostname === 'mywaterway-stage.app.cloud.gov') {
         // Stage

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -395,39 +395,40 @@
       // scrolling to odd positions after the page finishes loading
       history.scrollRestoration = 'manual';
 
-      function addGoogleAnalyticsObject() {
-        (function (i, s, o, g, r, a, m) {
-          i['GoogleAnalyticsObject'] = r;
-          (i[r] =
-            i[r] ||
-            function () {
-              (i[r].q = i[r].q || []).push(arguments);
-            }),
-            (i[r].l = 1 * new Date());
-          (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-          a.async = 1;
-          a.src = g;
-          m.parentNode.insertBefore(a, m);
-        })(
-          window,
-          document,
-          'script',
-          '//www.google-analytics.com/analytics.js',
-          'ga',
-        );
+      function configureGoogleAnalytics(uaId, ga4Id) {
+        const gaScript = document.createElement('script');
+        gaScript.async = 1;
+        gaScript.src = `//www.googletagmanager.com/gtag/js?id=${uaId}`;
+
+        const firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(gaScript, firstScript);
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag =
+          window.gtag ||
+          function () {
+            dataLayer.push(arguments);
+          };
+
+        gtag('js', new Date());
+
+        gtag('config', uaId);
+        // TODO: Remove debug_mode before going live.
+        gtag('config', ga4Id, { debug_mode: true });
       }
 
-      // Wrapper for logging to GA which adds the target to the command
-      function logToGa(command, ...props) {
-        if (!window.ga) return;
-        ga(`${window.gaTarget}.${command}`, ...props);
+      // Wrapper for logging to GA
+      function logToGa() {
+        if (!window.gtag) return;
+
+        gtag(...arguments);
       }
 
       function logErrorToGa(err, fatal = false) {
         const error = new Error(err);
-        window.logToGa('send', 'exception', {
-          exDescription: `${error.name}:${error.message}:${error.stack}`,
-          exFatal: fatal,
+        window.logToGa('event', 'exception', {
+          description: `${error.name}:${error.message}:${error.stack}`,
+          fatal,
         });
       }
 
@@ -458,125 +459,123 @@
       } else if (
         window.location.hostname === 'mywaterway-stage.app.cloud.gov'
       ) {
-        addGoogleAnalyticsObject();
-        ga('create', 'UA-37504877-4', 'auto', 'ERG'); //Stage
+        // Stage
         window.gaTarget = 'ERG';
-        logToGa('send', 'pageview');
+        // TODO: Update GA ID when ready.
+        //configureGoogleAnalytics('UA-37504877-4', 'G-XXXXXXXXXXX');
       } else if (
         window.location.hostname === 'mywaterway-dev.app.cloud.gov' ||
         window.location.hostname === 'localhost'
       ) {
-        addGoogleAnalyticsObject();
-        ga('create', 'UA-37504877-3', 'auto', 'ERG'); //Dev
+        // Dev
         window.gaTarget = 'ERG';
-        logToGa('send', 'pageview');
+        configureGoogleAnalytics('UA-37504877-3', 'G-X6JSLPJCWP');
       }
 
-      //Only setup the logging for public sites, ie don't log from localhost
-      if (gaTarget) {
-        // create the locationChange event
-        const locationChangeEvent = new Event('locationchange');
+      // create the locationChange event
+      const locationChangeEvent = new Event('locationchange');
 
-        // create the location change event listener
-        window.addEventListener('locationchange', function (event) {
-          logToGa('set', 'page', window.location.pathname);
-          logToGa('send', 'pageview');
+      // create the location change event listener
+      window.addEventListener('locationchange', function (event) {
+        logToGa('event', 'page_view', {
+          page_location: window.location,
         });
+      });
 
-        // Modify the pushState, replaceState and popState events so they
-        // will trigger the locationchange event.
-        const pushState = history.pushState;
-        history.pushState = function () {
-          pushState.apply(history, arguments);
-          window.dispatchEvent(locationChangeEvent);
-        };
-        const replaceState = history.replaceState;
-        history.replaceState = function () {
-          replaceState.apply(this, arguments);
-          window.dispatchEvent(locationChangeEvent);
-        };
-        window.addEventListener('popstate', function () {
-          window.dispatchEvent(locationChangeEvent);
-        });
+      // Modify the pushState, replaceState and popState events so they
+      // will trigger the locationchange event.
+      const pushState = history.pushState;
+      history.pushState = function () {
+        pushState.apply(history, arguments);
+        window.dispatchEvent(locationChangeEvent);
+      };
+      const replaceState = history.replaceState;
+      history.replaceState = function () {
+        replaceState.apply(this, arguments);
+        window.dispatchEvent(locationChangeEvent);
+      };
+      window.addEventListener('popstate', function () {
+        window.dispatchEvent(locationChangeEvent);
+      });
 
-        function wildcardIncludes(str, rule) {
-          const escapeRegex = (str) =>
-            str.replace(/([.*+?^=!:${}()|\]\\])/g, '\\$1');
-          return new RegExp(
-            '^' + rule.split('*').map(escapeRegex).join('.*') + '$',
-          ).test(str);
+      function wildcardIncludes(str, rule) {
+        const escapeRegex = (str) =>
+          str.replace(/([.*+?^=!:${}()|\]\\])/g, '\\$1');
+        return new RegExp(
+          '^' + rule.split('*').map(escapeRegex).join('.*') + '$',
+        ).test(str);
+      }
+
+      window.addEventListener('click', function (event) {
+        //Button clicks
+        if (event.target.onclick && event.target.textContent) {
+          const text = event.target.textContent.trim();
+          const title = event.target.title.trim();
+
+          //Log to Google Analytics
+          const action = title
+            ? 'ow-hmw2-' + text + ' - ' + title
+            : 'ow-hmw2-' + text;
+          logToGa('event', 'button_click', {
+            event_action: action,
+            event_category: 'buttonClick',
+            event_label: window.location.pathname,
+          });
         }
 
-        window.addEventListener('click', function (event) {
-          //Button clicks
-          if (event.target.onclick && event.target.textContent) {
-            const text = event.target.textContent.trim();
-            const title = event.target.title.trim();
+        //Link clicks
+        if (
+          event.target.tagName.toLowerCase() === 'a' &&
+          event.target.target === '_blank'
+        ) {
+          const href = event.target.href;
 
-            //Log to Google Analytics
-            const action = title
-              ? 'ow-hmw2-' + text + ' - ' + title
-              : 'ow-hmw2-' + text;
-            logToGa(
-              'send',
-              'event',
-              'buttonClick',
-              action,
-              window.location.pathname,
-            );
-          }
-
-          //Link clicks
-          if (
-            event.target.tagName.toLowerCase() === 'a' &&
-            event.target.target === '_blank'
-          ) {
-            const href = event.target.href;
-
-            // combine the web service and map service mappings
-            const mapping = window.googleAnalyticsMapping;
-            let name = '';
-            mapping.forEach((item) => {
-              if (!name && wildcardIncludes(href, item.wildcardUrl)) {
-                name = item.name;
-              }
-            });
-            const action =
-              'ow-hmw2-' + (name ? name : event.target.text.trim());
-
-            const extension = href.split('.').pop;
-            const category =
-              window.location.hostname === event.target.hostname
-                ? //Part of the HMW application
-                  extension === '.pdf' || extension === '.zip'
-                  ? 'Download'
-                  : 'Internal'
-                : 'External'; //External EPA Hyperlink
-
-            //Log to Google Analytics
-            logToGa('send', 'event', category, action, href);
-          }
-        });
-
-        window.addEventListener('error', function (event) {
-          if (
-            event.message ===
-              'ResizeObserver loop completed with undelivered notifications.' ||
-            event.message === 'ResizeObserver loop limit exceeded'
-          ) {
-            event.stopImmediatePropagation();
-            return;
-          }
-          window.logToGa('send', 'exception', {
-            exDescription: event.error
-              ? `${event.error.message}${event.error.stack}`
-              : event.message,
-            exFatal: true,
+          // combine the web service and map service mappings
+          const mapping = window.googleAnalyticsMapping;
+          let name = '';
+          mapping.forEach((item) => {
+            if (!name && wildcardIncludes(href, item.wildcardUrl)) {
+              name = item.name;
+            }
           });
+          const action = 'ow-hmw2-' + (name ? name : event.target.text.trim());
 
-          return true;
+          const extension = href.split('.').pop;
+          const category =
+            window.location.hostname === event.target.hostname
+              ? //Part of the HMW application
+                extension === '.pdf' || extension === '.zip'
+                ? 'Download'
+                : 'Internal'
+              : 'External'; //External EPA Hyperlink
+
+          //Log to Google Analytics
+          logToGa('event', 'link_click', {
+            event_action: action,
+            event_category: category,
+            event_label: href,
+          });
+        }
+      });
+
+      window.addEventListener('error', function (event) {
+        if (
+          event.message ===
+            'ResizeObserver loop completed with undelivered notifications.' ||
+          event.message === 'ResizeObserver loop limit exceeded'
+        ) {
+          event.stopImmediatePropagation();
+          return;
+        }
+        window.logToGa('event', 'exception', {
+          description: event.error
+            ? `${event.error.message}${event.error.stack}`
+            : event.message,
+          fatal: true,
         });
-      }
+
+        return true;
+      });
     </script>
     <!-- End Google Analytics-->
   </head>

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -432,7 +432,7 @@
         },
       ];
 
-      // Configure additional analytics destinations for non-production environments.
+      // Configure analytics destinations for non-production environments.
       let trackingId;
       if (window.location.hostname === 'mywaterway-stage.app.cloud.gov') {
         // Stage

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -395,10 +395,10 @@
       // scrolling to odd positions after the page finishes loading
       history.scrollRestoration = 'manual';
 
-      function configureGoogleAnalytics(uaId, ga4Id) {
+      function configureGoogleAnalytics(id, debug = false) {
         const gaScript = document.createElement('script');
         gaScript.async = 1;
-        gaScript.src = `//www.googletagmanager.com/gtag/js?id=${uaId}`;
+        gaScript.src = `//www.googletagmanager.com/gtag/js?id=${id}`;
 
         const firstScript = document.getElementsByTagName('script')[0];
         firstScript.parentNode.insertBefore(gaScript, firstScript);
@@ -412,24 +412,8 @@
 
         gtag('js', new Date());
 
-        gtag('config', uaId);
-        // TODO: Remove debug_mode before going live.
-        gtag('config', ga4Id, { debug_mode: true });
-      }
-
-      // Wrapper for logging to GA
-      function logToGa() {
-        if (!window.gtag) return;
-
-        gtag(...arguments);
-      }
-
-      function logErrorToGa(err, fatal = false) {
-        const error = new Error(err);
-        window.logToGa('event', 'exception', {
-          description: `${error.name}:${error.message}:${error.stack}`,
-          fatal,
-        });
+        const options = { ...(debug && { debug_mode: true }) };
+        gtag('config', id, options);
       }
 
       // get origin for mapping proxy calls
@@ -448,28 +432,41 @@
         },
       ];
 
-      //Only setup the logging for public sites, ie don't log from localhost
-      window.gaTarget = '';
-      if (
-        window.location.hostname === 'mywaterway.epa.gov' ||
-        window.location.hostname === 'mywaterway-prod.app.cloud.gov'
-      ) {
-        //EPA (Production) - Just initialize the HMW logs by setting gaTarget
-        window.gaTarget = 'EPA';
-      } else if (
-        window.location.hostname === 'mywaterway-stage.app.cloud.gov'
-      ) {
+      // Configure additional analytics destinations for non-production environments.
+      let trackingId;
+      if (window.location.hostname === 'mywaterway-stage.app.cloud.gov') {
         // Stage
-        window.gaTarget = 'ERG';
-        // TODO: Update GA ID when ready.
-        //configureGoogleAnalytics('UA-37504877-4', 'G-XXXXXXXXXXX');
+        trackingId = 'G-8ZG01NLPFL';
+        configureGoogleAnalytics(trackingId);
       } else if (
         window.location.hostname === 'mywaterway-dev.app.cloud.gov' ||
         window.location.hostname === 'localhost'
       ) {
         // Dev
-        window.gaTarget = 'ERG';
-        configureGoogleAnalytics('UA-37504877-3', 'G-X6JSLPJCWP');
+        trackingId = 'G-X6JSLPJCWP';
+        configureGoogleAnalytics(trackingId, true);
+      }
+
+      // Wrapper for logging to GA
+      function logToGa(name, parameters = {}) {
+        if (!window.gtag) return;
+
+        gtag('event', name, {
+          ...parameters,
+          ...(trackingId && { send_to: trackingId }),
+        });
+      }
+
+      function logErrorToGa(err, fatal = false) {
+        const description =
+          err instanceof Error
+            ? `${err.name}:${err.message}:${err.stack}`
+            : err;
+        window.logToGa('exception', {
+          description,
+          event_label: description,
+          fatal,
+        });
       }
 
       // create the locationChange event
@@ -477,7 +474,7 @@
 
       // create the location change event listener
       window.addEventListener('locationchange', function (event) {
-        logToGa('event', 'page_view', {
+        logToGa('page_view', {
           page_location: window.location,
         });
       });
@@ -516,7 +513,7 @@
           const action = title
             ? 'ow-hmw2-' + text + ' - ' + title
             : 'ow-hmw2-' + text;
-          logToGa('event', 'button_click', {
+          logToGa('button_click', {
             event_action: action,
             event_category: 'buttonClick',
             event_label: window.location.pathname,
@@ -550,7 +547,7 @@
               : 'External'; //External EPA Hyperlink
 
           //Log to Google Analytics
-          logToGa('event', 'link_click', {
+          logToGa('link_click', {
             event_action: action,
             event_category: category,
             event_label: href,
@@ -567,12 +564,7 @@
           event.stopImmediatePropagation();
           return;
         }
-        window.logToGa('event', 'exception', {
-          description: event.error
-            ? `${event.error.message}${event.error.stack}`
-            : event.message,
-          fatal: true,
-        });
+        window.logErrorToGa(event.error ?? event.message, true);
 
         return true;
       });

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -535,7 +535,7 @@
               name = item.name;
             }
           });
-          const action = 'ow-hmw2-' + (name ? name : event.target.text.trim());
+          const action = 'ow-hmw2-' + (name || event.target.text.trim());
 
           const extension = href.split('.').pop;
           const category =

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -247,20 +247,18 @@ function IdentifiedIssues() {
     );
     if (pollutedPercent > 0 && summaryByParameterImpairments.length === 0) {
       emptyCategoriesWithPercent = true;
-      window.logToGa('event', 'exception', {
-        description: `The summaryByParameterImpairments[] array is empty, even though ${pollutedPercent}% of assessed waters are impaired `,
-        fatal: false,
-      });
+      window.logErrorToGa(
+        `The summaryByParameterImpairments[] array is empty, even though ${pollutedPercent}% of assessed waters are impaired `,
+      );
     }
 
     // check for null percent of assess waters impaired
     const nullPollutedWaterbodies =
       containImpairedWatersCatchmentAreaPercent === null ? true : false;
     if (nullPollutedWaterbodies && summaryByParameterImpairments.length > 0) {
-      window.logToGa('event', 'exception', {
-        description: `The "% of assessed waters are impaired" value is 0, even though there are ${summaryByParameterImpairments.length} items in the summaryByParameterImpairments[] array.`,
-        fatal: false,
-      });
+      window.logErrorToGa(
+        `The "% of assessed waters are impaired" value is 0, even though there are ${summaryByParameterImpairments.length} items in the summaryByParameterImpairments[] array.`,
+      );
     }
 
     setEmptyCategoriesWithPercent(emptyCategoriesWithPercent);

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -222,7 +222,7 @@ function IdentifiedIssues() {
     useState(false);
   const [nullPollutedWaterbodies, setNullPollutedWaterbodies] = useState(false);
   useEffect(() => {
-    if (!window.gaTarget || cipSummary.status !== 'success') return;
+    if (cipSummary.status !== 'success') return;
 
     if (!cipSummary.data?.items?.length > 0) {
       setNullPollutedWaterbodies(true);
@@ -247,9 +247,9 @@ function IdentifiedIssues() {
     );
     if (pollutedPercent > 0 && summaryByParameterImpairments.length === 0) {
       emptyCategoriesWithPercent = true;
-      window.logToGa('send', 'exception', {
-        exDescription: `The summaryByParameterImpairments[] array is empty, even though ${pollutedPercent}% of assessed waters are impaired `,
-        exFatal: false,
+      window.logToGa('event', 'exception', {
+        description: `The summaryByParameterImpairments[] array is empty, even though ${pollutedPercent}% of assessed waters are impaired `,
+        fatal: false,
       });
     }
 
@@ -257,9 +257,9 @@ function IdentifiedIssues() {
     const nullPollutedWaterbodies =
       containImpairedWatersCatchmentAreaPercent === null ? true : false;
     if (nullPollutedWaterbodies && summaryByParameterImpairments.length > 0) {
-      window.logToGa('send', 'exception', {
-        exDescription: `The "% of assessed waters are impaired" value is 0, even though there are ${summaryByParameterImpairments.length} items in the summaryByParameterImpairments[] array.`,
-        exFatal: false,
+      window.logToGa('event', 'exception', {
+        description: `The "% of assessed waters are impaired" value is 0, even though there are ${summaryByParameterImpairments.length} items in the summaryByParameterImpairments[] array.`,
+        fatal: false,
       });
     }
 

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -173,9 +173,9 @@ function Restore() {
                                 );
                               } catch (err) {
                                 console.error(err);
-                                window.logToGa('send', 'exception', {
-                                  exDescription: `Failed to parse watershed_plans JSON data for the "${item.prj_title}" project with ID "${item.prj_seq}"`,
-                                  exFatal: false,
+                                window.logToGa('event', 'exception', {
+                                  description: `Failed to parse watershed_plans JSON data for the "${item.prj_title}" project with ID "${item.prj_seq}"`,
+                                  fatal: false,
                                 });
                               }
                             }

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -173,10 +173,9 @@ function Restore() {
                                 );
                               } catch (err) {
                                 console.error(err);
-                                window.logToGa('event', 'exception', {
-                                  description: `Failed to parse watershed_plans JSON data for the "${item.prj_title}" project with ID "${item.prj_seq}"`,
-                                  fatal: false,
-                                });
+                                window.logErrorToGa(
+                                  `Failed to parse watershed_plans JSON data for the "${item.prj_title}" project with ID "${item.prj_seq}"`,
+                                );
                               }
                             }
 

--- a/app/client/src/components/shared/ErrorBoundary.js
+++ b/app/client/src/components/shared/ErrorBoundary.js
@@ -56,12 +56,7 @@ class ErrorBoundary extends Component<Props, State> {
     try {
       throw error;
     } catch (err) {
-      if (!window.gaTarget) return;
-
-      window.logToGa('send', 'exception', {
-        exDescription: `${error.message}${error.stack}`,
-        exFatal: true,
-      });
+      window.logErrorToGa(err, true);
     }
   }
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -373,11 +373,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         idsNotInAssessmentUnitService &&
         idsNotInAssessmentUnitService.length > 0
       ) {
-        window.logToGa('send', 'exception', {
-          exDescription: `The Assessment Units service did not return data for the following assessment IDs ${idsNotInAssessmentUnitService.join(
+        window.logToGa('event', 'exception', {
+          description: `The Assessment Units service did not return data for the following assessment IDs ${idsNotInAssessmentUnitService.join(
             ', ',
           )}`,
-          exFatal: false,
+          fatal: false,
         });
       }
 
@@ -486,13 +486,13 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         if (orphanIDs.length === 0) return;
         setWaterbodyCountMismatch(true);
 
-        window.logToGa('send', 'exception', {
-          exDescription: `huc12Summary service contained ${assessmentUnitCount} Assessment Unit IDs but the GIS service contained ${
+        window.logToGa('event', 'exception', {
+          description: `huc12Summary service contained ${assessmentUnitCount} Assessment Unit IDs but the GIS service contained ${
             uniqueWaterbodies.length
           } features for HUC ${huc12}. Assessment Unit IDs not found in GIS service: (${orphanIDs.join(
             ', ',
           )})`,
-          exFatal: false,
+          fatal: false,
         });
 
         setOrphanFeatures({ features: [], status: 'fetching' });

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -373,12 +373,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         idsNotInAssessmentUnitService &&
         idsNotInAssessmentUnitService.length > 0
       ) {
-        window.logToGa('event', 'exception', {
-          description: `The Assessment Units service did not return data for the following assessment IDs ${idsNotInAssessmentUnitService.join(
+        window.logErrorToGa(
+          `The Assessment Units service did not return data for the following assessment IDs ${idsNotInAssessmentUnitService.join(
             ', ',
           )}`,
-          fatal: false,
-        });
+        );
       }
 
       const requests = [];
@@ -486,14 +485,13 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         if (orphanIDs.length === 0) return;
         setWaterbodyCountMismatch(true);
 
-        window.logToGa('event', 'exception', {
-          description: `huc12Summary service contained ${assessmentUnitCount} Assessment Unit IDs but the GIS service contained ${
+        window.logErrorToGa(
+          `huc12Summary service contained ${assessmentUnitCount} Assessment Unit IDs but the GIS service contained ${
             uniqueWaterbodies.length
           } features for HUC ${huc12}. Assessment Unit IDs not found in GIS service: (${orphanIDs.join(
             ', ',
           )})`,
-          fatal: false,
-        });
+        );
 
         setOrphanFeatures({ features: [], status: 'fetching' });
 

--- a/app/client/src/components/shared/Page.js
+++ b/app/client/src/components/shared/Page.js
@@ -378,6 +378,19 @@ function Page({ children }: Props) {
               Contact Us
             </a>
           </li>
+          {(process.env.NODE_ENV === 'local' ||
+            process.env.NODE_ENV === 'development') && (
+            <li>
+              <button
+                onClick={() => {
+                  Array(-100);
+                }}
+              >
+                <i className="fas fa-skull-crossbones" aria-hidden="true" />
+                PANIC
+              </button>
+            </li>
+          )}
         </ul>
       </div>
 

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -252,7 +252,7 @@ export function logCallToGoogleAnalytics(
   const eventLabel = `${url} | status:${status} | time:${duration}`;
 
   // log to google analytics if it has been setup
-  window.logToGa('event', 'service_call', {
+  window.logToGa('service_call', {
     event_action: eventAction,
     event_category: 'Web-service',
     event_label: eventLabel,

--- a/app/client/src/utils/fetchUtils.js
+++ b/app/client/src/utils/fetchUtils.js
@@ -235,9 +235,6 @@ export function logCallToGoogleAnalytics(
   status: number,
   startTime: number,
 ) {
-  if (!window.gaTarget) return;
-  if (!window.ga) return;
-
   const duration = performance.now() - startTime;
 
   // combine the web service and map service mappings
@@ -255,7 +252,11 @@ export function logCallToGoogleAnalytics(
   const eventLabel = `${url} | status:${status} | time:${duration}`;
 
   // log to google analytics if it has been setup
-  window.logToGa('send', 'event', 'Web-service', eventAction, eventLabel);
+  window.logToGa('event', 'service_call', {
+    event_action: eventAction,
+    event_category: 'Web-service',
+    event_label: eventLabel,
+  });
 }
 
 function wildcardIncludes(str, rule) {

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -58,12 +58,6 @@ import type {
   WaterbodyCondition,
 } from 'types';
 
-declare global {
-  interface Window {
-    logToGa: Function;
-  }
-}
-
 let dynamicPopupFields: __esri.Field[] = [];
 
 const allWaterbodiesAlpha = {


### PR DESCRIPTION
## Related Issues:
* [HMW-650](https://jira.epa.gov/browse/HMW-650)

## Main Changes:
* Updated the Google Analytics tracking ID to GA4 rather than Universal Analytics.
* Updated from the `analytics.js` API to the `gtag.js` API.

## Steps To Test:
1. Open the DebugView in the Google Analytics dashboard for the dev tracking ID.
2. Navigate to the HMW home page.
3. Confirm a `page_view` event and several `service_call` events are received. This may take up to a couple minutes to populate, and the events may not arrive in order, so it's best to note the event counts before opening the page and after events are received.
4. Navigate to DC through the application.
5. Click the link to open a Monitoring Report page, and confirm a `link_click` event is received.
6. Click the **PANIC** button at the top of the page, and confirm a `button_click` event and an `exception` event are received. 

## TODO:
- [ ] Remove the **PANIC** button after testing on development.
