### PR TITLE
Fixed broken icon link

### DIFF
--- a/app/client/public/browserconfig.xml
+++ b/app/client/public/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/images/mstile-150x150.png"/>
+            <square150x150logo src="/epa-template-files/images/mstile-150x150.png"/>
             <TileColor>#2b5797</TileColor>
         </tile>
     </msapplication>


### PR DESCRIPTION
## Main Changes:
* Fixed a path that was not updated when files were moved around in the EPA template update.
  * I believe this `browserconfig.xml` file is mostly irrelevant now that IE is nixed, but there may still be lingering users.
