### PR TITLE
Feature/670 display watershed size

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -256,6 +256,12 @@
         font-size: 0.91rem;
       }
 
+      .usa-nav.is-visible .menu--main .menu__link {
+        font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica',
+          'Roboto', 'Arial', sans-serif;
+        font-size: 1.06rem;
+      }
+
       .unsupportedMessageContainer {
         position: -webkit-sticky; /* Safari */
         position: sticky;

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -250,6 +250,12 @@
         float: unset;
       }
 
+      .menu--main .menu__link {
+        font-family: 'Merriweather Web', Georgia, Cambria, 'Times New Roman',
+          Times, serif;
+        font-size: 0.91rem;
+      }
+
       .unsupportedMessageContainer {
         position: -webkit-sticky; /* Safari */
         position: sticky;

--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -19,6 +19,8 @@ import { tabs } from 'config/communityConfig.js';
 // styles
 import { colors } from 'styles/index';
 import '@reach/tabs/styles.css';
+// utils
+import { formatNumber } from 'utils/utils';
 
 const lightBlue = '#f0f6f9';
 
@@ -451,9 +453,15 @@ function CommunityTabs() {
         <div css={locationTextStyles}>
           <p css={addressStyles}>{address}</p>
 
-          {watershed && (
+          {watershed.name && (
             <p css={watershedStyles}>
-              <span>WATERSHED:</span> {watershed} ({huc12})
+              <span>WATERSHED:</span> {watershed.name} ({huc12})
+            </p>
+          )}
+          {watershed.areasqkm && watershed.areaacres && (
+            <p css={watershedStyles}>
+              <span>SIZE:</span> {formatNumber(watershed.areaacres)} acres /{' '}
+              {formatNumber(watershed.areasqkm, 2)} km<sup>2</sup>
             </p>
           )}
         </div>

--- a/app/client/src/components/pages/Community.Tabs.AquaticLife.js
+++ b/app/client/src/components/pages/Community.Tabs.AquaticLife.js
@@ -44,7 +44,7 @@ function AquaticLife() {
             There {summary.total === 1 ? 'is' : 'are'}{' '}
             <strong>{summary.total.toLocaleString()}</strong>{' '}
             {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
-            aquatic life in the <em>{watershed}</em> watershed.
+            aquatic life in the <em>{watershed.name}</em> watershed.
           </>
         }
       />

--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -622,7 +622,7 @@ function DrinkingWater() {
                   {drinkingWater.data.length === 0 && (
                     <p css={centeredTextStyles}>
                       There is no drinking water data for the{' '}
-                      <em>{watershed}</em> watershed.
+                      <em>{watershed.name}</em> watershed.
                     </p>
                   )}
 
@@ -771,7 +771,7 @@ function DrinkingWater() {
                   {drinkingWater.data.length === 0 && (
                     <p css={centeredTextStyles}>
                       There is no drinking water data for the{' '}
-                      <em>{watershed}</em> watershed.
+                      <em>{watershed.name}</em> watershed.
                     </p>
                   )}
 
@@ -781,7 +781,7 @@ function DrinkingWater() {
                         <div css={infoBoxStyles}>
                           <p css={centeredTextStyles}>
                             There are no public water systems drawing water from
-                            the <em>{watershed}</em> watershed.
+                            the <em>{watershed.name}</em> watershed.
                           </p>
                         </div>
                       )}
@@ -896,7 +896,7 @@ function DrinkingWater() {
                                 <strong>{displayedWithdrawers.length}</strong>{' '}
                                 of <strong>{totalWithdrawersCount}</strong>{' '}
                                 public water systems withdrawing water from the{' '}
-                                <em>{watershed}</em> watershed.
+                                <em>{watershed.name}</em> watershed.
                               </>
                             }
                             onSortChange={(sortBy) =>
@@ -964,7 +964,7 @@ function DrinkingWater() {
                     <strong>{summary.total.toLocaleString()}</strong>{' '}
                     {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed
                     as potential future sources of drinking water in the{' '}
-                    <em>{watershed}</em> watershed.
+                    <em>{watershed.name}</em> watershed.
                   </>
                 }
               />

--- a/app/client/src/components/pages/Community.Tabs.EatingFish.js
+++ b/app/client/src/components/pages/Community.Tabs.EatingFish.js
@@ -44,7 +44,7 @@ function EatingFish() {
             There {summary.total === 1 ? 'is' : 'are'}{' '}
             <strong>{summary.total.toLocaleString()}</strong>{' '}
             {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
-            fish and shellfish consumption in the <em>{watershed}</em>{' '}
+            fish and shellfish consumption in the <em>{watershed.name}</em>{' '}
             watershed.
           </>
         }

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -598,7 +598,7 @@ function IdentifiedIssues() {
                     <div css={infoBoxStyles}>
                       <p css={centeredTextStyles}>
                         There are no impairment categories in the{' '}
-                        <em>{watershed}</em> watershed.
+                        <em>{watershed.name}</em> watershed.
                       </p>
                     </div>
                   )}
@@ -650,9 +650,9 @@ function IdentifiedIssues() {
                         {emptyCategoriesWithPercent && (
                           <p css={centeredTextStyles}>
                             Impairment Summary information is temporarily
-                            unavailable for the <em>{watershed}</em> watershed.
-                            Please see the Overview tab for specific impairment
-                            information on these waters.
+                            unavailable for the <em>{watershed.name}</em>{' '}
+                            watershed. Please see the Overview tab for specific
+                            impairment information on these waters.
                           </p>
                         )}
 
@@ -661,7 +661,7 @@ function IdentifiedIssues() {
                             <div css={infoBoxStyles}>
                               <p css={centeredTextStyles}>
                                 There are no impairment categories in the{' '}
-                                <em>{watershed}</em> watershed.
+                                <em>{watershed.name}</em> watershed.
                               </p>
                             </div>
                           )}
@@ -681,7 +681,7 @@ function IdentifiedIssues() {
 
                               <p>
                                 Impairment categories in the{' '}
-                                <em>{watershed}</em> watershed.
+                                <em>{watershed.name}</em> watershed.
                               </p>
 
                               <table css={toggleTableStyles} className="table">
@@ -787,8 +787,8 @@ function IdentifiedIssues() {
                   {!dischargers.length && (
                     <div css={infoBoxStyles}>
                       <p css={centeredTextStyles}>
-                        There are no dischargers in the <em>{watershed}</em>{' '}
-                        watershed.
+                        There are no dischargers in the{' '}
+                        <em>{watershed.name}</em> watershed.
                       </p>
                     </div>
                   )}
@@ -873,8 +873,8 @@ function IdentifiedIssues() {
                             <strong>
                               {dischargers.length.toLocaleString()}
                             </strong>{' '}
-                            permitted dischargers in the <em>{watershed}</em>{' '}
-                            watershed.
+                            permitted dischargers in the{' '}
+                            <em>{watershed.name}</em> watershed.
                           </>
                         }
                       >

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -488,7 +488,7 @@ function CurrentConditionsTab({
       {sortedLocations.length === 0 && (
         <div css={infoBoxStyles}>
           <p css={centeredTextStyles}>
-            There are no locations with data in the <em>{watershed}</em>{' '}
+            There are no locations with data in the <em>{watershed.name}</em>{' '}
             watershed.
           </p>
         </div>
@@ -607,7 +607,7 @@ function CurrentConditionsTab({
               <>
                 <strong>{filteredLocations.length}</strong> of{' '}
                 <strong>{sortedLocations.length}</strong> locations with data in
-                the <em>{watershed}</em> watershed.
+                the <em>{watershed.name}</em> watershed.
               </>
             }
             onSortChange={handleSortChange}
@@ -1075,7 +1075,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
           <div css={infoBoxStyles}>
             <p css={centeredTextStyles}>
               There are no monitoring sample locations in the{' '}
-              <em>{watershed}</em> watershed.
+              <em>{watershed.name}</em> watershed.
             </p>
           </div>
         )}
@@ -1137,7 +1137,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   headerElm={
                     <p css={subheadingStyles}>
                       <HelpTooltip label="Adjust the slider handles to filter location data by the selected year range" />
-                      &nbsp;&nbsp; Date range for the <em>{watershed}</em>{' '}
+                      &nbsp;&nbsp; Date range for the <em>{watershed.name}</em>{' '}
                       watershed{' '}
                     </p>
                   }
@@ -1295,7 +1295,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   {selectedCharacteristics.length > 0 &&
                     ' with the selected characteristic'}
                   {selectedCharacteristics.length > 1 && 's'} in the{' '}
-                  <em>{watershed}</em> watershed
+                  <em>{watershed.name}</em> watershed
                   {annualRecordsReady && (
                     <>
                       {' '}

--- a/app/client/src/components/pages/Community.Tabs.Overview.js
+++ b/app/client/src/components/pages/Community.Tabs.Overview.js
@@ -366,7 +366,9 @@ function WaterbodiesTab() {
   ) {
     return (
       <div css={infoBoxStyles}>
-        <p css={centeredTextStyles}>{zeroAssessedWaterbodies(watershed)}</p>
+        <p css={centeredTextStyles}>
+          {zeroAssessedWaterbodies(watershed.name)}
+        </p>
       </div>
     );
   }
@@ -380,7 +382,7 @@ function WaterbodiesTab() {
           Overall condition of{' '}
           <strong>{totalWaterbodies.toLocaleString()}</strong>{' '}
           {totalWaterbodies === 1 ? 'waterbody' : 'waterbodies'} in the{' '}
-          <em>{watershed}</em> watershed.
+          <em>{watershed.name}</em> watershed.
         </span>
       }
     />
@@ -821,7 +823,7 @@ function MonitoringAndSensorsTab({
         {allMonitoringAndSensors.length === 0 && (
           <div css={infoBoxStyles}>
             <p css={centeredTextStyles}>
-              There are no locations with data in the <em>{watershed}</em>{' '}
+              There are no locations with data in the <em>{watershed.name}</em>{' '}
               watershed.
             </p>
           </div>
@@ -907,7 +909,7 @@ function MonitoringAndSensorsTab({
                 <>
                   <strong>{filteredMonitoringAndSensors.length}</strong> of{' '}
                   <strong>{allMonitoringAndSensors.length}</strong> locations{' '}
-                  with data in the <em>{watershed}</em> watershed.
+                  with data in the <em>{watershed.name}</em> watershed.
                   {selectedCharacteristics.length > 0 && (
                     <>
                       <br />
@@ -1275,7 +1277,8 @@ function PermittedDischargersTab({
         {totalPermittedDischargers === 0 && (
           <div css={infoBoxStyles}>
             <p css={centeredTextStyles}>
-              There are no dischargers in the <em>{watershed}</em> watershed.
+              There are no dischargers in the <em>{watershed.name}</em>{' '}
+              watershed.
             </p>
           </div>
         )}
@@ -1362,7 +1365,8 @@ function PermittedDischargersTab({
                   </strong>{' '}
                   of{' '}
                   <strong>{totalPermittedDischargers.toLocaleString()}</strong>{' '}
-                  permitted dischargers in the <em>{watershed}</em> watershed.
+                  permitted dischargers in the <em>{watershed.name}</em>{' '}
+                  watershed.
                 </>
               }
               onSortChange={handleSortChange}

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -583,7 +583,7 @@ function Protect() {
                             rows={[
                               {
                                 label: 'Watershed Name',
-                                value: watershed,
+                                value: watershed.name,
                               },
                               {
                                 label: 'Watershed',

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -571,7 +571,7 @@ function Protect() {
                         <div css={modifiedInfoBoxStyles}>
                           <p>
                             No Watershed Health Score data available for the{' '}
-                            <em>{watershed}</em> watershed.
+                            <em>{watershed.name}</em> watershed.
                           </p>
                         </div>
                       )}
@@ -789,7 +789,7 @@ function Protect() {
                         <div css={modifiedInfoBoxStyles}>
                           <p>
                             No Wild and Scenic River data available in the{' '}
-                            <em>{watershed}</em> watershed.
+                            <em>{watershed.name}</em> watershed.
                           </p>
                         </div>
                       )}
@@ -810,7 +810,7 @@ function Protect() {
                               {wildScenicRiversData.data.length === 1
                                 ? 'river'
                                 : 'rivers'}{' '}
-                              in the <em>{watershed}</em> watershed.
+                              in the <em>{watershed.name}</em> watershed.
                             </p>
                           </div>
 
@@ -980,7 +980,7 @@ function Protect() {
                         <div css={modifiedInfoBoxStyles}>
                           <p>
                             No Protected Areas Database data available for the{' '}
-                            <em>{watershed}</em> watershed.
+                            <em>{watershed.name}</em> watershed.
                           </p>
                         </div>
                       )}
@@ -1001,7 +1001,7 @@ function Protect() {
                               {protectedAreasData.data.length === 1
                                 ? 'area'
                                 : 'areas'}{' '}
-                              in the <em>{watershed}</em> watershed.
+                              in the <em>{watershed.name}</em> watershed.
                             </>
                           }
                         >
@@ -1170,7 +1170,7 @@ function Protect() {
                             <div css={modifiedInfoBoxStyles}>
                               <p>
                                 There are no EPA funded protection projects in
-                                the <em>{watershed}</em> watershed.
+                                the <em>{watershed.name}</em> watershed.
                               </p>
                             </div>
                           )}
@@ -1190,7 +1190,7 @@ function Protect() {
                                   {allProtectionProjects.length === 1
                                     ? 'project'
                                     : 'projects'}{' '}
-                                  in the <em>{watershed}</em> watershed.
+                                  in the <em>{watershed.name}</em> watershed.
                                 </p>
                               </div>
 

--- a/app/client/src/components/pages/Community.Tabs.Restore.js
+++ b/app/client/src/components/pages/Community.Tabs.Restore.js
@@ -136,7 +136,7 @@ function Restore() {
                       <div css={infoBoxStyles}>
                         <p css={textStyles}>
                           There are no nonpoint source projects in the{' '}
-                          <em>{watershed}</em> watershed.
+                          <em>{watershed.name}</em> watershed.
                         </p>
                       </div>
                     )}
@@ -159,7 +159,7 @@ function Restore() {
                                 Clean Water Act Section 319
                               </GlossaryTerm>{' '}
                               that benefit waterbodies in the{' '}
-                              <em>{watershed}</em> watershed.
+                              <em>{watershed.name}</em> watershed.
                             </>
                           }
                         >
@@ -319,7 +319,7 @@ function Restore() {
                           <GlossaryTerm term="Restoration plan">
                             restoration plans
                           </GlossaryTerm>{' '}
-                          in the <em>{watershed}</em> watershed.
+                          in the <em>{watershed.name}</em> watershed.
                         </p>
                       </div>
                     )}
@@ -339,7 +339,7 @@ function Restore() {
                                 ? 'plan'
                                 : 'plans'}
                             </GlossaryTerm>{' '}
-                            in the <em>{watershed}</em> watershed.
+                            in the <em>{watershed.name}</em> watershed.
                           </>
                         }
                       >

--- a/app/client/src/components/pages/Community.Tabs.Swimming.js
+++ b/app/client/src/components/pages/Community.Tabs.Swimming.js
@@ -63,7 +63,7 @@ function Swimming() {
                 There {summary.total === 1 ? 'is' : 'are'}{' '}
                 <strong>{summary.total.toLocaleString()}</strong>{' '}
                 {summary.total === 1 ? 'waterbody' : 'waterbodies'} assessed for
-                swimming and boating in the <em>{watershed}</em> watershed.
+                swimming and boating in the <em>{watershed.name}</em> watershed.
               </>
             }
           />

--- a/app/client/src/components/shared/AddSaveDataWidget.SearchPanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SearchPanel.tsx
@@ -696,8 +696,8 @@ const cardThumbnailStyles = css`
 const cardTitleStyles = css`
   margin: 0;
   padding: 0;
-  font-family: 'Merriweather', 'Georgia', 'Cambria', 'Times New Roman', 'Times',
-    serif;
+  font-family: 'Merriweather Web', 'Georgia', 'Cambria', 'Times New Roman',
+    'Times', serif;
   font-size: 12px;
   font-weight: 500;
   overflow: hidden;

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1223,7 +1223,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       // queryNonprofits(boundaries); // re-add when EPA approves RiverNetwork service for HMW
 
       // boundaries data, also has attributes for watershed
-      setWatershed(boundaries.features[0].attributes.name);
+      setWatershed(boundaries.features[0].attributes);
 
       // pass all of the states that the HUC12 is in
       getFishingLinkData(boundaries.features[0].attributes.states);

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -1432,7 +1432,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             }
           }
 
-          if (candidates.length === 0 || !location || !location.attributes) {
+          if (candidates.length === 0 || !location?.attributes) {
             const newAddress = coordinatesPart ? searchPart : searchText;
             setAddress(newAddress); // preserve the user's search so it is displayed
             handleNoDataAvailable(noDataAvailableError);
@@ -1699,12 +1699,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   }, [searchText, setHuc12]);
 
   useEffect(() => {
-    if (
-      !mapView ||
-      !hucBoundaries ||
-      !hucBoundaries.features ||
-      !hucBoundaries.features[0]
-    ) {
+    if (!mapView || !hucBoundaries?.features?.[0]) {
       return;
     }
 

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -573,7 +573,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   const getSharedLayers = useSharedLayers();
   useWaterbodyHighlight();
 
-  const { setDynamicPopupFields } = useDynamicPopup();
+  const { getTemplate, getTitle, setDynamicPopupFields } = useDynamicPopup();
 
   // Builds the layers that have no dependencies
   useEffect(() => {
@@ -1714,6 +1714,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         spatialReference: hucBoundaries.spatialReference,
         rings: hucBoundaries.features[0].geometry.rings,
       },
+      popupTemplate: {
+        title: getTitle,
+        content: getTemplate,
+        outFields: ['areasqkm'],
+      },
       symbol: {
         type: 'simple-fill', // autocasts as new SimpleFillSymbol()
         color: [204, 255, 255, 0.5],
@@ -1747,6 +1752,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       });
     });
   }, [
+    getTemplate,
+    getTitle,
     mapView,
     hucBoundaries,
     boundariesLayer,

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -879,9 +879,9 @@ function LocationSearch({ route, label }: Props) {
                   value={
                     inputText === searchTerm &&
                     isHuc12(inputText) &&
-                    watershed &&
+                    watershed.name &&
                     huc12
-                      ? `WATERSHED: ${watershed} (${huc12})`
+                      ? `WATERSHED: ${watershed.name} (${huc12})`
                       : inputText.split('|')[0]
                   }
                   onChange={(ev) => {

--- a/app/client/src/components/shared/Map.tsx
+++ b/app/client/src/components/shared/Map.tsx
@@ -57,6 +57,7 @@ function Map({ children, layers = null, startingExtent = null }: Props) {
       container: 'hmw-map-container',
       map: esriMap,
       highlightOptions,
+      popupEnabled: false, // Popup is handled manually in the MapMouseEvents component
       ...(homeWidget?.viewpoint
         ? { viewpoint: homeWidget.viewpoint }
         : { extent: startingExtent ?? initialExtent() }),

--- a/app/client/src/components/shared/MapLegend.js
+++ b/app/client/src/components/shared/MapLegend.js
@@ -706,7 +706,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
           className="esri-widget__heading esri-legend__service-label"
           style={{
             fontFamily:
-              '"Merriweather", "Georgia", "Cambria", "Times New Roman", "Times", serif',
+              '"Merriweather Web", "Georgia", "Cambria", "Times New Roman", "Times", serif',
           }}
         >
           {layerName}
@@ -923,7 +923,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
           className="esri-widget__heading esri-legend__service-label"
           style={{
             fontFamily:
-              '"Merriweather", "Georgia", "Cambria", "Times New Roman", "Times", serif',
+              '"Merriweather Web", "Georgia", "Cambria", "Times New Roman", "Times", serif',
           }}
         >
           {layerName}

--- a/app/client/src/components/shared/MapMouseEvents.tsx
+++ b/app/client/src/components/shared/MapMouseEvents.tsx
@@ -333,13 +333,9 @@ function MapMouseEvents({ view }: Props) {
         .catch((err) => console.error(err));
     },
     [
-      fetchedDataDispatch,
       getHucBoundaries,
-      navigate,
       openChangeLocationPopup,
       protectedAreasLayer,
-      resetData,
-      resetLayers,
       services,
       setSelectedGraphic,
     ],

--- a/app/client/src/components/shared/MapMouseEvents.tsx
+++ b/app/client/src/components/shared/MapMouseEvents.tsx
@@ -150,10 +150,13 @@ async function queryPadUsFeatures(
     geometry: location,
     outFields: ['*'],
   };
+  const mapContainer = document.getElementById('hmw-map-container');
+  if (mapContainer) mapContainer.style.cursor = 'wait';
   const padRes = await query.executeQueryJSON(url, queryPadUs).catch((err) => {
     console.error(err);
     return { features: [] };
   });
+  if (mapContainer) mapContainer.style.cursor = 'default';
   return padRes.features.map((feature) => {
     return new Graphic({
       attributes: feature.attributes,
@@ -276,8 +279,8 @@ function MapMouseEvents({ view }: Props) {
         .then((res: __esri.HitTestResult) => {
           // get and update the selected graphic
           const extraLayersToIgnore = ['selectedTribeLayer'];
-          queryPadUsFeatures(location, protectedAreasLayer, services).then(
-            (padUsGraphics) => {
+          queryPadUsFeatures(location, protectedAreasLayer, services)
+            .then((padUsGraphics) => {
               const graphics = [
                 ...padUsGraphics,
                 ...(getGraphicsFromResponse(res, extraLayersToIgnore) ?? []),
@@ -290,7 +293,7 @@ function MapMouseEvents({ view }: Props) {
                 setSelectedGraphic(graphic);
                 view.popup = new Popup({
                   collapseEnabled: false,
-                  features: graphics ?? undefined,
+                  features: graphics,
                   location: point,
                   visible: true,
                 });
@@ -322,13 +325,12 @@ function MapMouseEvents({ view }: Props) {
                     if (boundaries.features.length === 0) return;
 
                     openChangeLocationPopup(point, boundaries);
-                  })
-                  .catch((err) => console.error(err));
+                  });
               }
-            },
-          );
+            })
+            .catch((err) => console.error(err));
         })
-        .catch((err: string) => console.error(err));
+        .catch((err) => console.error(err));
     },
     [
       fetchedDataDispatch,

--- a/app/client/src/components/shared/MapMouseEvents.tsx
+++ b/app/client/src/components/shared/MapMouseEvents.tsx
@@ -16,6 +16,8 @@ import { useServicesContext } from 'contexts/LookupFiles';
 import { getPopupContent, graphicComparison } from 'utils/mapFunctions';
 // types
 import type { MonitoringFeatureUpdate, MonitoringFeatureUpdates } from 'types';
+// utils
+import { isInScale } from 'utils/mapFunctions';
 
 // --- types ---
 interface ClickEvent {
@@ -138,10 +140,12 @@ function prioritizePopup(
 // Query the PAD-US database for features at the clicked location.
 async function queryPadUsFeatures(
   location: __esri.Point,
+  scale: number,
   protectedAreasLayer: __esri.MapImageLayer | null,
   services: any,
 ) {
-  if (!protectedAreasLayer?.visible) return [];
+  if (!protectedAreasLayer?.visible || !isInScale(protectedAreasLayer, scale))
+    return [];
 
   // check if protected areas layer was clicked on
   const url = `${services.data.protectedAreasDatabase}0`;
@@ -279,7 +283,12 @@ function MapMouseEvents({ view }: Props) {
         .then((res: __esri.HitTestResult) => {
           // get and update the selected graphic
           const extraLayersToIgnore = ['selectedTribeLayer'];
-          queryPadUsFeatures(location, protectedAreasLayer, services)
+          queryPadUsFeatures(
+            location,
+            view.scale,
+            protectedAreasLayer,
+            services,
+          )
             .then((padUsGraphics) => {
               const graphics = [
                 ...padUsGraphics,

--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -76,7 +76,7 @@ import type {
   MutableRefObject,
   SetStateAction,
 } from 'react';
-import type { ServicesState } from 'types';
+import type { ServicesState, WatershedAttributes } from 'types';
 // styles
 import { fonts } from 'styles';
 
@@ -1422,7 +1422,7 @@ function retrieveUpstreamWatershed(
   getUpstreamExtent: () => __esri.Extent,
   upstreamLayer: __esri.GraphicsLayer | null,
   getUpstreamWidgetDisabled: () => boolean,
-  getWatershed: () => string,
+  getWatershed: () => WatershedAttributes,
   lastHuc12: string,
   services: ServicesState,
   setErrorMessage: Dispatch<SetStateAction<string>>,
@@ -1506,7 +1506,7 @@ function retrieveUpstreamWatershed(
     .then((res) => {
       setUpstreamLoading(false);
       setUpstreamWatershedResponse({ status: 'success', data: res });
-      const watershed = getWatershed() || 'Unknown Watershed';
+      const watershed = getWatershed().name || 'Unknown Watershed';
       const upstreamTitle = `Upstream Watershed for Currently Selected Location: ${watershed} (${currentHuc12})`;
 
       if (!res?.features?.length) {
@@ -1663,7 +1663,7 @@ type ShowCurrentUpstreamWatershedProps = Omit<
   getUpstreamExtent: () => __esri.Extent;
   upstreamLayer: __esri.GraphicsLayer | null;
   getUpstreamWidgetDisabled: () => boolean;
-  getWatershed: () => string;
+  getWatershed: () => WatershedAttributes;
   services: ServicesState;
   setErrorMessage: Dispatch<SetStateAction<string>>;
   setUpstreamExtent: Dispatch<SetStateAction<__esri.Viewpoint>>;

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -928,11 +928,12 @@ function WaterbodyInfo({
   const tribeContent = labelValue('Tribe Name', attributes.TRIBE_NAME);
 
   // jsx
-  const upstreamWatershedContent = (
+  const watershedContent = (
     <>
       {labelValue(
         'Area',
-        attributes.areasqkm && `${formatNumber(attributes.areasqkm)} sq. km.`,
+        attributes.areasqkm &&
+          `${formatNumber(attributes.areasqkm, 2)} sq. km.`,
       )}
     </>
   );
@@ -1228,7 +1229,8 @@ function WaterbodyInfo({
   if (type === 'Action') content = actionContent;
   if (type === 'County') content = countyContent();
   if (type === 'Tribe') content = tribeContent;
-  if (type === 'Upstream Watershed') content = upstreamWatershedContent;
+  if (type === 'Watershed' || type === 'Upstream Watershed')
+    content = watershedContent;
   if (type === 'Wild and Scenic Rivers') content = wildScenicRiversContent;
   if (type === 'State Watershed Health Index') content = wsioContent;
   if (type === 'Alaska Native Village') content = alaskaNativeVillageContent;
@@ -1315,6 +1317,9 @@ function MapPopup({
     }
     if (type === 'Protection Plans') {
       title = 'Protection Plans for this Waterbody';
+    }
+    if (type === 'Watershed') {
+      title = <GlossaryTerm term="Watershed">{title}</GlossaryTerm>;
     }
     if (type === 'Upstream Watershed') {
       title = <GlossaryTerm term="Upstream Watershed">{title}</GlossaryTerm>;

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -933,11 +933,9 @@ function WaterbodyInfo({
       {labelValue(
         'Area',
         attributes.areasqkm &&
-          attributes.areaacres &&
-          `${formatNumber(attributes.areaacres)} acres / ${formatNumber(
-            attributes.areasqkm,
-            2,
-          )} km²`,
+          `${formatNumber(
+            attributes.areaacres ?? attributes.areasqkm / 0.004046856422,
+          )} acres / ${formatNumber(attributes.areasqkm, 2)} km²`,
       )}
     </>
   );

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -933,7 +933,11 @@ function WaterbodyInfo({
       {labelValue(
         'Area',
         attributes.areasqkm &&
-          `${formatNumber(attributes.areasqkm, 2)} sq. km.`,
+          attributes.areaacres &&
+          `${formatNumber(attributes.areaacres)} acres / ${formatNumber(
+            attributes.areasqkm,
+            2,
+          )} km²`,
       )}
     </>
   );

--- a/app/client/src/config/communityConfig.js
+++ b/app/client/src/config/communityConfig.js
@@ -109,7 +109,7 @@ function EatingFishUpper() {
 
       <p>
         Eating fish and shellfish caught in impaired waters can pose health
-        risks. For the <em>{watershed}</em> watershed, be sure to look for
+        risks. For the <em>{watershed.name}</em> watershed, be sure to look for
         posted fish advisories or consult your local or state environmental
         health department for{' '}
         {fishingInfo.status === 'success' ? (

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -42,7 +42,7 @@ const initialViewpoint = () => new Viewpoint({
   targetGeometry: initialExtent(),
 });
 
-const nullWatershed: WatershedAttributes = () => ({
+const initialWatershed: WatershedAttributes = () => ({
   areaacres: 0,
   areasqkm: 0,
   huc12: '',
@@ -124,7 +124,7 @@ export class LocationSearchProvider extends Component<Props, State> {
     lastSearchText: '',
     huc12: '',
     assessmentUnitIDs: [],
-    watershed: nullWatershed(),
+    watershed: initialWatershed(),
     address: '',
     fishingInfo: { status: 'fetching', data: [] },
     statesData: { status: 'fetching', data: [] },
@@ -386,7 +386,7 @@ export class LocationSearchProvider extends Component<Props, State> {
         huc12: '',
         assessmentUnitIDs: null,
         errorMessage: '',
-        watershed: nullWatershed(),
+        watershed: initialWatershed(),
         pointsData: null,
         linesData: null,
         areasData: null,
@@ -421,7 +421,7 @@ export class LocationSearchProvider extends Component<Props, State> {
       this.setState({
         huc12: '',
         assessmentUnitIDs: null,
-        watershed: nullWatershed(),
+        watershed: initialWatershed(),
         pointsData: [],
         linesData: [],
         areasData: [],

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -14,6 +14,7 @@ import type {
   MonitoringLocationGroups,
   MonitoringYearsRange,
   ParameterToggleObject,
+  WatershedAttributes,
 } from 'types';
 
 export const initialMonitoringGroups = () => {
@@ -41,6 +42,13 @@ const initialViewpoint = () => new Viewpoint({
   targetGeometry: initialExtent(),
 });
 
+const nullWatershed: WatershedAttributes = () => ({
+  areaacres: 0,
+  areasqkm: 0,
+  huc12: '',
+  name: '',
+});
+
 export const LocationSearchContext = createContext();
 
 type Props = {
@@ -57,7 +65,7 @@ type State = {
   lastSearchText: string,
   huc12: string,
   assessmentUnitIDs: Array<string>,
-  watershed: string,
+  watershed: WatershedAttributes,
   address: string,
   assessmentUnitId: string,
   grts: Object,
@@ -116,7 +124,7 @@ export class LocationSearchProvider extends Component<Props, State> {
     lastSearchText: '',
     huc12: '',
     assessmentUnitIDs: [],
-    watershed: '',
+    watershed: nullWatershed(),
     address: '',
     fishingInfo: { status: 'fetching', data: [] },
     statesData: { status: 'fetching', data: [] },
@@ -378,7 +386,7 @@ export class LocationSearchProvider extends Component<Props, State> {
         huc12: '',
         assessmentUnitIDs: null,
         errorMessage: '',
-        watershed: '',
+        watershed: nullWatershed(),
         pointsData: null,
         linesData: null,
         areasData: null,
@@ -413,7 +421,7 @@ export class LocationSearchProvider extends Component<Props, State> {
       this.setState({
         huc12: '',
         assessmentUnitIDs: null,
-        watershed: '',
+        watershed: nullWatershed(),
         pointsData: [],
         linesData: [],
         areasData: [],

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -589,7 +589,9 @@ export type PortalLayerTypes =
   | 'Vector Tile Service'
   | 'WMS';
 
-interface WatershedAttributes {
+export interface WatershedAttributes {
+  areaacres: number;
+  areasqkm: number;
   huc12: string;
   name: string;
 }

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -367,11 +367,6 @@ export interface ProtectedAreaAttributes {
   Loc_Nm: string;
 }
 
-export interface ScaledLayer extends __esri.Layer {
-  minScale?: number;
-  maxScale?: number;
-}
-
 export interface ServicesData {
   attains: { serviceUrl: string };
   cyan: {

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -357,6 +357,7 @@ export type PopupAttributes =
   | UsgsStreamgageAttributes
   | VillageAttributes
   | WaterbodyAttributes
+  | WatershedAttributes
   | WildScenicRiverAttributes
   | WsioHealthIndexAttributes
   | CyanWaterbodyAttributes;
@@ -587,6 +588,11 @@ export type PortalLayerTypes =
   | 'Map Service'
   | 'Vector Tile Service'
   | 'WMS';
+
+interface WatershedAttributes {
+  huc12: string;
+  name: string;
+}
 
 export type WidgetLayer =
   | {

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -1363,6 +1363,11 @@ function useSharedLayers({
       listMode: 'show',
       visible: false,
       outFields: ['*'],
+      popupTemplate: {
+        outFields: ['areasqkm'],
+        title: getTitle,
+        content: getTemplate,
+      },
     });
     setLayer('watershedsLayer', watershedsLayer);
     return watershedsLayer;

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -441,9 +441,7 @@ function useWaterbodyHighlight(findOthers: boolean = true) {
   useEffect(() => {
     if (
       !mapView ||
-      !selectedGraphic ||
-      !selectedGraphic.attributes ||
-      !selectedGraphic.attributes.zoom ||
+      !selectedGraphic?.attributes?.zoom ||
       services.status === 'fetching'
     ) {
       return;

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -1364,7 +1364,7 @@ function useSharedLayers({
       visible: false,
       outFields: ['*'],
       popupTemplate: {
-        outFields: ['areasqkm'],
+        outFields: ['areasqkm', 'huc12', 'name'],
         title: getTitle,
         content: getTemplate,
       },

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -737,6 +737,11 @@ export function getPopupTitle(attributes: PopupAttributes | null) {
     title = attributes.GNIS_NAME;
   }
 
+  // Watershed
+  else if ('huc12' in attributes) {
+    title = `Watershed for Currently Selected Location: ${attributes.name} (${attributes.huc12})`;
+  }
+
   return title;
 }
 
@@ -848,6 +853,11 @@ export function getPopupContent({
     // EJSCREEN
     else if ('T_OVR64PCT' in attributes) {
       type = 'Demographic Indicators';
+    }
+
+    // Watershed
+    else if ('huc12' in attributes) {
+      type = 'Watershed';
     }
   }
 

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -170,6 +170,12 @@
       [tabindex='-1']:focus {
         outline: none !important;
       }
+
+      .menu--main .menu__link {
+        font-family: 'Merriweather Web', Georgia, Cambria, 'Times New Roman',
+          Times, serif;
+        font-size: 0.91rem;
+      }
     </style>
 
     <!-- Google Tag Manager -->

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -176,6 +176,12 @@
           Times, serif;
         font-size: 0.91rem;
       }
+
+      .usa-nav.is-visible .menu--main .menu__link {
+        font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica',
+          'Roboto', 'Arial', sans-serif;
+        font-size: 1.06rem;
+      }
     </style>
 
     <!-- Google Tag Manager -->

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -170,6 +170,12 @@
       [tabindex='-1']:focus {
         outline: none !important;
       }
+
+      .menu--main .menu__link {
+        font-family: 'Merriweather Web', Georgia, Cambria, 'Times New Roman',
+          Times, serif;
+        font-size: 0.91rem;
+      }
     </style>
 
     <!-- Google Tag Manager -->

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -176,6 +176,12 @@
           Times, serif;
         font-size: 0.91rem;
       }
+
+      .usa-nav.is-visible .menu--main .menu__link {
+        font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica',
+          'Roboto', 'Arial', sans-serif;
+        font-size: 1.06rem;
+      }
     </style>
 
     <!-- Google Tag Manager -->


### PR DESCRIPTION
## Related Issues:
* [HMW-670](https://jira.epa.gov/browse/HMW-670)

## Main Changes:
* Added popups for the Watersheds layer and the Boundaries layer.
  * These popups are identical: if both are visible and clicked, only one will be shown.
* Removed the default handling of popups universally.
  * Previously, this was only done on the Tribal page and the Monitoring tab, but the Watersheds layer is available everywhere, and we'd like the watershed popups to always be last. To my knowledge, this only affected the Protected Areas layer (a MapImageLayer) popups, which need to fetch from the server before showing. I changed this to instead fetch the features manually if the layer is visible. This also fixes the popups in the two locations mentioned previously. I wasn't able to recreate the Esri cursor spinner, though, so the default browser wait cursor is used instead.
* Added the watershed area (in acres and square kilometers) to the watershed summary information to the right of the pin icon above the tabs on the Community page.
* Updated the Upstream Watershed popup to use two points of precision for consistency with the other watersheds popup.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/overview.
2. Click outside the Boundaries layer. The "Change to This Location?" popup should appear.
3. Toggle on the visibility of the Watersheds layer, then click outside the Boundaries layer again. A watershed popup should show with a "Change to this location?" button within.
4. With the Watersheds layer still visible, click inside the boundaries of the current HUC. Only one watershed popup should show, and no "Change to this location?" message should be displayed.
5. Toggle on the visibility of the Protected Areas layer, then click on of its features. The cursor should change to a wait cursor inside the map container, then a popup should show with one or more Protected Areas features.
6. Repeat steps 1-5 for other pages.