### PR TITLE
Bugfix/660 fullscreen map focus trap

### DIFF
--- a/app/client/package.json
+++ b/app/client/package.json
@@ -58,8 +58,8 @@
     "web-vitals": "3.5.1"
   },
   "dependencies": {
-    "@emotion/react": "11.11.3",
     "@arcgis/core": "4.28.10",
+    "@emotion/react": "11.11.3",
     "@radix-ui/react-dialog": "1.0.5",
     "@reach/tabs": "0.18.0",
     "@reach/tooltip": "0.18.0",

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -2342,19 +2342,15 @@ function MonitoringReportContent() {
   );
 
   const fullScreenView = (
-    <WindowSize>
-      {({ width, height }) => (
-        <div data-content="location-map" style={{ width, height }}>
-          <SiteMapContainer
-            layout="fullscreen"
-            site={site}
-            siteFilter={siteFilter}
-            siteStatus={siteStatus}
-            widthRef={widthRef}
-          />
-        </div>
-      )}
-    </WindowSize>
+    <div data-content="location-map">
+      <SiteMapContainer
+        layout="fullscreen"
+        site={site}
+        siteFilter={siteFilter}
+        siteStatus={siteStatus}
+        widthRef={widthRef}
+      />
+    </div>
   );
 
   const twoColumnView = (

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -216,8 +216,7 @@ const mapFooterStyles = css`
   width: 100%;
   /* match ESRI map footer text */
   padding: 3px 5px;
-  border: 1px solid #aebac3;
-  border-top: none;
+  border-top: 1px solid #aebac3;
   font-size: 0.75em;
   background-color: whitesmoke;
 `;
@@ -1133,10 +1132,7 @@ function AdvancedSearch() {
       activeState={activeState}
       numberOfRecords={numberOfRecords}
     >
-      <div
-        css={mapFooterStyles}
-        style={{ width: fullscreenActive ? width : '100%' }}
-      >
+      <div css={mapFooterStyles}>
         {reportStatusMapping.status === 'failure' && (
           <div css={mapFooterMessageStyles}>{status303dError}</div>
         )}

--- a/app/client/src/components/shared/FullscreenContainer.tsx
+++ b/app/client/src/components/shared/FullscreenContainer.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource @emotion/react */
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { WindowSize } from '@reach/window-size';
+// contexts
+import { useFullscreenState } from 'contexts/Fullscreen';
+// types
+import type { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+  description?: string;
+  title?: string;
+};
+
+export default function FullscreenContainer({
+  children,
+  description,
+  title,
+}: Props) {
+  const { fullscreenActive, setFullscreenActive } = useFullscreenState();
+
+  return (
+    <WindowSize>
+      {({ width, height }) => (
+        <Dialog.Root
+          modal={false}
+          open={fullscreenActive}
+          onOpenChange={setFullscreenActive}
+        >
+          <Dialog.Content
+            css={{
+              backgroundColor: 'white',
+              height,
+              left: 0,
+              position: 'fixed',
+              top: 0,
+              width,
+              zIndex: 9999,
+            }}
+          >
+            {title && <Dialog.Title className="sr-only">{title}</Dialog.Title>}
+            {description && (
+              <Dialog.Description className="sr-only">
+                {description}
+              </Dialog.Description>
+            )}
+            {children}
+          </Dialog.Content>
+        </Dialog.Root>
+      )}
+    </WindowSize>
+  );
+}

--- a/app/client/src/components/shared/FullscreenContainer.tsx
+++ b/app/client/src/components/shared/FullscreenContainer.tsx
@@ -24,28 +24,32 @@ export default function FullscreenContainer({
     <WindowSize>
       {({ width, height }) => (
         <Dialog.Root open={fullscreenActive} onOpenChange={setFullscreenActive}>
-          <Dialog.Content
-            css={{
-              backgroundColor: 'white',
-              height,
-              left: 0,
-              position: 'fixed',
-              top: 0,
-              width,
-              zIndex: 9999,
-            }}
-            onEscapeKeyDown={(event) => {
-              event.preventDefault();
-            }}
-          >
-            {title && <Dialog.Title className="sr-only">{title}</Dialog.Title>}
-            {description && (
-              <Dialog.Description className="sr-only">
-                {description}
-              </Dialog.Description>
-            )}
-            {children}
-          </Dialog.Content>
+          <Dialog.Portal>
+            <Dialog.Content
+              css={{
+                backgroundColor: 'white',
+                height,
+                left: 0,
+                position: 'fixed',
+                top: 0,
+                width,
+                zIndex: 9999,
+              }}
+              onEscapeKeyDown={(event) => {
+                event.preventDefault();
+              }}
+            >
+              {title && (
+                <Dialog.Title className="sr-only">{title}</Dialog.Title>
+              )}
+              {description && (
+                <Dialog.Description className="sr-only">
+                  {description}
+                </Dialog.Description>
+              )}
+              {children}
+            </Dialog.Content>
+          </Dialog.Portal>
         </Dialog.Root>
       )}
     </WindowSize>

--- a/app/client/src/components/shared/FullscreenContainer.tsx
+++ b/app/client/src/components/shared/FullscreenContainer.tsx
@@ -23,11 +23,7 @@ export default function FullscreenContainer({
   return (
     <WindowSize>
       {({ width, height }) => (
-        <Dialog.Root
-          modal={false}
-          open={fullscreenActive}
-          onOpenChange={setFullscreenActive}
-        >
+        <Dialog.Root open={fullscreenActive} onOpenChange={setFullscreenActive}>
           <Dialog.Content
             css={{
               backgroundColor: 'white',
@@ -37,6 +33,9 @@ export default function FullscreenContainer({
               top: 0,
               width,
               zIndex: 9999,
+            }}
+            onEscapeKeyDown={(event) => {
+              event.preventDefault();
             }}
           >
             {title && <Dialog.Title className="sr-only">{title}</Dialog.Title>}

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -4,10 +4,12 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import EsriMap from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
+import FullscreenContainer from 'components/shared/FullscreenContainer';
 import MapWidgets from 'components/shared/MapWidgets';
 import MapMouseEvents from 'components/shared/MapMouseEvents';
 // contexts
 import { useAddSaveDataWidgetState } from 'contexts/AddSaveDataWidget';
+import { useFullscreenState } from 'contexts/Fullscreen';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useLayers } from 'contexts/Layers';
 // types
@@ -94,4 +96,13 @@ function Map({ layers = null, startingExtent = null }: Props) {
   );
 }
 
-export default Map;
+export default function MapContainer(props: Props) {
+  const { fullscreenActive } = useFullscreenState();
+  return fullscreenActive ? (
+    <FullscreenContainer>
+      <Map {...props} />
+    </FullscreenContainer>
+  ) : (
+    <Map {...props} />
+  );
+}

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -99,7 +99,7 @@ function Map({ layers = null, startingExtent = null }: Props) {
 export default function MapContainer(props: Props) {
   const { fullscreenActive } = useFullscreenState();
   return fullscreenActive ? (
-    <FullscreenContainer>
+    <FullscreenContainer title="Fullscreen Map View">
       <Map {...props} />
     </FullscreenContainer>
   ) : (

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useContext, useEffect, useRef, useState } from 'react';
-import { css } from '@emotion/react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import EsriMap from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
 import FullscreenContainer from 'components/shared/FullscreenContainer';
@@ -14,19 +13,15 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useLayers } from 'contexts/Layers';
 // types
 import type { LayerId } from 'contexts/Layers';
-
-const mapContainerStyles = css`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-`;
+import type { ReactNode } from 'react';
 
 type Props = {
+  children?: ReactNode;
   layers: __esri.Layer[] | null;
   startingExtent?: Object | null;
 };
 
-function Map({ layers = null, startingExtent = null }: Props) {
+function Map({ children, layers = null, startingExtent = null }: Props) {
   const { widgetLayers } = useAddSaveDataWidgetState();
   const { basemap, highlightOptions, initialExtent, mapView, setMapView } =
     useContext(LocationSearchContext);
@@ -79,19 +74,37 @@ function Map({ layers = null, startingExtent = null }: Props) {
 
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
 
+  // Calculate the height of the div holding the footer content.
+  const [footerHeight, setFooterHeight] = useState(0);
+  const footerRef = useCallback((node: HTMLDivElement | null) => {
+    if (!node) return;
+    setFooterHeight(node.getBoundingClientRect().height);
+  }, []);
+
   return (
-    <div id="hmw-map-container" css={mapContainerStyles} ref={mapContainerRef}>
-      {map && mapView && (
-        <>
-          <MapWidgets
-            map={map}
-            mapRef={mapContainerRef}
-            view={mapView}
-            layers={layers}
-          />
-          <MapMouseEvents map={map} view={mapView} />
-        </>
-      )}
+    <div css={{ position: 'absolute', height: '100%', width: '100%' }}>
+      <div
+        id="hmw-map-container"
+        css={{
+          position: 'relative',
+          height: `calc(100% - ${footerHeight}px)`,
+          width: '100%',
+        }}
+        ref={mapContainerRef}
+      >
+        {map && mapView && (
+          <>
+            <MapWidgets
+              map={map}
+              mapRef={mapContainerRef}
+              view={mapView}
+              layers={layers}
+            />
+            <MapMouseEvents map={map} view={mapView} />
+          </>
+        )}
+      </div>
+      <div ref={footerRef}>{children}</div>
     </div>
   );
 }

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -1,7 +1,7 @@
 // @flow
 /** @jsxImportSource @emotion/react */
 
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import type { Node } from 'react';
 import { css } from '@emotion/react';
 import StickyBox from 'react-sticky-box';
@@ -430,12 +430,6 @@ function StateMap({
   }, [layout, windowHeight, windowWidth]);
 
   // calculate height of div holding the footer content
-  const [footerHeight, setFooterHeight] = useState(0);
-  const measuredRef = useCallback((node) => {
-    if (!node) return;
-    setFooterHeight(node.getBoundingClientRect().height);
-  }, []);
-
   const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
   const mapInputsHeight = mapInputs?.getBoundingClientRect().height;
 
@@ -456,15 +450,11 @@ function StateMap({
         style={
           layout === 'fullscreen'
             ? {
-                height: windowHeight - footerHeight,
+                height: windowHeight,
                 width: windowWidth,
               }
             : {
-                height:
-                  windowHeight -
-                  footerHeight -
-                  mapInputsHeight -
-                  3 * mapPadding,
+                height: windowHeight - mapInputsHeight - 3 * mapPadding,
               }
         }
       >
@@ -477,12 +467,11 @@ function StateMap({
             spatialReference: { wkid: 102100 },
           }}
           layers={layers}
-        />
+        >
+          {children}
+        </Map>
         {mapView && mapLoading && <MapLoadingSpinner />}
       </div>
-
-      {/* The StateMap's children is a footer */}
-      <div ref={measuredRef}>{children}</div>
     </div>
   );
 

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -88,6 +88,7 @@ import {
 // styles
 import { tabsStyles } from 'components/shared/ContentTabs';
 // types
+import type { ReactNode } from 'react';
 import type { MonitoringLocationAttributes } from 'types';
 
 const mapPadding = 20;
@@ -137,8 +138,7 @@ const mapFooterStyles = css`
   width: 100%;
   /* match ESRI map footer text */
   padding: 3px 5px;
-  border: 1px solid #aebac3;
-  border-top: none;
+  border-top: 1px solid #aebac3;
   font-size: 0.75em;
   background-color: whitesmoke;
 `;
@@ -319,13 +319,6 @@ function TribalMapList({
   const layerTogglesRef = useCallback((node) => {
     if (!node) return;
     setLayerTogglesHeight(node.getBoundingClientRect().height);
-  }, []);
-
-  // calculate height of div holding the footer content
-  const [footerHeight, setFooterHeight] = useState(0);
-  const footerRef = useCallback((node) => {
-    if (!node) return;
-    setFooterHeight(node.getBoundingClientRect().height);
   }, []);
 
   const { fullscreenActive } = useFullscreenState();
@@ -511,11 +504,11 @@ function TribalMapList({
         style={
           layout === 'fullscreen'
             ? {
-                height: windowHeight - footerHeight,
+                height: windowHeight,
                 width: windowWidth,
               }
             : {
-                height: mapListHeight - footerHeight,
+                height: mapListHeight,
                 width: '100%',
                 display: displayMode === 'map' && mapShown ? 'block' : 'none',
               }
@@ -525,14 +518,8 @@ function TribalMapList({
           activeState={activeState}
           filter={filter}
           setTribalBoundaryError={setTribalBoundaryError}
-        />
-      </div>
-      {displayMode === 'map' && mapShown && (
-        <div ref={footerRef}>
-          <div
-            css={mapFooterStyles}
-            style={{ width: layout === 'fullscreen' ? windowWidth : '100%' }}
-          >
+        >
+          <div css={mapFooterStyles}>
             <div css={mapFooterStatusStyles}>
               <strong>Year Last Reported:</strong>
               &nbsp;&nbsp;
@@ -547,8 +534,8 @@ function TribalMapList({
               )}
             </div>
           </div>
-        </div>
-      )}
+        </TribalMap>
+      </div>
 
       {displayMode === 'list' && listShown && (
         <div css={modifiedTabStyles(mapListHeight)}>
@@ -597,12 +584,14 @@ function TribalMapList({
 
 type TribalMapProps = {
   activeState: Object,
+  children: ReactNode,
   filter: string,
   setTribalBoundaryError: Function,
 };
 
 function TribalMap({
   activeState,
+  children,
   filter,
   setTribalBoundaryError,
 }: TribalMapProps) {
@@ -950,7 +939,9 @@ function TribalMap({
 
   return (
     <Fragment>
-      <Map layers={layers} />
+      <Map layers={layers}>
+        {children}
+      </Map>
       {mapView && mapLoading && <MapLoadingSpinner />}
     </Fragment>
   );


### PR DESCRIPTION
## Related Issues:
* [HMW-660](https://jira.epa.gov/browse/HMW-660)

## Main Changes:
* Fixed an issue where pressing the `Tab` key in the fullscreen map view could tab away from and offset the map.
  * This fix uses a fixed position, fullscreen modal to display the fullscreen map. I started to implement the focus trap with custom logic, but then decided to use the package on hand.

## Steps To Test:
1. Test the fullscreen mode of all maps, ensuring behavior is consistent while toggling back and forth.
2. Navigate the fullscreen view with the `Tab` and `S-Tab` keys. Verify the focus does not leave the map.
3. Check that the State and Tribal map footers are still present in the fullscreen view.

## TODO:
- [ ] A fair amount of rendering logic could be trimmed away since the fixed dialog is used. I decided to hold off on the changes for now, since there is other logic (e.g. zoom on render) that needs to be accommodated.
