### PR TITLE
bugfix/678 monitoring stations stay

### DIFF
--- a/app/client/src/utils/boundariesToggleLayer.ts
+++ b/app/client/src/utils/boundariesToggleLayer.ts
@@ -332,7 +332,7 @@ export async function updateFeatureLayer(
 ) {
   if (!layer) return;
 
-  const featureSet = await layer.queryFeatures();
+  const featureSet = await layer.queryFeatures({ where: '1=1' });
   const edits: {
     addFeatures?: __esri.Graphic[];
     deleteFeatures: __esri.Graphic[];


### PR DESCRIPTION
## Related Issues:
* [HMW-678](https://jira.epa.gov/browse/HMW-678)

## Main Changes:
* Fixed an issue of monitoring stations sticking around after changing locations.
  * I think the issue is because the definition expression for the monitoring locations is changed. I just added a where clause to the `layer.queryFeatures` clause that ignores the definition expression for the layer.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Turn on the Past Water Conditions layer
3. Change locations via the "Change to this location" popup
4. Verify the Past Water Conditions of the previous HUC were removed
5. Repeat steps 1 and 2
6. Change locations via the location search input
7. Repeat step 4
