### PR TITLE
Feature/686 disabled button styles

### DIFF
--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -199,6 +199,19 @@
         white-space: normal;
       }
 
+      button:disabled {
+        background-color: #c9c9c9;
+        color: #454545;
+        cursor: not-allowed;
+        opacity: 1;
+      }
+
+      button:&not(:disabled):hover,
+      button:&not(:disabled):focus {
+        color: #fff;
+        background-color: #40618e;
+      }
+
       li {
         margin-bottom: unset;
       }

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.js
@@ -955,8 +955,9 @@ function AdvancedSearch() {
       <div css={searchStyles}>
         <Modal
           closeTitle="Cancel search"
-          confirmEnabled={numberOfRecords > 0}
+          confirmEnabled={searchLoading || numberOfRecords > 0}
           isConfirm={true}
+          isLoading={searchLoading}
           label="Warning about potentially slow search"
           onConfirm={() => {
             setCurrentFilter(nextFilter);

--- a/app/client/src/components/pages/StateTribal.js
+++ b/app/client/src/components/pages/StateTribal.js
@@ -88,15 +88,7 @@ const buttonStyles = css`
   margin-top: 1em;
   margin-bottom: 0;
   font-size: 0.9375em;
-  font-weight: bold;
-  color: ${colors.white()};
-  background-color: ${colors.blue()};
-
-  &:hover,
-  &:focus {
-    color: ${colors.white()};
-    background-color: ${colors.navyBlue()};
-  }
+  padding: 0.375rem 0.75rem;
 `;
 
 const modifiedErrorBoxStyles = css`
@@ -547,7 +539,6 @@ function StateTribal() {
 
               <button
                 onClick={() => handleSubmit(selectedStateTribe)}
-                className="btn"
                 css={buttonStyles}
               >
                 <i className="fas fa-angle-double-right" aria-hidden="true" />{' '}

--- a/app/client/src/components/shared/AddSaveDataWidget.SearchPanel.tsx
+++ b/app/client/src/components/shared/AddSaveDataWidget.SearchPanel.tsx
@@ -740,10 +740,6 @@ const cardButtonStyles = css`
   font-size: 13px;
   margin: 0 5px 0 0;
   padding: 0.3em 0.7em;
-
-  :hover {
-    background-color: rgba(64, 97, 142, 1);
-  }
 `;
 
 const cardLinkStyles = css`

--- a/app/client/src/components/shared/AddSaveDataWidget.URLPanel.js
+++ b/app/client/src/components/shared/AddSaveDataWidget.URLPanel.js
@@ -55,18 +55,6 @@ const addButtonStyles = css`
   min-width: 50%;
   font-weight: normal;
   font-size: 12px;
-  color: ${colors.white()};
-  background-color: ${colors.blue()};
-
-  &:not(.btn-danger):hover,
-  &:not(.btn-danger):focus {
-    color: ${colors.white()};
-    background-color: ${colors.navyBlue()};
-  }
-
-  &:disabled {
-    cursor: default;
-  }
 `;
 
 const urlInputStyles = css`
@@ -255,7 +243,6 @@ function URLPanel() {
         </button>
         <button
           css={addButtonStyles}
-          className="btn"
           disabled={!url.trim()}
           type="submit"
           onClick={handleAdd}

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -64,19 +64,6 @@ const buttonStyles = css`
   margin-top: 1em;
   margin-bottom: 0;
   font-size: 0.875em;
-  font-weight: bold;
-  color: ${colors.white()};
-  background-color: ${colors.blue()};
-
-  &:not(.btn-danger):hover,
-  &:not(.btn-danger):focus {
-    color: ${colors.white()};
-    background-color: ${colors.navyBlue()};
-  }
-
-  &:disabled {
-    cursor: default;
-  }
 
   @media (min-width: 480px) {
     font-size: 0.9375em;
@@ -1005,7 +992,6 @@ function LocationSearch({ route, label }: Props) {
 
         <button
           css={buttonStyles}
-          className="btn"
           type="submit"
           disabled={inputText === searchText}
         >
@@ -1017,19 +1003,13 @@ function LocationSearch({ route, label }: Props) {
             <p css={textStyles}>OR</p>
 
             {geolocationError ? (
-              <button
-                css={buttonStyles}
-                className="btn btn-danger"
-                type="button"
-                disabled
-              >
+              <button css={buttonStyles} type="button" disabled>
                 <i className="fas fa-exclamation-triangle" aria-hidden="true" />
                 &nbsp;&nbsp;Error Getting Location
               </button>
             ) : (
               <button
                 css={buttonStyles}
-                className="btn"
                 type="button"
                 onClick={(ev) => {
                   setGeolocating(true);

--- a/app/client/src/components/shared/Modal.tsx
+++ b/app/client/src/components/shared/Modal.tsx
@@ -18,7 +18,10 @@ const buttonContainerStyles = css`
 `;
 
 const cancelButtonStyles = css`
-  background-color: lightgray;
+  background-color: transparent;
+  box-shadow: inset 0 0 0 2px ${colors.blue()};
+  color: ${colors.blue()};
+  font-weight: bold;
 `;
 
 const closeButtonStyles = css`
@@ -45,12 +48,20 @@ const closeButtonStyles = css`
 const confirmButtonStyles = css`
   margin-bottom: 0;
   font-size: 0.9375em;
+  font-weight: bold;
   color: ${colors.white()};
   background-color: ${colors.blue()};
 
   &:hover {
     color: ${colors.white()};
     background-color: ${colors.navyBlue()};
+  }
+
+  &:disabled {
+    background-color: ${colors.grayc9};
+    color: ${colors.gray45};
+    cursor: not-allowed;
+    opacity: 1;
   }
 `;
 
@@ -127,6 +138,7 @@ type Props = {
   closeTitle?: string;
   confirmEnabled?: boolean;
   isConfirm?: boolean;
+  isLoading?: boolean;
   label: string;
   maxWidth?: string;
   onConfirm?: Function;
@@ -139,6 +151,7 @@ export default function Modal({
   closeTitle,
   confirmEnabled = false,
   isConfirm = false,
+  isLoading = false,
   label,
   maxWidth = '25rem',
   onClose = () => {},
@@ -186,6 +199,7 @@ export default function Modal({
                     <div>
                       <button
                         css={confirmButtonStyles}
+                        disabled={isLoading}
                         className="btn"
                         onClick={() => {
                           setDialogShown(false);

--- a/app/client/src/components/shared/Page.js
+++ b/app/client/src/components/shared/Page.js
@@ -78,8 +78,8 @@ const topLinksStyles = css`
     background-color: transparent;
     user-select: none;
 
-    :hover,
-    :focus {
+    &:not(:disabled):hover,
+    &:not(:disabled):focus {
       border-color: ${colors.white(0.75)};
       background-color: ${colors.white(0.125)};
     }

--- a/app/client/src/styles/index.ts
+++ b/app/client/src/styles/index.ts
@@ -31,7 +31,9 @@ export const colors = {
   gray4: '#444',
   gray6: '#666',
   gray9: '#999',
+  gray45: '#454545',
   grayc: '#ccc',
+  grayc9: '#c9c9c9',
   grayd: '#ddd',
   graye: '#eee',
 };

--- a/app/client/src/styles/index.ts
+++ b/app/client/src/styles/index.ts
@@ -62,6 +62,7 @@ export const downloadLinksStyles = css`
 
 export const iconButtonStyles = css`
   background: none;
+  background-color: transparent !important;
   border: none;
   color: inherit;
   margin: 0;


### PR DESCRIPTION
## Related Issues:
* [HMW-686](https://jira.epa.gov/browse/HMW-686)

## Main Changes:
* Changed styles of disabled buttons to match more closely with USWDS styles (i.e., dark gray on light gray with a not-available cursor).
* Changed cancel button styles to match more closely with USWDS styles (i.e., blue border, white background).

## Steps To Test:
1. Navigate to http://localhost:3000/state/NY/advanced-search
2. Perform a search
3. While it is loading verify the "Continue" button is disabled with above styles
4. Navigate to http://localhost:3000/community/dc/overview
5. Verify GO button has above styles when disabled
6. Open a monitoring report
7. Verify the up/down arrows look the same when disabled

