### PR TITLE
Bugfix/674 wsr toggle flicker

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Protect.js
+++ b/app/client/src/components/pages/Community.Tabs.Protect.js
@@ -818,7 +818,7 @@ function Protect() {
                             const attributes = item.attributes;
                             return (
                               <FeatureItem
-                                key={attributes.GlobalID}
+                                key={attributes.OBJECTID}
                                 feature={item}
                                 title={
                                   <strong>

--- a/app/client/src/contexts/locationSearch.js
+++ b/app/client/src/contexts/locationSearch.js
@@ -373,7 +373,7 @@ export class LocationSearchProvider extends Component<Props, State> {
 
       // reset the zoom and home widget to the initial extent
       if (useDefaultZoom && mapView) {
-        mapView.extent = initialExtent();
+        mapView.goTo(initialExtent());
 
         if (homeWidget) {
           homeWidget.viewpoint = initialViewpoint();

--- a/app/client/src/utils/hooks.ts
+++ b/app/client/src/utils/hooks.ts
@@ -1012,9 +1012,6 @@ function useSharedLayers({
     });
 
     setLayer('wsioHealthIndexLayer', wsioHealthIndexLayer);
-    setResetHandler('wsioHealthIndexLayer', () => {
-      wsioHealthIndexLayer.visible = false;
-    });
 
     // Toggles the shading of the watershed graphic based on
     // whether or not the wsio layer is on or off
@@ -1066,9 +1063,6 @@ function useSharedLayers({
     });
 
     setLayer('protectedAreasLayer', protectedAreasLayer);
-    setResetHandler('protectedAreasLayer', () => {
-      protectedAreasLayer.visible = false;
-    });
 
     return protectedAreasLayer;
   }
@@ -1112,11 +1106,6 @@ function useSharedLayers({
       },
     });
     setLayer('wildScenicRiversLayer', wildScenicRiversLayer);
-    setResetHandler('wildScenicRiversLayer', () => {
-      setTimeout(() => {
-        wildScenicRiversLayer.visible = false;
-      }, 100);
-    });
 
     return wildScenicRiversLayer;
   }


### PR DESCRIPTION
## Related Issues:
* [HMW-674](https://jira.epa.gov/browse/HMW-674)

## Main Changes:
* Fixed issue of `Wild and Scenic Rivers` layer switch flickering when changing locations. Basically, I just removed any `setResetHandler` that only set the layer visibility to `false`, since that is handled elsewhere. 
* Fixed issue of map not zooming out to continental US when clicking "Community" tab button from a community search page.

## Steps To Test:
1. Navigate to http://localhost:3000/community/020401010506/protect
2. Turn on the wild and scenic rivers layer and one other layer on this tab
3. Use the map to change to other locations with wild and scenic rivers 
4. Verify the Wild and Scenic Rivers layer switch does not flicker on and off infinitely
    * Note: The switch will shut off and turn back on, but this should only happen once
5. Repeat steps 3 and 4 several times
6. Click on the "Community" button that is just below the HMW header image
7. Verify the map zooms out to the continental US and no layers are visible
