### PR TITLE
HMW-662 Call reset data function when leaving pages

### DIFF
--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -1,7 +1,7 @@
 // @flow
 /** @jsxImportSource @emotion/react */
 
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import { WindowSize } from '@reach/window-size';
@@ -35,8 +35,9 @@ import {
 } from 'components/shared/Box';
 // contexts
 import { LayersProvider } from 'contexts/Layers';
-import { MapHighlightProvider } from 'contexts/MapHighlight';
+import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
+import { MapHighlightProvider } from 'contexts/MapHighlight';
 // utilities
 import { fetchCheck } from 'utils/fetchUtils';
 import {
@@ -782,6 +783,13 @@ function Actions() {
 }
 
 export default function ActionsContainer() {
+  const { resetData } = useContext(LocationSearchContext);
+  useEffect(() => {
+    return function cleanup() {
+      resetData(true);
+    };
+  }, [resetData]);
+
   return (
     <LayersProvider>
       <MapHighlightProvider>

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -2403,11 +2403,11 @@ function MonitoringReportContent() {
   );
 }
 
-function MonitoringReport() {
+export default function MonitoringReport() {
   const { resetData } = useContext(LocationSearchContext);
   useEffect(() => {
     return function cleanup() {
-      resetData();
+      resetData(true);
     };
   }, [resetData]);
 
@@ -2557,5 +2557,3 @@ function StatusContent({
       return idle;
   }
 }
-
-export default MonitoringReport;

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -21,6 +21,7 @@ import {
   keyMetricLabelStyles,
 } from 'components/shared/KeyMetrics';
 // contexts
+import { LocationSearchContext } from 'contexts/locationSearch';
 import {
   StateTribalTabsContext,
   StateTribalTabsProvider,
@@ -544,8 +545,8 @@ function StateTribal() {
                     selectedSource === 'All'
                       ? 'Select a state, tribe or territory...'
                       : selectedSource === 'State'
-                        ? 'Select a state or territory...'
-                        : 'Select a tribe...'
+                      ? 'Select a state or territory...'
+                      : 'Select a tribe...'
                   }
                   options={selectOptions}
                   value={selectedStateTribe}
@@ -705,6 +706,13 @@ function StateTribal() {
 }
 
 export default function StateTribalContainer() {
+  const { resetData } = useContext(LocationSearchContext);
+  useEffect(() => {
+    return function cleanup() {
+      resetData(true);
+    };
+  }, [resetData]);
+
   return (
     <StateTribalTabsProvider>
       <StateTribal />

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -2,7 +2,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useContext, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { WindowSize } from '@reach/window-size';
 import StickyBox from 'react-sticky-box';
@@ -31,8 +31,9 @@ import {
 } from 'components/shared/Box';
 // contexts
 import { LayersProvider } from 'contexts/Layers';
-import { MapHighlightProvider } from 'contexts/MapHighlight';
+import { LocationSearchContext } from 'contexts/locationSearch';
 import { useServicesContext } from 'contexts/LookupFiles';
+import { MapHighlightProvider } from 'contexts/MapHighlight';
 // utilities
 import { fetchCheck, fetchPost } from 'utils/fetchUtils';
 import { mapRestorationPlanToGlossary } from 'utils/mapFunctions';
@@ -1567,6 +1568,13 @@ function WaterbodyUse({ categories }: WaterbodyUseProps) {
 }
 
 export default function WaterbodyReportContainer() {
+  const { resetData } = useContext(LocationSearchContext);
+  useEffect(() => {
+    return function cleanup() {
+      resetData(true);
+    };
+  }, [resetData]);
+
   return (
     <LayersProvider>
       <MapHighlightProvider>

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -9,7 +9,7 @@ import MapMouseEvents from 'components/shared/MapMouseEvents';
 // contexts
 import { useAddSaveDataWidgetState } from 'contexts/AddSaveDataWidget';
 import { useFullscreenState, FullscreenProvider } from 'contexts/Fullscreen';
-import { LocationSearchContext } from 'contexts/locationSearch';
+import { initialExtent, LocationSearchContext } from 'contexts/locationSearch';
 import { useLayers } from 'contexts/Layers';
 // types
 import type { LayerId } from 'contexts/Layers';
@@ -23,14 +23,8 @@ type Props = {
 
 function Map({ children, layers = null, startingExtent = null }: Props) {
   const { widgetLayers } = useAddSaveDataWidgetState();
-  const {
-    basemap,
-    highlightOptions,
-    homeWidget,
-    initialExtent,
-    mapView,
-    setMapView,
-  } = useContext(LocationSearchContext);
+  const { basemap, highlightOptions, homeWidget, mapView, setMapView } =
+    useContext(LocationSearchContext);
 
   const { visibleLayers } = useLayers();
 
@@ -65,7 +59,7 @@ function Map({ children, layers = null, startingExtent = null }: Props) {
       highlightOptions,
       ...(homeWidget?.viewpoint
         ? { viewpoint: homeWidget.viewpoint }
-        : { extent: startingExtent ?? initialExtent }),
+        : { extent: startingExtent ?? initialExtent() }),
     });
 
     setMapView(view);
@@ -75,7 +69,6 @@ function Map({ children, layers = null, startingExtent = null }: Props) {
     basemap,
     highlightOptions,
     homeWidget,
-    initialExtent,
     mapInitialized,
     setMapView,
     startingExtent,

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -1,4 +1,6 @@
 import Color from '@arcgis/core/Color';
+import Extent from '@arcgis/core/geometry/Extent';
+import Viewpoint from '@arcgis/core/Viewpoint';
 import React, { Component, createContext } from 'react';
 // config
 import { characteristicGroupMappings } from 'config/characteristicGroupMappings';
@@ -26,6 +28,19 @@ export const initialMonitoringGroups = () => {
   }, {});
 };
 
+export const initialExtent = () => new Extent({
+  xmin: -15634679.853814237,
+  ymin: -3023256.7294788733,
+  xmax: -5713765.078627277,
+  ymax: 12180985.440778064,
+  spatialReference: { wkid: 102100 },
+});
+
+const initialViewpoint = () => new Viewpoint({
+  scale: 73957190.9489445,
+  targetGeometry: initialExtent(),
+});
+
 export const LocationSearchContext = createContext();
 
 type Props = {
@@ -35,7 +50,6 @@ type Props = {
 export type Status = 'idle' | 'fetching' | 'success' | 'failure' | 'pending';
 
 type State = {
-  initialExtent: Object,
   currentExtent: Object,
   upstreamExtent: Object,
   highlightOptions: Object,
@@ -90,13 +104,6 @@ type State = {
 
 export class LocationSearchProvider extends Component<Props, State> {
   state: State = {
-    initialExtent: {
-      xmin: -15634679.853814237,
-      ymin: -3023256.7294788733,
-      xmax: -5713765.078627277,
-      ymax: 12180985.440778064,
-      spatialReference: { wkid: 102100 },
-    },
     currentExtent: '',
     upstreamExtent: '',
     highlightOptions: {
@@ -354,14 +361,14 @@ export class LocationSearchProvider extends Component<Props, State> {
     },
 
     resetMap: (useDefaultZoom = false) => {
-      const { initialExtent, mapView, homeWidget } = this.state;
+      const { mapView, homeWidget } = this.state;
 
       // reset the zoom and home widget to the initial extent
       if (useDefaultZoom && mapView) {
-        mapView.extent = initialExtent;
+        mapView.extent = initialExtent();
 
         if (homeWidget) {
-          homeWidget.viewpoint = mapView.viewpoint;
+          homeWidget.viewpoint = initialViewpoint();
         }
       }
     },

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -366,7 +366,7 @@ export class LocationSearchProvider extends Component<Props, State> {
       }
     },
 
-    resetData: () => {
+    resetData: (useDefaultZoom = false) => {
       this.setState({
         huc12: '',
         assessmentUnitIDs: null,
@@ -395,7 +395,7 @@ export class LocationSearchProvider extends Component<Props, State> {
 
       // remove map content
       // only zoom out the map if we are on the community intro page at /community
-      if (window.location.pathname === '/community') {
+      if (useDefaultZoom || window.location.pathname === '/community') {
         this.state.resetMap(true);
       } else {
         this.state.resetMap(false);


### PR DESCRIPTION
## Related Issues:
* [HMW-662](https://jira.epa.gov/browse/HMW-662)

## Main Changes:
* Fixed the issue where navigating to the Community page from the Monitoring Report, Waterbody Report, or Plan Summary pages would not reset the map extent.

## Steps To Test:
1. Go to http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-01651800/.
2. Click the "How's My Waterway" logo, then click the Community button.
3. Verify the map is zoomed out to show the Americas.
4. Repeat steps 1-3 for http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022, http://localhost:3000/plan-summary/MDE_EASP/39162, http://localhost:3000/tribe/PUEBLO_POJOAQUE, and http://localhost:3000/state/AK/advanced-search (after performing a search).

## NOTE:
I think a better solution would be to lower the `LocationSearchContext` (by lowering the placement of the provider), but this has the potential to introduce more bugs so I think it should be done in a separate issue/ticket.
