### PR TITLE
HMW-664 Fixed array access bug in characteristics select menu

### DIFF
--- a/app/client/src/components/shared/PaginatedSelect.tsx
+++ b/app/client/src/components/shared/PaginatedSelect.tsx
@@ -69,6 +69,7 @@ export function PaginatedSelect(props: Props) {
 
   const optionsOrGroupsPage = useMemo(() => {
     const page = filteredOptions.slice(startIndex, startIndex + PAGE_SIZE * 2);
+    // A group is only used in one place, so we can get away with only checking the first item.
     const optionOrGroup = optionsOrGroups[0];
     return optionOrGroup && 'options' in optionOrGroup
       ? [{ label: 'Group', options: page }]

--- a/app/client/src/components/shared/PaginatedSelect.tsx
+++ b/app/client/src/components/shared/PaginatedSelect.tsx
@@ -31,9 +31,9 @@ export function PaginatedSelect(props: Props) {
   const { options: optionsOrGroups, styles, ...rest } = props;
 
   const options = useMemo(() => {
-    return optionsOrGroups.flatMap((groupOrOption) => {
-      if ('options' in groupOrOption) return groupOrOption.options;
-      return groupOrOption;
+    return optionsOrGroups.flatMap((optionOrGroup) => {
+      if ('options' in optionOrGroup) return optionOrGroup.options;
+      return optionOrGroup;
     });
   }, [optionsOrGroups]);
 
@@ -69,7 +69,8 @@ export function PaginatedSelect(props: Props) {
 
   const optionsOrGroupsPage = useMemo(() => {
     const page = filteredOptions.slice(startIndex, startIndex + PAGE_SIZE * 2);
-    return 'options' in optionsOrGroups
+    const optionOrGroup = optionsOrGroups[0];
+    return optionOrGroup && 'options' in optionOrGroup
       ? [{ label: 'Group', options: page }]
       : page;
   }, [filteredOptions, optionsOrGroups, startIndex]);


### PR DESCRIPTION
## Related Issues:
* [HMW-664](https://jira.epa.gov/browse/HMW-664)

## Main Changes:
* Fixed a bug introduced in the issue noted above: the array checked to determine whether the select menu header should be shown was being incorrectly accessed, resulting in a missing header in the "Filter by Characteristics" select menu.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview, then show the _Water Monitoring Locations_ section.
2. Open the "Filter by Characteristics" menu and confirm the "Characteristic | # of Locations with Characteristic" header is shown.
3. Go to http://localhost:3000/state/PA/advanced-search.
4. Open the "Watershed Names (HUC12)" select menu and confirm that no header is shown, and that all options display correctly.
