### PR TITLE
HMW-685 Fixed widget heading sizes on State/Tribal page

### DIFF
--- a/app/client/src/components/pages/Community.Routes.CommunityTabs.js
+++ b/app/client/src/components/pages/Community.Routes.CommunityTabs.js
@@ -458,7 +458,7 @@ function CommunityTabs() {
               <span>WATERSHED:</span> {watershed.name} ({huc12})
             </p>
           )}
-          {watershed.areasqkm && watershed.areaacres && (
+          {Boolean(watershed.areasqkm) && Boolean(watershed.areaacres) && (
             <p css={watershedStyles}>
               <span>SIZE:</span> {formatNumber(watershed.areaacres)} acres /{' '}
               {formatNumber(watershed.areasqkm, 2)} km<sup>2</sup>

--- a/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
+++ b/app/client/src/components/pages/Community.Tabs.IdentifiedIssues.js
@@ -90,6 +90,13 @@ const headingStyles = css`
   font-size: 1.375em;
 `;
 
+const modifiedTabLegendStyles = css`
+  ${tabLegendStyles};
+  > span {
+    margin-bottom: 0;
+  }
+`;
+
 function IdentifiedIssues() {
   const navigate = useNavigate();
   const { infoToggleChecked } = useContext(CommunityTabsContext);
@@ -795,7 +802,7 @@ function IdentifiedIssues() {
 
                   {dischargers.length > 0 && (
                     <>
-                      <div css={tabLegendStyles}>
+                      <div css={modifiedTabLegendStyles}>
                         <span>
                           {diamondIcon({ color: colors.orange() })}
                           &nbsp;Permitted Dischargers&nbsp;

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalIntro.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalIntro.js
@@ -8,6 +8,7 @@ import {
   introHeadingStyles,
   introTextStyles,
 } from 'components/shared/IntroBox';
+import { h2Styles } from 'styles/stateTribal';
 
 const headerStyles = css`
   display: flex;
@@ -19,6 +20,8 @@ const headerStyles = css`
   background-color: transparent;
 
   h2 {
+    ${h2Styles}
+    ${introHeadingStyles}
     margin: 0;
     padding: 0;
   }
@@ -35,7 +38,7 @@ function StateTribalIntro() {
     <div css={introBoxStyles}>
       <header css={headerStyles}>
         <i className="fas fa-tint" aria-hidden="true" />
-        <h2 css={introHeadingStyles}>
+        <h2>
           States and Tribes Play a Primary Role in Protecting Water Quality
         </h2>
       </header>

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -121,7 +121,7 @@ function StateTribalTabs() {
 
     return (
       <div>
-        <h2 className={h2Styles}>
+        <h2 css={h2Styles}>
           <i className="fas fa-map-marked-alt" aria-hidden="true" />
           <strong>{activeState.label}</strong> at a Glance
         </h2>

--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.js
@@ -13,6 +13,7 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import TribalMapList from 'components/shared/TribalMapList';
 // styled components
 import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
+import { h2Styles } from 'styles/stateTribal';
 // contexts
 import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
 
@@ -120,7 +121,7 @@ function StateTribalTabs() {
 
     return (
       <div>
-        <h2>
+        <h2 className={h2Styles}>
           <i className="fas fa-map-marked-alt" aria-hidden="true" />
           <strong>{activeState.label}</strong> at a Glance
         </h2>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.Documents.js
@@ -12,6 +12,7 @@ import { useDocumentOrderContext } from 'contexts/LookupFiles';
 import { getExtensionFromPath } from 'utils/utils';
 // styled components
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
+import { h3Styles } from 'styles/stateTribal';
 // errors
 import {
   stateDocumentError,
@@ -56,6 +57,7 @@ const containerStyles = css`
   }
 
   h3 {
+    ${h3Styles}
     margin-bottom: 0px;
   }
 `;

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.js
@@ -23,6 +23,7 @@ import { formatNumber } from 'utils/utils';
 import { impairmentFields } from 'config/attainsToHmwMapping';
 // styles
 import { fonts, colors } from 'styles/index';
+import { h3Styles } from 'styles/stateTribal';
 // errors
 import { fishingAdvisoryError } from 'config/errorMessages';
 
@@ -76,6 +77,7 @@ const highchartsContainerStyles = css`
 `;
 
 const fishingAdvisoryTextStyles = css`
+  ${h3Styles}
   display: inline-block;
 `;
 
@@ -277,7 +279,7 @@ function SiteSpecific({
     <>
       {waterType && useSelected && (
         <>
-          <h3>
+          <h3 css={h3Styles}>
             Assessed{' '}
             <strong>
               <em>{waterType}</em>
@@ -430,7 +432,7 @@ function SiteSpecific({
         <AccordionList expandDisabled={true}>
           <AccordionItem
             title={
-              <h3>
+              <h3 css={h3Styles}>
                 Top Reasons for Impairment for {activeState.label}{' '}
                 <strong>
                   <em>{waterType}</em>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SurveyResults.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SurveyResults.js
@@ -14,6 +14,7 @@ import LoadingSpinner from 'components/shared/LoadingSpinner';
 import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 // styled components
 import { errorBoxStyles } from 'components/shared/MessageBoxes';
+import { h3Styles } from 'styles/stateTribal';
 // contexts
 import {
   useSurveyMappingContext,
@@ -409,7 +410,7 @@ function SurveyResults({
   return (
     subPopulationCodes?.length > 0 && (
       <>
-        <h3>
+        <h3 css={h3Styles}>
           Overall water quality in {activeState.label}{' '}
           <strong>
             <em>{waterType}</em>
@@ -568,7 +569,7 @@ function SurveyResults({
           <AccordionList expandDisabled={true}>
             <AccordionItem
               title={
-                <h3>
+                <h3 css={h3Styles}>
                   Stressors surveyed for{' '}
                   <strong>
                     <em>{surveyUseSelected}</em>

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.js
@@ -26,6 +26,7 @@ import Stories from 'components/pages/StateTribal.Tabs.WaterQualityOverview.Stor
 import { errorBoxStyles } from 'components/shared/MessageBoxes';
 // styles
 import { colors, reactSelectStyles } from 'styles/index';
+import { h2Styles, h3Styles, h4Styles } from 'styles/stateTribal';
 // contexts
 import { StateTribalTabsContext } from 'contexts/StateTribalTabs';
 import {
@@ -150,6 +151,7 @@ const topicIconStyles = css`
 `;
 
 const headingStyles = css`
+  ${h2Styles}
   margin-top: 0 !important;
 
   i {
@@ -936,7 +938,7 @@ function WaterQualityOverview() {
         <strong>{activeState.label}</strong> Water Quality
       </h2>
 
-      <h3>Choose a Topic:</h3>
+      <h3 css={h3Styles}>Choose a Topic:</h3>
 
       <div css={topicTabsStyles}>
         <Tabs
@@ -967,7 +969,7 @@ function WaterQualityOverview() {
                 data-testid={`hmw-${tab.id}-tab-panel`}
               >
                 <div css={filtersSectionStyles}>
-                  <h4>Pick your Water Type and Use:</h4>
+                  <h4 css={h4Styles}>Pick your Water Type and Use:</h4>
 
                   <div css={inputsStyles}>
                     <div css={inputStyles}>
@@ -1065,7 +1067,7 @@ function WaterQualityOverview() {
                       activeState.source === 'State',
                   )}
                 >
-                  <h3>
+                  <h3 css={h3Styles}>
                     <img
                       css={imageIconStyles}
                       src={drinkingWaterIcon}
@@ -1075,7 +1077,9 @@ function WaterQualityOverview() {
                     <strong>{activeState.label}</strong>
                   </h3>
 
-                  <h4>EPA has defined three types of public water systems:</h4>
+                  <h4 css={h4Styles}>
+                    EPA has defined three types of public water systems:
+                  </h4>
 
                   {tab.id === 'drinking' && activeState.value && (
                     <WaterSystemSummary state={activeState} />

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -36,7 +36,8 @@ import { fetchCheck } from 'utils/fetchUtils';
 import { useKeyPress } from 'utils/hooks';
 import { isClick } from 'utils/utils';
 // styles
-import { colors, fonts, reactSelectStyles } from 'styles/index';
+import { colors, reactSelectStyles } from 'styles/index';
+import { h2Styles } from 'styles/stateTribal';
 // errors
 import {
   stateListError,
@@ -95,36 +96,6 @@ const buttonStyles = css`
   &:focus {
     color: ${colors.white()};
     background-color: ${colors.navyBlue()};
-  }
-`;
-
-const contentStyles = css`
-  h2 {
-    margin-top: 0.75rem;
-    font-size: 1.625em;
-
-    i {
-      margin-right: 0.3125em;
-      color: #2c72b5;
-    }
-  }
-
-  h3 {
-    font-size: 1.375em;
-  }
-
-  h2,
-  h3 {
-    font-family: ${fonts.primary};
-    font-weight: normal;
-  }
-
-  h4 {
-    margin-bottom: 0.75rem;
-    padding-bottom: 0;
-    font-size: 1.125em;
-    color: #526571;
-    font-family: ${fonts.primary};
   }
 `;
 
@@ -594,7 +565,7 @@ function StateTribal() {
             )}
           </div>
         ) : (
-          <div css={contentStyles}>
+          <div>
             {activeState.value !== '' && (
               <>
                 {introText.status === 'fetching' && <LoadingSpinner />}
@@ -613,7 +584,7 @@ function StateTribal() {
                       <>
                         {stateIntro.organizationMetrics.length > 0 && (
                           <>
-                            <h2>
+                            <h2 css={h2Styles}>
                               <i
                                 className="fas fa-chart-line"
                                 aria-hidden="true"
@@ -665,7 +636,7 @@ function StateTribal() {
 
                         {stateIntro.description && (
                           <>
-                            <h2>
+                            <h2 css={h2Styles}>
                               <i aria-hidden="true" className="fas fa-water" />
                               About <strong>{activeState.label}</strong>
                             </h2>

--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -153,11 +153,11 @@ calcite-flow {
 }
 
 .hmw-map-toggle h2 {
-  margin: 0 10px !important;
+  margin: 0 10px;
   padding: 0;
   font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto',
     'Arial', sans-serif;
-  font-size: 1.25em !important;
+  font-size: 1.25em;
 }
 
 .hmw-map-toggle hr {

--- a/app/client/src/styles/stateTribal.ts
+++ b/app/client/src/styles/stateTribal.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { fonts } from 'styles';
+
+export const h2Styles = css`
+  margin-top: 0.75rem;
+  font-family: ${fonts.primary};
+  font-size: 1.625em;
+  font-weight: normal;
+
+  i {
+    margin-right: 0.3125em;
+    color: #2c72b5;
+  }
+`;
+
+export const h3Styles = css`
+  font-family: ${fonts.primary};
+  font-size: 1.375em;
+  font-weight: normal;
+`;
+
+export const h4Styles = css`
+  margin-bottom: 0.75rem;
+  padding-bottom: 0;
+  font-size: 1.125em;
+  color: #526571;
+  font-family: ${fonts.primary};
+`;


### PR DESCRIPTION
## Related Issues:
* [HMW-685](https://jira.epa.gov/browse/HMW-685)
* [HMW-682](https://jira.epa.gov/browse/HMW-682)

## Main Changes:
* Fixed two headings in the Add/Save Data widget which had their styles overridden by page styles on the State/Tribal page (I thought I fixed this in #953, but it appears otherwise).
  * I opted to break up the page-level `contentStyles` instead of abusing the `!important` flag more.
* Fixed an issue where 0 showed in place of the watershed size on the Community page while the data was loading.

## Steps To Test:
1. Go to http://localhost:3000/state/IA/water-quality-overview and verify the headings are all styled correctly, making sure to check the survey results under the "Aquatic Life" topic.
2. Perform a search in the Advanced Search tab, and verify the widgets are styled as expected.
3. Go to http://localhost:3000/community/dc/overview, and verify that only the location name shows next to the pin icon while the location is loading.