### PR TITLE
Feature/673 change location area

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -1424,9 +1424,6 @@
                 </a>
               </li>
             </ul>
-            <p class="footer__last-updated">
-              Last updated on December 26, 2023
-            </p>
           </div>
         </div>
       </div>

--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -818,7 +818,7 @@ function Protect() {
                             const attributes = item.attributes;
                             return (
                               <FeatureItem
-                                key={attributes.GlobalID}
+                                key={attributes.OBJECTID}
                                 feature={item}
                                 title={
                                   <strong>

--- a/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SavePanel.tsx
@@ -221,7 +221,6 @@ const saveAsInputStyles = css`
 `;
 
 const submitSectionStyles = css`
-  margin-top: 1.5rem;
   margin-bottom: 0.625rem;
 `;
 

--- a/app/client/src/components/shared/MessageBoxes.js
+++ b/app/client/src/components/shared/MessageBoxes.js
@@ -15,6 +15,10 @@ const boxStyles = css`
     :first-of-type {
       margin-top: 0;
     }
+
+    :last-of-type {
+      margin-bottom: 0;
+    }
   }
 `;
 

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -1332,9 +1332,6 @@ function MapPopup({
 
   if (!attributes) return null;
 
-  const huc12 = clickedHuc?.data?.huc12;
-  const watershed = clickedHuc?.data?.watershed;
-
   return (
     <div css={popupContainerStyles}>
       {clickedHuc && (
@@ -1349,7 +1346,21 @@ function MapPopup({
               )}
 
               <div css={changeWatershedContainerStyles}>
-                <div>{labelValue('WATERSHED', `${watershed} (${huc12})`)}</div>
+                <div>
+                  {labelValue(
+                    'WATERSHED',
+                    `${clickedHuc.data.name} (${clickedHuc.data.huc12})`,
+                  )}
+                  {labelValue(
+                    'SIZE',
+                    `${formatNumber(
+                      clickedHuc.data.areaacres,
+                    )} acres / ${formatNumber(
+                      clickedHuc.data.areasqkm,
+                      2,
+                    )} km²`,
+                  )}
+                </div>
 
                 <div css={buttonsContainer}>
                   <button
@@ -1365,7 +1376,7 @@ function MapPopup({
                       // has a lot of waterbodies.
                       if (resetData) resetData();
 
-                      let baseRoute = `/community/${huc12}`;
+                      let baseRoute = `/community/${clickedHuc.data.huc12}`;
 
                       // community will attempt to stay on the same tab
                       // if available, stay on the same tab otherwise go to overview

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -62,7 +62,7 @@ export interface ChangeLocationAttributes {
 
 export type ClickedHucState =
   | { status: 'fetching' | 'no-data' | 'none' | 'failure'; data: null }
-  | { status: 'success'; data: { huc12: string; watershed: string } };
+  | { status: 'success'; data: WatershedAttributes };
 
 export interface CongressionalDistrictAttributes {
   CDFIPS: string;

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -56,6 +56,7 @@ import type {
   ExtendedGraphic,
   Feature,
   WaterbodyCondition,
+  WatershedAttributes,
 } from 'types';
 
 let dynamicPopupFields: __esri.Field[] = [];
@@ -804,13 +805,9 @@ function useDynamicPopup() {
               return;
             }
 
-            const { attributes } = boundaries.features[0];
             resolve({
               status: 'success',
-              data: {
-                huc12: attributes.huc12,
-                watershed: attributes.name,
-              },
+              data: boundaries.features[0].attributes as WatershedAttributes,
             });
           })
           .catch((err) => {
@@ -1361,11 +1358,6 @@ function useSharedLayers({
       listMode: 'show',
       visible: false,
       outFields: ['*'],
-      popupTemplate: {
-        outFields: ['areasqkm', 'huc12', 'name'],
-        title: getTitle,
-        content: getTemplate,
-      },
     });
     setLayer('watershedsLayer', watershedsLayer);
     return watershedsLayer;

--- a/app/server/app/public/400.html
+++ b/app/server/app/public/400.html
@@ -896,9 +896,6 @@
                 </a>
               </li>
             </ul>
-            <p class="footer__last-updated">
-              Last updated on December 26, 2023
-            </p>
           </div>
         </div>
       </div>

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -902,9 +902,6 @@
                 </a>
               </li>
             </ul>
-            <p class="footer__last-updated">
-              Last updated on December 26, 2023
-            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Related Issues:
* [HMW-673](https://jira.epa.gov/browse/HMW-673)
* [HMW-675](https://jira.epa.gov/browse/HMW-675)

## Main Changes:
* Reverted the watershed layer to having no popup.
  * The Boundaries layer still has a popup with the watershed size.
* Moved the watershed size into the "change location" popup content.
* Updated a key that was pointing to an obsolete attribute of the Wild and Scenic Rivers layer.
* Adjusted two margins.
* Removed the "last updated on <date>" message from the EPA template footer.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/overview.
2. Click outside the current HUC boundaries. The clicked watershed size should show in a Change Location section (inside another popup or in its own popup).
3. Toggle on the Watersheds layer, and click outside the current HUC boundaries again. The same popup should show.
4. Click inside the HUC boundaries. A watershed popup should show that is similar to the Upstream Watershed popup.
5. Navigate to the Restoration tab, then open the browser's developer tools. In the Network tab, block the https://attains.epa.gov/attains-public/api/actions URL, then open one of the restoration plan popups. The error message that shows should not have excess bottom padding.
6. Open the Add & Save Data Widget, then click the Save tab. Choose a title for the output, then click "Save to ArcGIS Online". The success message should not have excess top padding.