### PR TITLE
Feature/684 hide view on map

### DIFF
--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -47,7 +47,7 @@ import {
 } from 'utils/mapFunctions';
 import { chunkArrayCharLength } from 'utils/utils';
 // styles
-import { colors } from 'styles/index';
+import { colors, noMapDataWarningStyles } from 'styles/index';
 // errors
 import { actionsError, noActionsAvailableCombo } from 'config/errorMessages';
 
@@ -720,7 +720,18 @@ function Actions() {
                                   }
                                   subTitle={
                                     <>
-                                      {orgLabel} {auId}
+                                      {orgLabel} {auId}{' '}
+                                      {!graphic && (
+                                        <>
+                                          <br />
+                                          <span css={noMapDataWarningStyles}>
+                                            <i className="fas fa-exclamation-triangle" />
+                                            <strong>
+                                              [Waterbody not visible on map.]
+                                            </strong>
+                                          </span>
+                                        </>
+                                      )}
                                     </>
                                   }
                                   feature={graphic}
@@ -749,19 +760,18 @@ function Actions() {
                                       )}
 
                                     <p css={paragraphContentStyles}>
-                                      {graphic && (
-                                        <ViewOnMapButton
-                                          feature={{
-                                            attributes: {
-                                              assessmentunitidentifier: auId,
-                                              organizationid: orgId,
-                                              fieldName: 'hmw-extra-content',
-                                            },
-                                          }}
-                                          layers={[mapLayer.layer]}
-                                          fieldName="hmw-extra-content"
-                                        />
-                                      )}
+                                      <ViewOnMapButton
+                                        feature={{
+                                          attributes: {
+                                            assessmentunitidentifier: auId,
+                                            organizationid: orgId,
+                                            fieldName: 'hmw-extra-content',
+                                          },
+                                        }}
+                                        layers={[mapLayer.layer]}
+                                        fieldName="hmw-extra-content"
+                                        disabled={graphic ? false : true}
+                                      />
                                     </p>
                                   </div>
                                 </AccordionItem>

--- a/app/client/src/components/pages/Actions.js
+++ b/app/client/src/components/pages/Actions.js
@@ -721,17 +721,18 @@ function Actions() {
                                   subTitle={
                                     <>
                                       {orgLabel} {auId}{' '}
-                                      {!graphic && (
-                                        <>
-                                          <br />
-                                          <span css={noMapDataWarningStyles}>
-                                            <i className="fas fa-exclamation-triangle" />
-                                            <strong>
-                                              [Waterbody not visible on map.]
-                                            </strong>
-                                          </span>
-                                        </>
-                                      )}
+                                      {mapLayer.status === 'success' &&
+                                        !graphic && (
+                                          <>
+                                            <br />
+                                            <span css={noMapDataWarningStyles}>
+                                              <i className="fas fa-exclamation-triangle" />
+                                              <strong>
+                                                [Waterbody not visible on map.]
+                                              </strong>
+                                            </span>
+                                          </>
+                                        )}
                                     </>
                                   }
                                   feature={graphic}
@@ -760,18 +761,20 @@ function Actions() {
                                       )}
 
                                     <p css={paragraphContentStyles}>
-                                      <ViewOnMapButton
-                                        feature={{
-                                          attributes: {
-                                            assessmentunitidentifier: auId,
-                                            organizationid: orgId,
-                                            fieldName: 'hmw-extra-content',
-                                          },
-                                        }}
-                                        layers={[mapLayer.layer]}
-                                        fieldName="hmw-extra-content"
-                                        disabled={graphic ? false : true}
-                                      />
+                                      {mapLayer.status === 'success' && (
+                                        <ViewOnMapButton
+                                          feature={{
+                                            attributes: {
+                                              assessmentunitidentifier: auId,
+                                              organizationid: orgId,
+                                              fieldName: 'hmw-extra-content',
+                                            },
+                                          }}
+                                          layers={[mapLayer.layer]}
+                                          fieldName="hmw-extra-content"
+                                          disabled={graphic ? false : true}
+                                        />
+                                      )}
                                     </p>
                                   </div>
                                 </AccordionItem>

--- a/app/client/src/components/shared/ViewOnMapButton.js
+++ b/app/client/src/components/shared/ViewOnMapButton.js
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 import { useLayers } from 'contexts/Layers';
 import { useMapHighlightState } from 'contexts/MapHighlight';
 // styles
-import { colors } from 'styles/index';
+import { colors, noMapDataWarningStyles } from 'styles/index';
 
 const buttonStyles = css`
   margin-bottom: 0;
@@ -123,6 +123,15 @@ function ViewOnMapButton({
     }
 
     queryLayers(); // initiate the recursive layer query
+  }
+
+  if (disabled) {
+    return (
+      <span css={noMapDataWarningStyles}>
+        <i className="fas fa-exclamation-triangle" />
+        <strong>No map data available for this waterbody.</strong>
+      </span>
+    );
   }
 
   return (

--- a/app/client/src/components/shared/ViewOnMapButton.js
+++ b/app/client/src/components/shared/ViewOnMapButton.js
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 import { useLayers } from 'contexts/Layers';
 import { useMapHighlightState } from 'contexts/MapHighlight';
 // styles
-import { colors, noMapDataWarningStyles } from 'styles/index';
+import { noMapDataWarningStyles } from 'styles/index';
 
 const buttonStyles = css`
   margin-bottom: 0;
@@ -14,16 +14,6 @@ const buttonStyles = css`
 
   @media (min-width: 560px) {
     font-size: 1em;
-  }
-
-  &:not([disabled]):hover,
-  &:not([disabled]):focus {
-    background-color: ${colors.navyBlue()};
-  }
-
-  &:disabled {
-    opacity: 0.625;
-    cursor: default;
   }
 `;
 
@@ -150,7 +140,6 @@ function ViewOnMapButton({
           getGeometry((feature) => viewClick(feature));
         }
       }}
-      disabled={disabled}
     >
       <i className="fas fa-map-marker-alt" aria-hidden="true" />
       &nbsp;&nbsp;View on Map

--- a/app/client/src/components/shared/WaterbodyList.js
+++ b/app/client/src/components/shared/WaterbodyList.js
@@ -28,7 +28,7 @@ import {
 // errors
 import { huc12SummaryError } from 'config/errorMessages';
 // styles
-import { colors } from 'styles/index';
+import { noMapDataWarningStyles } from 'styles/index';
 
 const paragraphStyles = css`
   margin-bottom: 0.5em;
@@ -70,18 +70,6 @@ const modifiedInfoBoxStyles = css`
   ${infoBoxStyles};
   margin-bottom: 1em;
   text-align: center;
-`;
-
-const noMapDataWarningStyles = css`
-  font-size: 0.875rem;
-
-  i {
-    background-color: ${colors.black()};
-    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-    color: ${colors.yellow()};
-    font-size: 0.95rem;
-    margin-right: 5px;
-  }
 `;
 
 type Props = {
@@ -190,10 +178,6 @@ function WaterbodyList({ waterbodies, title, fieldName }: Props) {
                   fieldName={fieldName}
                   disabled={graphic.limited ? true : false}
                 />
-
-                {graphic.limited && (
-                  <p>No map data available for this waterbody.</p>
-                )}
               </div>
             </AccordionItem>
           );

--- a/app/client/src/components/shared/WaterbodyListVirtualized.tsx
+++ b/app/client/src/components/shared/WaterbodyListVirtualized.tsx
@@ -21,6 +21,8 @@ import {
   useStateNationalUsesContext,
 } from 'contexts/LookupFiles';
 import { useMapHighlightState } from 'contexts/MapHighlight';
+// styles
+import { noMapDataWarningStyles } from 'styles/index';
 
 const textStyles = css`
   margin: 1em;
@@ -183,7 +185,16 @@ function WaterbodyListVirtualized({
                 title={<strong>{name}</strong>}
                 subTitle={
                   <>
-                    {getOrganizationLabel(graphic.attributes)} {auId}
+                    {getOrganizationLabel(graphic.attributes)} {auId}{' '}
+                    {viewOnMapDisabled && (
+                      <>
+                        <br />
+                        <span css={noMapDataWarningStyles}>
+                          <i className="fas fa-exclamation-triangle" />
+                          <strong>[Waterbody not visible on map.]</strong>
+                        </span>
+                      </>
+                    )}
                   </>
                 }
                 icon={<WaterbodyIcon condition={condition} selected={false} />}

--- a/app/client/src/styles/index.ts
+++ b/app/client/src/styles/index.ts
@@ -91,8 +91,11 @@ export const noMapDataWarningStyles = css`
   font-size: 0.875rem;
 
   i {
-    background-color: ${colors.black()};
-    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    text-shadow:
+      -1px 0 #000,
+      0 1px #000,
+      1px 0 #000,
+      0 -1px #000;
     color: ${colors.yellow()};
     font-size: 0.95rem;
     margin-right: 5px;

--- a/app/client/src/styles/index.ts
+++ b/app/client/src/styles/index.ts
@@ -87,6 +87,18 @@ export const groupHeadingStyles: CSSObjectWithLabel = {
   textTransform: 'none',
 };
 
+export const noMapDataWarningStyles = css`
+  font-size: 0.875rem;
+
+  i {
+    background-color: ${colors.black()};
+    clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    color: ${colors.yellow()};
+    font-size: 0.95rem;
+    margin-right: 5px;
+  }
+`;
+
 export const reactSelectStyles = {
   group: (defaultStyles: CSSObjectWithLabel) => ({
     ...defaultStyles,


### PR DESCRIPTION
## Related Issues:
* [HMW-684](https://jira.epa.gov/browse/HMW-684)

## Main Changes:
* Replaced the disabled "View on Map" button with a "No map data available for this waterbody" message.
* Added the no GIS data message to the State Advanced Search page.
* Added the no GIS data message to the Plan Summary page.

## Steps To Test:
1. Navigate to http://localhost:3000/community/annapolis,%20md/overview
2. Verify the `[Waterbody not visible on map.]` message is visible in the accordion header for some waterbodies.
3. Expand one of those and verify the `View on Map` button is not visible and the `No map data available for this waterbody.` message is visible.
4. Expand one that does have GIS data and verify the `View on Map` button is visible.
5. Navigate to http://localhost:3000/plan-summary/DOEE/40594
6. Repeat steps 2 - 4.
7. Navigate to http://localhost:3000/state/MD/advanced-search
8. Select the `020600040203` watershed and click Search
9. Go to the list view
10. Repeat steps 2 - 4.

