### PR TITLE
Bugfix/677 advanced search list filter

### DIFF
--- a/app/client/src/components/shared/PaginatedSelect.tsx
+++ b/app/client/src/components/shared/PaginatedSelect.tsx
@@ -130,7 +130,7 @@ function wrapMenuList(loadPrevious: () => boolean, loadNext: () => boolean) {
     }
 
     const hasSubChildren =
-      children.length === 1 && Boolean(children[0].props?.children);
+      children.length === 1 && Array.isArray(children[0].props?.children);
 
     // Determine if this is a group and get the children accordingly.
     const childrenToDisplay = hasSubChildren


### PR DESCRIPTION
## Related Issues:
* [HMW-677](https://jira.epa.gov/browse/HMW-677)

## Main Changes:
* Fixed a bug where filtering a select input with the custom menu list down to one item would show each character on its own line. This was due to a check that tested whether the immediate child is a group or list of options: it previously determined the child is a group if it has children, but an option can have children, too (string characters), so it  has been updated to check that the `children` prop is an array.

## Steps To Test:
1. Navigate to http://localhost:3000/state/AK/advanced-search.
2. In the _Watershed Names (HUC12)_ select input, paste the string "190101020101" to filter to one option. The option should display as expected.
3. Repeat for the _Waterbody Names (IDs)_ input by typing or pasting the string "Akutan".
4. Go to http://localhost:3000/community/dc/monitoring, then select the _Past Water Conditions_ tab.
5. Open the characteristics filter, and verify the group label still displays correctly. Ensure the filter functions as expected.