### PR TITLE
Bugfix/662 fullscreen glossary terms

### DIFF
--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -34,7 +34,6 @@ import {
   boxSectionStyles,
 } from 'components/shared/Box';
 // contexts
-import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
 import { LayersProvider } from 'contexts/Layers';
 import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
@@ -254,8 +253,6 @@ const strongBottomMarginStyles = css`
 
 function Actions() {
   const { orgId, actionId } = useParams();
-
-  const { fullscreenActive } = useFullscreenState();
 
   const services = useServicesContext();
 
@@ -571,24 +568,6 @@ function Actions() {
     );
   }
 
-  if (fullscreenActive) {
-    return (
-      <WindowSize>
-        {({ width, height }) => {
-          return (
-            <div data-content="actionsmap" style={{ height, width }}>
-              <ActionsMap
-                layout="fullscreen"
-                unitIds={unitIds}
-                onLoad={setMapLayer}
-              />
-            </div>
-          );
-        }}
-      </WindowSize>
-    );
-  }
-
   return (
     <Page>
       <NavBar title="Plan Summary" />
@@ -806,9 +785,7 @@ export default function ActionsContainer() {
   return (
     <LayersProvider>
       <MapHighlightProvider>
-        <FullscreenProvider>
-          <Actions />
-        </FullscreenProvider>
+        <Actions />
       </MapHighlightProvider>
     </LayersProvider>
   );

--- a/app/client/src/components/pages/Community.js
+++ b/app/client/src/components/pages/Community.js
@@ -22,7 +22,6 @@ import {
 } from 'contexts/CommunityTabs';
 import { EsriMapProvider } from 'contexts/EsriMap';
 import { MapHighlightProvider } from 'contexts/MapHighlight';
-import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
 import { useSurroundingsState } from 'contexts/Surroundings';
 // config
 import { tabs } from 'config/communityConfig.js';
@@ -112,8 +111,6 @@ function Community() {
 
   const { activeTabIndex } = useContext(CommunityTabsContext);
 
-  const { fullscreenActive } = useFullscreenState();
-
   // CommunityIntro is rendered in Outlet when at the '/community' and '/community/' routes
   const atCommunityIntroRoute =
     window.location.pathname.replace(/\//g, '') === 'community'; // replace slashes "/" with empty string
@@ -197,22 +194,6 @@ function Community() {
       <TabLinks />
       <WindowSize>
         {({ width, height }) => {
-          if (fullscreenActive) {
-            return (
-              <>
-                <LocationMap windowHeight={height} layout="fullscreen" />
-
-                <div style={{ display: 'none' }}>
-                  <Outlet />
-                </div>
-
-                {!atCommunityIntroRoute && (
-                  <div style={{ display: 'none' }}>{lowerTab}</div>
-                )}
-              </>
-            );
-          }
-
           if (width < 960) {
             // narrow screens
             return (
@@ -290,9 +271,7 @@ export default function CommunityContainer() {
       <CommunityTabsProvider>
         <LayersProvider>
           <MapHighlightProvider>
-            <FullscreenProvider>
-              <Community />
-            </FullscreenProvider>
+            <Community />
           </MapHighlightProvider>
         </LayersProvider>
       </CommunityTabsProvider>

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -2476,7 +2476,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
 
   // Zoom to the location of the site
   useEffect(() => {
-    if (!mapView || !layersInitialized || !homeWidget) return;
+    if (!mapLoading || !mapView || !layersInitialized || !homeWidget) return;
     if (siteStatus !== 'success') return;
 
     if (!monitoringLocationsLayer) return;
@@ -2503,6 +2503,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
     getSignal,
     homeWidget,
     layersInitialized,
+    mapLoading,
     mapView,
     monitoringLocationsLayer,
     siteStatus,
@@ -2520,7 +2521,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
 
   return (
     <div css={mapContainerStyles} data-testid="hmw-site-map" ref={widthRef}>
-      {siteStatus === 'pending' ? <LoadingSpinner /> : <Map layers={layers} />}
+      <Map layers={layers} />
       {mapView && mapLoading && <MapLoadingSpinner />}
     </div>
   );

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -41,7 +41,6 @@ import {
 // config
 import { monitoringDownloadError, monitoringError } from 'config/errorMessages';
 // contexts
-import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
 import { LayersProvider, useLayers } from 'contexts/Layers';
 import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
@@ -2238,7 +2237,6 @@ function MonitoringReportContent() {
       ? 'empty'
       : monitoringLocationsStatus;
 
-  const { fullscreenActive } = useFullscreenState();
   const [characteristics, characteristicsStatus] = useCharacteristics(
     provider,
     orgId,
@@ -2341,19 +2339,7 @@ function MonitoringReportContent() {
     </Page>
   );
 
-  const fullScreenView = (
-    <div data-content="location-map">
-      <SiteMapContainer
-        layout="fullscreen"
-        site={site}
-        siteFilter={siteFilter}
-        siteStatus={siteStatus}
-        widthRef={widthRef}
-      />
-    </div>
-  );
-
-  const twoColumnView = (
+  const content = (
     <Page>
       <NavBar title="Water Monitoring Report" />
       <div css={containerStyles} data-content="container">
@@ -2406,8 +2392,6 @@ function MonitoringReportContent() {
     </Page>
   );
 
-  const content = fullscreenActive ? fullScreenView : twoColumnView;
-
   return (
     <StatusContent
       empty={noSiteView}
@@ -2429,11 +2413,9 @@ function MonitoringReport() {
 
   return (
     <LayersProvider>
-      <FullscreenProvider>
-        <MapHighlightProvider>
-          <MonitoringReportContent />
-        </MapHighlightProvider>
-      </FullscreenProvider>
+      <MapHighlightProvider>
+        <MonitoringReportContent />
+      </MapHighlightProvider>
     </LayersProvider>
   );
 }
@@ -2528,8 +2510,7 @@ function SiteMap({ layout, siteStatus, widthRef }) {
 
   // Scrolls to the map when switching layouts
   useEffect(() => {
-    const itemName = layout === 'fullscreen' ? 'location-map' : 'container';
-    const content = document.querySelector(`[data-content="${itemName}"]`);
+    const content = document.querySelector(`[data-content="container"]`);
     if (content) {
       let pos = content.getBoundingClientRect();
 

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -15,7 +15,6 @@ import TribalMapList from 'components/shared/TribalMapList';
 import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
 // contexts
 import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
-import { useFullscreenState } from 'contexts/Fullscreen';
 
 function StateTribalTabs() {
   const { stateCode, tabName } = useParams();
@@ -28,8 +27,6 @@ function StateTribalTabs() {
     setActiveTabIndex,
     setErrorType,
   } = useContext(StateTribalTabsContext);
-
-  const { fullscreenActive } = useFullscreenState();
 
   // redirect to overview tab if tabName param wasn't provided in the url
   // (e.g. '/state/al' redirects to '/state/AL/water-quality-overview')
@@ -100,15 +97,10 @@ function StateTribalTabs() {
 
   const tabListRef = useRef();
 
-  const { width, height } = useWindowSize();
+  const { height } = useWindowSize();
 
   const mapContent = (
-    <TribalMapList
-      windowHeight={height}
-      windowWidth={width}
-      layout={fullscreenActive ? 'fullscreen' : 'narrow'}
-      activeState={activeState}
-    />
+    <TribalMapList windowHeight={height} activeState={activeState} />
   );
 
   if (activeState.source === 'All') {
@@ -125,7 +117,6 @@ function StateTribalTabs() {
 
   if (activeState.source === 'Tribe') {
     if (tribes.status === 'failure') return null;
-    if (fullscreenActive) return mapContent;
 
     return (
       <div>

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -134,7 +134,6 @@ function StateTribalTabs() {
   return (
     <Tabs
       css={tabsStyles}
-      data-content="stateTabs"
       index={activeTabIndex}
       onChange={(index) => {
         setActiveTabIndex(index);

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -1182,7 +1182,7 @@ function AdvancedSearch() {
   }
 
   return (
-    <div data-content="stateoverview">
+    <div>
       {filterControls}
 
       {currentFilter && resultsContainer}

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -23,7 +23,6 @@ import {
   useMapHighlightState,
   MapHighlightProvider,
 } from 'contexts/MapHighlight';
-import { useFullscreenState } from 'contexts/Fullscreen';
 import {
   useReportStatusMappingContext,
   useServicesContext,
@@ -260,8 +259,6 @@ function AdvancedSearch() {
     stateAndOrganization,
     setStateAndOrganization,
   } = useContext(StateTribalTabsContext);
-
-  const { fullscreenActive } = useFullscreenState();
 
   const {
     mapView,
@@ -1127,7 +1124,6 @@ function AdvancedSearch() {
     <StateMap
       windowHeight={height}
       windowWidth={width}
-      layout={fullscreenActive ? 'fullscreen' : 'narrow'}
       filter={currentFilter}
       activeState={activeState}
       numberOfRecords={numberOfRecords}
@@ -1174,10 +1170,6 @@ function AdvancedSearch() {
       </div>
     </StateMap>
   );
-
-  if (fullscreenActive) {
-    return mapContent;
-  }
 
   const contentVisible = currentFilter && waterbodyData;
 

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -399,7 +399,7 @@ function StateTribal() {
     <Page>
       <TabLinks />
 
-      <div css={containerStyles} data-content="state">
+      <div css={containerStyles}>
         {(states.status === 'fetching' || tribes.status === 'fetching') && (
           <LoadingSpinner />
         )}
@@ -544,8 +544,8 @@ function StateTribal() {
                     selectedSource === 'All'
                       ? 'Select a state, tribe or territory...'
                       : selectedSource === 'State'
-                      ? 'Select a state or territory...'
-                      : 'Select a tribe...'
+                        ? 'Select a state or territory...'
+                        : 'Select a tribe...'
                   }
                   options={selectOptions}
                   value={selectedStateTribe}

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -21,7 +21,6 @@ import {
   keyMetricLabelStyles,
 } from 'components/shared/KeyMetrics';
 // contexts
-import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
 import {
   StateTribalTabsContext,
   StateTribalTabsProvider,
@@ -46,9 +45,8 @@ import {
 
 const allSources = ['All', 'State', 'Tribe'];
 
-const containerStyles = (fullscreenActive) => css`
-  ${fullscreenActive ? '' : 'margin: auto;'}
-  ${fullscreenActive ? '' : 'padding: 15px;'}
+const containerStyles = css`
+  margin: auto;
   margin-top: 15px;
   margin-bottom: 15px;
   max-width: 1140px;
@@ -192,8 +190,6 @@ function StateTribal() {
     setUsesStateSummaryServiceError,
     usesStateSummaryServiceError,
   } = useContext(StateTribalTabsContext);
-
-  const { fullscreenActive } = useFullscreenState();
 
   // redirect to '/stateandtribe' if the url is /state or /tribe
   useEffect(() => {
@@ -403,7 +399,7 @@ function StateTribal() {
     <Page>
       <TabLinks />
 
-      <div css={containerStyles(fullscreenActive)} data-content="state">
+      <div css={containerStyles} data-content="state">
         {(states.status === 'fetching' || tribes.status === 'fetching') && (
           <LoadingSpinner />
         )}
@@ -548,8 +544,8 @@ function StateTribal() {
                     selectedSource === 'All'
                       ? 'Select a state, tribe or territory...'
                       : selectedSource === 'State'
-                        ? 'Select a state or territory...'
-                        : 'Select a tribe...'
+                      ? 'Select a state or territory...'
+                      : 'Select a tribe...'
                   }
                   options={selectOptions}
                   value={selectedStateTribe}
@@ -711,9 +707,7 @@ function StateTribal() {
 export default function StateTribalContainer() {
   return (
     <StateTribalTabsProvider>
-      <FullscreenProvider>
-        <StateTribal />
-      </FullscreenProvider>
+      <StateTribal />
     </StateTribalTabsProvider>
   );
 }

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -31,7 +31,6 @@ import {
 } from 'components/shared/Box';
 // contexts
 import { LayersProvider } from 'contexts/Layers';
-import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
 import { MapHighlightProvider } from 'contexts/MapHighlight';
 import { useServicesContext } from 'contexts/LookupFiles';
 // utilities
@@ -236,7 +235,6 @@ const conditions = {
 
 function WaterbodyReport() {
   const { orgId, auId, reportingCycle } = useParams();
-  const { fullscreenActive } = useFullscreenState();
 
   const services = useServicesContext();
 
@@ -1056,25 +1054,6 @@ function WaterbodyReport() {
     );
   }
 
-  if (fullscreenActive) {
-    return (
-      <WindowSize>
-        {({ width, height }) => {
-          return (
-            <div data-content="actionsmap" style={{ height, width }}>
-              <ActionsMap
-                layout="fullscreen"
-                unitIds={unitIds}
-                onLoad={setMapLayer}
-                includePhoto
-              />
-            </div>
-          );
-        }}
-      </WindowSize>
-    );
-  }
-
   return (
     <Page>
       <NavBar title="Waterbody Report" />
@@ -1591,9 +1570,7 @@ export default function WaterbodyReportContainer() {
   return (
     <LayersProvider>
       <MapHighlightProvider>
-        <FullscreenProvider>
-          <WaterbodyReport />
-        </FullscreenProvider>
+        <WaterbodyReport />
       </MapHighlightProvider>
     </LayersProvider>
   );

--- a/app/client/src/components/shared/ActionsMap.js
+++ b/app/client/src/components/shared/ActionsMap.js
@@ -59,7 +59,7 @@ const imageStyles = css`
 
 // --- components ---
 type Props = {
-  layout: 'narrow' | 'wide' | 'fullscreen',
+  layout: 'narrow' | 'wide',
   unitIds: Array<string>,
   onLoad: ?Function,
   includePhoto?: boolean,
@@ -350,10 +350,7 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
   // Scrolls to the map when switching layouts
   useEffect(() => {
     // scroll container or actions map content into view
-    // get container or actions map content DOM node to scroll page
-    // the layout changes
-    const itemName = layout === 'fullscreen' ? 'actionsmap' : 'container';
-    const content = document.querySelector(`[data-content="${itemName}"]`);
+    const content = document.querySelector(`[data-content="container"]`);
     if (content) {
       let pos = content.getBoundingClientRect();
 
@@ -365,6 +362,7 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
   const [mapLoading, setMapLoading] = useState(true);
   useEffect(() => {
     if (
+      !mapLoading ||
       !fetchStatus ||
       !mapView ||
       !actionsWaterbodies ||
@@ -390,15 +388,15 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     mapView.when(() => {
       mapView.goTo(zoomParams).then(() => {
         // set map zoom and home widget's viewpoint
-        mapView.zoom = mapView.zoom - 1;
-        homeWidget.viewpoint = new Viewpoint({
-          targetGeometry: mapView.extent,
-        });
+          mapView.zoom = mapView.zoom - 1;
+          homeWidget.viewpoint = new Viewpoint({
+            targetGeometry: mapView.extent,
+          });
+          setMapLoading(false);
       });
     });
 
-    setMapLoading(false);
-  }, [fetchStatus, mapView, actionsWaterbodies, homeWidget]);
+  }, [fetchStatus, mapLoading, mapView, actionsWaterbodies, homeWidget]);
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
   if (!browserIsCompatibleWithArcGIS()) {

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1850,18 +1850,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   };
   */
 
-  useEffect(() => {
-    if (layout !== 'fullscreen') return;
-
-    // scroll community content into view
-    // get community content DOM node to scroll page when form is submitted
-    const content = document.querySelector(`[data-content="locationmap"]`);
-    if (content) {
-      let pos = content.getBoundingClientRect();
-      window.scrollTo(pos.left + window.scrollX, pos.top + window.scrollY);
-    }
-  }, [layout, windowHeight]);
-
   // calculate height of div holding searchText
   const [searchTextHeight, setSearchTextHeight] = useState(0);
   const measuredRef = useCallback((node) => {
@@ -1895,10 +1883,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         data-testid="hmw-community-map"
         style={{
           marginTop: layout === 'wide' ? '1.25em' : '0',
-          height:
-            layout === 'fullscreen'
-              ? windowHeight
-              : windowHeight - searchTextHeight - 3 * mapPadding,
+          height: windowHeight - searchTextHeight - 3 * mapPadding,
         }}
       >
         <Map layers={layers} />

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1879,7 +1879,6 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
 
       <div
         css={containerStyles}
-        data-content="locationmap"
         data-testid="hmw-community-map"
         style={{
           marginTop: layout === 'wide' ? '1.25em' : '0',

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -94,7 +94,7 @@ const containerStyles = css`
 `;
 
 type Props = {
-  layout: 'narrow' | 'wide' | 'fullscreen',
+  layout: 'narrow' | 'wide',
   windowHeight: number,
   children?: Node,
 };

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
-import * as reactiveUtils from '@arcgis/core/core/reactiveUtils';
 import EsriMap from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
 import FullscreenContainer from 'components/shared/FullscreenContainer';
@@ -63,19 +62,13 @@ function Map({ children, layers = null, startingExtent = null }: Props) {
     const view = new MapView({
       container: 'hmw-map-container',
       map: esriMap,
-      extent: startingExtent ?? initialExtent,
       highlightOptions,
+      ...(homeWidget?.viewpoint
+        ? { viewpoint: homeWidget.viewpoint }
+        : { extent: startingExtent ?? initialExtent }),
     });
 
     setMapView(view);
-
-    if (homeWidget?.viewpoint) {
-      reactiveUtils
-        .whenOnce(() => !view.updating)
-        .then(() => {
-          view.goTo(homeWidget.viewpoint);
-        });
-    }
 
     setMapInitialized(true);
   }, [
@@ -104,6 +97,7 @@ function Map({ children, layers = null, startingExtent = null }: Props) {
         css={{
           position: 'relative',
           height: `calc(100% - ${footerHeight}px)`,
+          overflow: 'hidden',
           width: '100%',
         }}
         ref={mapContainerRef}

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -415,29 +415,27 @@ function StateMap({
 
   // jsx
   const mapContent = (
-    <>
-      <div
-        data-content="statemap"
-        css={css`
-          ${containerStyles};
-          height: ${windowHeight - mapInputsHeight - 3 * mapPadding}px;
-        `}
+    <div
+      data-content="statemap"
+      css={css`
+        ${containerStyles};
+        height: ${windowHeight - mapInputsHeight - 3 * mapPadding}px;
+      `}
+    >
+      <Map
+        startingExtent={{
+          xmin: -13873570.722124241,
+          ymin: 2886242.8013031036,
+          xmax: -7474874.210317273,
+          ymax: 6271485.909996087,
+          spatialReference: { wkid: 102100 },
+        }}
+        layers={layers}
       >
-        <Map
-          startingExtent={{
-            xmin: -13873570.722124241,
-            ymin: 2886242.8013031036,
-            xmax: -7474874.210317273,
-            ymax: 6271485.909996087,
-            spatialReference: { wkid: 102100 },
-          }}
-          layers={layers}
-        >
-          {children}
-        </Map>
-        {mapView && mapLoading && <MapLoadingSpinner />}
-      </div>
-    </>
+        {children}
+      </Map>
+      {mapView && mapLoading && <MapLoadingSpinner />}
+    </div>
   );
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -416,7 +416,6 @@ function StateMap({
   // jsx
   const mapContent = (
     <div
-      data-content="statemap"
       css={css`
         ${containerStyles};
         height: ${windowHeight - mapInputsHeight - 3 * mapPadding}px;

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -4,7 +4,6 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import type { Node } from 'react';
 import { css } from '@emotion/react';
-import StickyBox from 'react-sticky-box';
 import { useNavigate } from 'react-router-dom';
 import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import GroupLayer from '@arcgis/core/layers/GroupLayer';
@@ -62,7 +61,6 @@ const containerStyles = css`
 
 // --- components ---
 type Props = {
-  layout: 'narrow' | 'wide',
   windowHeight: number,
   windowWidth: number,
   filter: string,
@@ -72,7 +70,6 @@ type Props = {
 };
 
 function StateMap({
-  layout = 'narrow',
   windowHeight,
   windowWidth,
   filter,
@@ -409,26 +406,12 @@ function StateMap({
   useEffect(() => {
     // scroll community content into view
     // get community content DOM node to scroll page when form is submitted
+    const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
 
-    // if in fullscreen, scroll to top of map
-
-    if (layout === 'fullscreen') {
-      const mapContent = document.querySelector(`[data-content="statemap"]`);
-
-      if (mapContent) {
-        let pos = mapContent.getBoundingClientRect();
-        window.scrollTo(pos.left + window.scrollX, pos.top + window.scrollY);
-      }
+    if (mapInputs) {
+      mapInputs.scrollIntoView();
     }
-    // if in normal layout, display the inputs above the map
-    else {
-      const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
-
-      if (mapInputs) {
-        mapInputs.scrollIntoView();
-      }
-    }
-  }, [layout, windowHeight, windowWidth]);
+  }, [windowHeight, windowWidth]);
 
   // calculate height of div holding the footer content
   const mapInputs = document.querySelector(`[data-content="stateinputs"]`);
@@ -436,28 +419,13 @@ function StateMap({
 
   // jsx
   const mapContent = (
-    <div
-      style={
-        layout === 'fullscreen'
-          ? windowWidth < 400
-            ? { marginLeft: '-1.75em' }
-            : { marginLeft: '-1.5em' }
-          : {}
-      }
-    >
+    <>
       <div
-        css={containerStyles}
         data-content="statemap"
-        style={
-          layout === 'fullscreen'
-            ? {
-                height: windowHeight,
-                width: windowWidth,
-              }
-            : {
-                height: windowHeight - mapInputsHeight - 3 * mapPadding,
-              }
-        }
+        css={css`
+          ${containerStyles};
+          height: ${windowHeight - mapInputsHeight - 3 * mapPadding}px;
+        `}
       >
         <Map
           startingExtent={{
@@ -473,7 +441,7 @@ function StateMap({
         </Map>
         {mapView && mapLoading && <MapLoadingSpinner />}
       </div>
-    </div>
+    </>
   );
 
   // track Esri map load errors for older browsers and devices that do not support ArcGIS 4.x
@@ -491,15 +459,6 @@ function StateMap({
     );
   }
 
-  if (layout === 'wide') {
-    return (
-      <StickyBox offsetTop={mapPadding} offsetBottom={mapPadding}>
-        {mapContent}
-      </StickyBox>
-    );
-  }
-
-  // layout defaults to 'narrow'
   return mapContent;
 }
 

--- a/app/client/src/components/shared/StateMap.js
+++ b/app/client/src/components/shared/StateMap.js
@@ -56,7 +56,6 @@ const containerStyles = css`
   position: relative;
   border: 1px solid #aebac3;
   background-color: #fff;
-  overflow: hidden;
 `;
 
 // --- components ---
@@ -259,17 +258,15 @@ function StateMap({
     };
   }, [fetchedDataDispatch, resetData, resetLayers]);
 
-  const [lastFilter, setLastFilter] = useState('');
-
   // keep the selectedGraphicGlobal variable up to date
   useEffect(() => {
     selectedGraphicGlobal = selectedGraphic;
   }, [selectedGraphic]);
 
-  // cDU
   // detect when user changes their search
-  const [homeWidgetSet, setHomeWidgetSet] = useState(false);
+  const homeWidgetSet = useRef(false);
   const [mapLoading, setMapLoading] = useState(true);
+  const [lastFilter, setLastFilter] = useState('');
   useEffect(() => {
     // query geocode server for every new search
     if (
@@ -368,9 +365,9 @@ function StateMap({
                     }
 
                     // only set the home widget if the user selects a different state
-                    if (!homeWidgetSet) {
+                    if (!homeWidgetSet.current) {
                       homeWidget.viewpoint = new Viewpoint(homeParams);
-                      setHomeWidgetSet(true);
+                      homeWidgetSet.current = true;
                     }
                   } else {
                     setMapLoading(false);
@@ -387,7 +384,6 @@ function StateMap({
     waterbodyAreas,
     filter,
     homeWidget,
-    homeWidgetSet,
     lastFilter,
     waterbodyLines,
     mapView,
@@ -400,7 +396,7 @@ function StateMap({
   // Used to tell if the homewidget has been set to the selected state.
   // This will reset the value when the user selects a different state.
   useEffect(() => {
-    setHomeWidgetSet(false);
+    homeWidgetSet.current = false;
   }, [activeState]);
 
   useEffect(() => {

--- a/app/client/src/components/shared/TribalMapList.js
+++ b/app/client/src/components/shared/TribalMapList.js
@@ -42,7 +42,6 @@ import WaterbodyList from 'components/shared/WaterbodyList';
 import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 // contexts
-import { useFullscreenState } from 'contexts/Fullscreen';
 import {
   LocationSearchContext,
   LocationSearchProvider,
@@ -158,20 +157,14 @@ const switchContainerStyles = css`
   margin-top: 0.5em;
 `;
 
-type Layout = 'narrow' | 'wide' | 'fullscreen';
-
 type Props = {
   activeState: Object,
-  layout: Layout,
   windowHeight: number,
-  windowWidth: number,
 };
 
 function TribalMapList({
   activeState,
-  layout,
   windowHeight,
-  windowWidth,
 }: Props) {
   const { currentReportingCycle } = useContext(StateTribalTabsContext);
   const { errorMessage, mapView } = useContext(LocationSearchContext);
@@ -286,18 +279,6 @@ function TribalMapList({
       .catch(handelQueryError);
   }, [waterbodyPoints, waterbodyLines, waterbodyAreas, mapView, filter]);
 
-  // scroll to the tribe map when the user switches to full screen mode
-  useEffect(() => {
-    if (layout === 'fullscreen') {
-      const mapContent = document.querySelector(`[aria-label="Tribal Map"]`);
-
-      if (mapContent) {
-        let pos = mapContent.getBoundingClientRect();
-        window.scrollTo(pos.left + window.scrollX, pos.top + window.scrollY);
-      }
-    }
-  }, [layout, windowHeight, windowWidth]);
-
   // Makes the view on map button work for the state page
   // (i.e. switches and scrolls to the map when the selected graphic changes)
   const [displayMode, setDisplayMode] = useState('map');
@@ -322,7 +303,6 @@ function TribalMapList({
     setLayerTogglesHeight(node.getBoundingClientRect().height);
   }, []);
 
-  const { fullscreenActive } = useFullscreenState();
   const { width } = useWindowSize();
 
   const [mapShown, setMapShown] = useState(true);
@@ -436,7 +416,7 @@ function TribalMapList({
       )}
 
       <div
-        css={inputStyles(width < 960 && !fullscreenActive)}
+        css={inputStyles(width < 960)}
         ref={viewModeRef}
       >
         <div className="btn-group" role="group">
@@ -471,7 +451,7 @@ function TribalMapList({
         </div>
       </div>
 
-      {width < 960 && !fullscreenActive && (
+      {width < 960 && (
         <div>
           {displayMode === 'map' && (
             <MapVisibilityButton
@@ -501,19 +481,12 @@ function TribalMapList({
 
       <div
         aria-label="Tribal Map"
-        css={containerStyles}
-        style={
-          layout === 'fullscreen'
-            ? {
-                height: windowHeight,
-                width: windowWidth,
-              }
-            : {
-                height: mapListHeight,
-                width: '100%',
-                display: displayMode === 'map' && mapShown ? 'block' : 'none',
-              }
-        }
+        css={css`
+          ${containerStyles};
+          height: ${mapListHeight}px;
+          width: '100%';
+          display: ${displayMode === 'map' && mapShown ? 'block' : 'none'};
+        `}
       >
         <TribalMap
           activeState={activeState}


### PR DESCRIPTION
## Related Issues:
* [HMW-662](https://jira.epa.gov/browse/HMW-662)

## Main Changes:
* Removed code that conditionally renders the fullscreen map, since this is accomplished in the `Map` component now.
  * This fixed the error generated by glossary terms in the fullscreen view, since the error was caused by the `GlossaryPanel` not being rendered.
* Updated the `Map` component to take its initial viewpoint from the home widget, if applicable.
* Updated the initial zoom behavior of the pages to be more consistent.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/UTEMTN.
2. Confirm the map zooms to the proper location.
3. Toggle on the fullscreen view. The extent should remain the same.
4. Open a popup that has a glossary term, and click the term. The glossary panel should open without error.
5. Toggle off the fullscreen view. The extent should remain the same.
6. Repeat steps 1-5 for http://localhost:3000/state/SC/advanced-search (test multiple searches), http://localhost:3000/community/dc/overview, http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-01651770/, http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022, & http://localhost:3000/plan-summary/MDE_EASP/39161.