### PR TITLE
Feature/668 669 popup basemap styles

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -311,6 +311,10 @@ const resizeHandleStyles = css`
 /*
 ## Components
 */
+interface PopupExt extends __esri.Popup {
+  featureMenuOpen: boolean;
+}
+
 type Props = {
   // map and view props auto passed from parent Map component by react-arcgis
   map: __esri.Map;
@@ -390,6 +394,34 @@ function MapWidgets({
   useEffect(() => {
     if (!view?.popup) return;
 
+    const popupFeatureMenuWatcher = reactiveUtils.watch(
+      () => (view.popup as PopupExt).featureMenuOpen,
+      () => {
+        const id = 'overridePopupStyles';
+        if ((view.popup as PopupExt).featureMenuOpen) {
+          const styles = document.createElement('style');
+          styles.id = id;
+          styles.innerHTML = `
+            calcite-flow,
+            calcite-action,
+            calcite-action-bar {
+              --calcite-ui-border-3: white;
+              --calcite-ui-foreground-1: white;
+              --calcite-ui-foreground-2: white;
+              --calcite-ui-foreground-3: white;
+              --calcite-ui-text-1: black;
+              --calcite-ui-text-2: black;
+              --calcite-ui-text-3: black;
+            }
+          `;
+          document.body.appendChild(styles);
+        } else {
+          const styles = document.getElementById(id);
+          if (styles) document.body.removeChild(styles);
+        }
+      },
+    );
+
     const popupWatcher = reactiveUtils.watch(
       () => view.popup.features,
       () => {
@@ -425,6 +457,7 @@ function MapWidgets({
     );
 
     return function cleanup() {
+      popupFeatureMenuWatcher.remove();
       popupWatcher.remove();
     };
   }, [getHucBoundaries, view]);

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -165,6 +165,7 @@ const modifiedIconButtonStyles = css`
 `;
 
 const popupContainerStyles = css`
+  color: black;
   margin: 0;
   overflow-y: auto;
 

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -111,6 +111,10 @@ calcite-flow {
   color: white;
 }
 
+.esri-popup__pointer-direction.blue-popup-pointer {
+  background-color: #0674ba;
+}
+
 .esri-popup th {
   padding: 0.35rem;
 }

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -81,65 +81,36 @@
     'Arial', sans-serif;
 }
 
+.esri-widget--panel-height-only {
+  width: 225px !important;
+}
+
+/* esri popup styles*/
+calcite-action,
+calcite-action-bar,
+calcite-flow {
+  --calcite-ui-border-3: #0674ba;
+  --calcite-ui-foreground-1: #0674ba;
+  --calcite-ui-foreground-2: #0674ba;
+  --calcite-ui-foreground-3: #0674ba;
+  --calcite-ui-text-1: white;
+  --calcite-ui-text-2: white;
+  --calcite-ui-text-3: white;
+}
+
 .esri-features__container {
+  background-color: white !important;
   padding: 0 0 12px 0;
 }
 
-.esri-popup__inline-actions-container {
-  width: 60% !important;
+.esri-features__header {
+  border: none;
 }
 
-/* small screens (redfin style) docked to the bottom */
-.esri-popup--aligned-bottom-center .esri-popup__content {
-  margin: 0 0 0 0;
-}
-
-/* docked in top right */
-.esri-popup--is-docked-top-right .esri-popup__content {
-  margin: 0 0 0 0;
-}
-
-.esri-popup__header {
-  background-color: #0674ba;
+.esri-features__heading {
   color: white;
 }
 
-.esri-popup__header h2 {
-  /* override styles from state Content styled component so state popups look like community */
-  margin: 6px auto 6px 7px;
-  font-size: 14px !important;
-  font-weight: 500 !important;
-  font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto',
-    'Arial', sans-serif !important;
-  color: white !important;
-}
-
-.esri-popup__header-container--button:hover {
-  background-color: transparent;
-}
-
-.esri-popup__feature-menu-button:focus {
-  color: #2e2e2e;
-}
-
-.esri-popup--is-docked .esri-popup__header {
-  margin-top: -4px; /* prevent white space above the header */
-}
-
-.esri-popup__button {
-  color: white;
-}
-
-.esri-popup__navigation {
-  background-color: #0674ba;
-}
-
-.esri-popup__footer {
-  background-color: #0674ba;
-  color: white;
-}
-
-/* popup arrow that points to where user clicked */
 .esri-popup th {
   padding: 0.35rem;
 }

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -15,6 +15,12 @@
   max-height: 100% !important;
 }
 
+.esri-basemap-gallery__item-thumbnail {
+  height: 31px;
+  width: 64px;
+  min-width: 64px;
+}
+
 .esri-layer-list {
   padding: 12px 10px 0;
   background-color: inherit;


### PR DESCRIPTION
## Related Issues:
* [HMW-668](https://jira.epa.gov/browse/HMW-668)
* [HMW-669](https://jira.epa.gov/browse/HMW-669)

## Main Changes:
* Shrunk the basemap image size to be closer to what it used to be.
* Switched back to having the popup header and footer bars be blue like they were before.
  * This ended up being a lot harder to figure out than I initially thought. In 4.28, esri switched to using the calcite design system for popups. The calcite design system uses shadow dom, so we can't just override classes like before. [More info here](https://community.esri.com/t5/arcgis-javascript-maps-sdk-questions/4-28-popup-styling-not-working/td-p/1362431).

## Steps To Test:
1. Navigate to http://localhost:3000/community/auburn%20al/restore
2. Open basemap/layerlist widget
3. Verify images are small enough to see layer list
4. Click on features on map
5. Verify popup styles are like they were before
6. Other items to be aware of while testing
    * Popup pointer arrow is colored correctly when popup is in various different positions
    * Multiple feature popup vs single feature popup
    * Change to this location popup

