### PR TITLE
Bugfix/724 chart tooltip drift

### DIFF
--- a/app/client/package-lock.json
+++ b/app/client/package-lock.json
@@ -24,7 +24,7 @@
         "@visx/xychart": "3.8.0",
         "file-saver": "2.0.5",
         "glossary-panel": "github:Eastern-Research-Group/glossary",
-        "highcharts": "11.3.0",
+        "highcharts": "11.4.1",
         "highcharts-react-official": "3.2.1",
         "html-to-image": "1.11.11",
         "papaparse": "5.4.1",
@@ -33,7 +33,6 @@
         "react-app-polyfill": "3.0.0",
         "react-dom": "18.2.0",
         "react-dropzone": "14.2.3",
-        "react-ranger": "2.1.0",
         "react-rnd": "10.4.1",
         "react-router-dom": "6.21.3",
         "react-scripts": "5.0.1",
@@ -11233,9 +11232,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.3.0.tgz",
-      "integrity": "sha512-Dk+Qfk/xit8KnXKPDxmcVcq48ZlcVSq7oYJR5VZlAVWnJ0BY3JFFi1GOvgSNUzlh2wzsfenihWpkAkWoag4Xqg=="
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.1.tgz",
+      "integrity": "sha512-t+BjB4hba5rNheczCrpyDz8BJrqGdgECHaaXQrgbf1mRdPMPemlOfo08/kTMgZ/Kp/Xfj015atdXpUFdwUU12Q=="
     },
     "node_modules/highcharts-react-official": {
       "version": "3.2.1",
@@ -17861,15 +17860,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-ranger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-ranger/-/react-ranger-2.1.0.tgz",
-      "integrity": "sha512-d8ezhyX3v/KlN8SkyoE5e8Dybsdmn94eUAqBDsAPrVhZde8sVt6pLJw4fC784KiMmS4LyAjvtjGxhAEqjjGYgw==",
-      "hasInstallScript": true,
-      "peerDependencies": {
-        "react": "^16.6.3"
-      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -29382,9 +29372,9 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "highcharts": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.3.0.tgz",
-      "integrity": "sha512-Dk+Qfk/xit8KnXKPDxmcVcq48ZlcVSq7oYJR5VZlAVWnJ0BY3JFFi1GOvgSNUzlh2wzsfenihWpkAkWoag4Xqg=="
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.1.tgz",
+      "integrity": "sha512-t+BjB4hba5rNheczCrpyDz8BJrqGdgECHaaXQrgbf1mRdPMPemlOfo08/kTMgZ/Kp/Xfj015atdXpUFdwUU12Q=="
     },
     "highcharts-react-official": {
       "version": "3.2.1",
@@ -34049,11 +34039,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-ranger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-ranger/-/react-ranger-2.1.0.tgz",
-      "integrity": "sha512-d8ezhyX3v/KlN8SkyoE5e8Dybsdmn94eUAqBDsAPrVhZde8sVt6pLJw4fC784KiMmS4LyAjvtjGxhAEqjjGYgw=="
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -73,7 +73,7 @@
     "@visx/xychart": "3.8.0",
     "file-saver": "2.0.5",
     "glossary-panel": "github:Eastern-Research-Group/glossary",
-    "highcharts": "11.3.0",
+    "highcharts": "11.4.1",
     "highcharts-react-official": "3.2.1",
     "html-to-image": "1.11.11",
     "papaparse": "5.4.1",

--- a/app/client/public/index.html
+++ b/app/client/public/index.html
@@ -11,7 +11,10 @@
 
     <link rel="canonical" href="https://mywaterway.epa.gov" />
     <link rel="shortlink" href="https://mywaterway.epa.gov" />
-    <meta name="keywords" content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies" />
+    <meta
+      name="keywords"
+      content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
+    />
     <meta name="DC.title" content="How&#x27;s My Waterway?" />
     <meta property="DC.Subject.epachannel" content="Learn the Issues" />
     <meta property="DC.type" content="Overviews and Factsheets" />
@@ -153,7 +156,6 @@
         outline: none !important;
       }
 
-
       .menu--main .menu__link {
         font-family: 'Merriweather Web', Georgia, Cambria, 'Times New Roman',
           Times, serif;
@@ -181,584 +183,603 @@
     </style>
     <!-- End style fixes for the EPA template -->
 
-
     <!-- Google Tag Manager -->
     <script>
-      (function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start':
-      new Date().getTime(), event: 'gtm.js' }); var f =
-      d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l !=
-      'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-      'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-      f.parentNode.insertBefore(j, f); })(window, document, 'script',
-      'dataLayer', 'GTM-L8ZB');
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-L8ZB');
     </script>
     <!-- End Google Tag Manager -->
 
     <link
-  rel="stylesheet"
-  href="https://fonts.googleapis.com/css?family=Roboto+Slab&display=swap"
-/>
-<link
-  rel="stylesheet"
-  href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
-  integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
-  crossorigin="anonymous"
-/>
-<link
-  rel="stylesheet"
-  href="https://use.fontawesome.com/releases/v5.7.0/css/all.css"
-  integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ"
-  crossorigin="anonymous"
-/>
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto+Slab&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.7.0/css/all.css"
+      integrity="sha384-lZN37f5QGtY3VHgisS14W3ExzMWZxybE1SJSEsQp9S+oqd12jhcu+A56Ebc1zFSJ"
+      crossorigin="anonymous"
+    />
 
-<!-- Style overrides for the EPA template -->
-<style>
-  /* bootstrap overrides */
-  a {
-    color: #0071bc;
-  }
-
-  body {
-    font-family: "Source Sans Pro Web", "Helvetica Neue", "Helvetica", "Roboto",
-      "Arial", sans-serif;
-    overflow-x: unset;
-  }
-
-  /* epa template overrides */
-  button {
-    background-color: #0071bc;
-    border: 0;
-    border-radius: 3px;
-    color: #fff;
-    display: inline-block;
-    font-weight: bold;
-    line-height: 1;
-    padding: 0.5882em 1.1765em;
-    text-align: center;
-    text-decoration: none;
-    vertical-align: baseline;
-    white-space: normal;
-  }
-
-  button:disabled {
-    background-color: #c9c9c9;
-    color: #454545;
-    cursor: not-allowed;
-    opacity: 1;
-  }
-
-  button:not(:disabled):hover,
-  button:not(:disabled):focus {
-    color: #fff;
-    background-color: #40618e;
-  }
-
-  li {
-    margin-bottom: unset;
-  }
-
-  ul {
-    margin: unset;
-  }
-
-  ul:last-child {
-    margin-bottom: unset;
-  }
-
-  table {
-    font-size: inherit;
-  }
-
-  table td,
-  table th {
-    background-color: inherit;
-    border: 0;
-    border-top: 1px solid #dee2e6;
-  }
-
-  table thead th {
-    background-color: inherit;
-  }
-
-  .l-header {
-    z-index: 901;
-  }
-
-  .exit-disclaimer {
-    background-color: #aeb0b5;
-    border-radius: 3px;
-    color: #323a45 !important;
-    display: inline-block;
-    font-size: 88.2352941176%;
-    margin: 0 0.3333333333em;
-    padding: 0.0666666667em 0.4666666667em;
-    text-decoration: none;
-    text-transform: uppercase;
-  }
-
-  .back-to-top {
-    z-index: 2;
-  }
-
-  .js-glossary-search {
-    float: unset;
-  }
-
-  .unsupportedMessageContainer {
-    position: -webkit-sticky; /* Safari */
-    position: sticky;
-    top: 0;
-    z-index: 900;
-    display: none;
-  }
-
-  .unsupportedErrorBox {
-    padding: 1rem;
-    text-align: center;
-    border-color: #f5c6cb;
-    color: #721c24;
-    background-color: #f8d7da;
-  }
-
-  .unsupportedMessage {
-    margin-right: 1rem;
-  }
-
-  .unsupportedCloseButton {
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 0;
-    border: none;
-    border-radius: 0;
-    width: 1.5rem;
-    height: 1.5rem;
-    color: white;
-    background-color: rgba(0, 0, 0, 0.5);
-  }
-
-  .usa-banner__button:hover,
-  .usa-banner__button:focus {
-    background-color: inherit !important;
-    color: #1a4480 !important;
-  }
-
-  .visx-tooltip {
-    transition-property: opacity;
-  }
-
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    /* IE10 and IE11 styles */
-    .unsupportedMessageContainer {
-      display: block;
-    }
-  }
-
-  @media screen {
-    main p {
-      margin-bottom: 0;
-      padding-bottom: 1.5em;
-    }
-  }
-</style>
-
-<!-- Set the page title dynamically -->
-<script>
-  // map pathnames to a formatted title for SEO purposes
-  const pathnameMapping = {
-    default: "How's My Waterway - Home",
-    community: "How's My Waterway - Community",
-    "state-and-tribal": "How's My Waterway - State and Tribal",
-    state: "How's My Waterway - State",
-    tribe: "How's My Waterway - Tribe",
-    national: "How's My Waterway - National",
-    "waterbody-report": "How's My Waterway - Waterbody Report",
-    "plan-summary": "How's My Waterway - Plan Summary",
-    data: "How's My Waterway - Data",
-    about: "How's My Waterway - About",
-    swimming: "How's My Waterway - Explore - Swimming",
-    "eating-fish": "How's My Waterway - Explore - Eating Fish",
-    "aquatic-life": "How's My Waterway - Explore - Aquatic Life",
-    "drinking-water": "How's My Waterway - Explore - Drinking Water",
-    attains: "How's My Waterway - ATTAINS",
-    educators: "How's My Waterway - Educators",
-    "monitoring-report": "How's My Waterway - Water Monitoring Report",
-  };
-
-  const descriptionMapping = {
-    default:
-      "An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language.",
-    community:
-      "Enter a location to learn about water quality in your community. Explore information about local stream conditions, watershed protection, restoration, drinking water and whether your waterways are suitable for swimming or eating fish and aquatic life.",
-    "state-and-tribal":
-      "Choose a state, tribe, or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites.",
-    state:
-      "Choose a state or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites. Search for water conditions throughout your state with the advanced search tool.",
-    tribe:
-      "Choose a tribe to get the most recent information on water quality submitted to EPA, documents, and links to organizational websites.",
-    national:
-      "Explore information about overall water quality in the United State and the basics of EPA’s drinking water program.",
-    "waterbody-report":
-      "Use the waterbody report page to find information on individual waterbodies including uses, probable sources of impairments and plans to restore water quality. ",
-    "plan-summary":
-      "The restoration plan summary page includes basic plan information, submitted documents, impairments addressed, and waters covered. ",
-    educators:
-      "Find How’s My Waterway resources for educators including lesson plans and other materials.",
-    "monitoring-report":
-      "Use the water monitoring report page to find information on individual monitoring locations including historical data from the Water Quality Portal.",
-  };
-
-  // update page title and description using mapping
-  function setPageTitle(pathnameMapping) {
-    const pageTitle = window.location.pathname.split("/")[1];
-    document.title = pathnameMapping[pageTitle] || pathnameMapping.default;
-
-    // remove old description tags if necessary
-    let oldDescTag = document.querySelector("[name='description']");
-    if (oldDescTag) oldDescTag.remove();
-    let oldDcDescTag = document.querySelector("[name='DC.description']");
-    if (oldDcDescTag) oldDcDescTag.remove();
-
-    // create description tags
-    const descTag = document.createElement("meta");
-    descTag.setAttribute("name", "description");
-    descTag.content =
-      descriptionMapping[pageTitle] || descriptionMapping.default;
-    document.getElementsByTagName("head")[0].appendChild(descTag);
-
-    const dcDescTag = document.createElement("meta");
-    dcDescTag.setAttribute("name", "DC.description");
-    dcDescTag.content =
-      descriptionMapping[pageTitle] || descriptionMapping.default;
-    document.getElementsByTagName("head")[0].appendChild(dcDescTag);
-  }
-
-  setPageTitle(pathnameMapping); // set page title when page loads
-
-  // set page title when window location changes
-  window.addEventListener("locationchange", function (event) {
-    setPageTitle(pathnameMapping);
-  });
-</script>
-
-<script>
-  /**
-   * This script is used for displaying a "browser unsupported"
-   * message. This script polls for the unsupported-browser-message
-   * div, when available it then checks the browser version and
-   * displays the message if necessary.
-   */
-
-  function unsupportedBrowserMessage() {
-    const unsupportedMessage = document.getElementById(
-      "unsupported-browser-message",
-    );
-
-    if (unsupportedMessage) {
-      // If fetch is supported, hide the unsupported browser message until
-      // we can get the supported browsers lookup file.
-      if ("fetch" in window) {
-        unsupportedMessage.style.display = "none";
+    <!-- Style overrides for the EPA template -->
+    <style>
+      /* bootstrap overrides */
+      a {
+        color: #0071bc;
       }
 
-      // Parse the user agent string to determine which browser the user is using.
-      const { browserName, browserVersion } = (function () {
-        const ua = navigator.userAgent;
+      body {
+        font-family: 'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica',
+          'Roboto', 'Arial', sans-serif;
+        overflow-x: unset;
+      }
 
-        let item;
-        let M =
-          ua.match(
-            /(opera|chrome|safari|firefox|edg|msie|trident(?=\/))\/?\s*(\d+)/i,
-          ) || [];
-        if (/trident/i.test(M[1])) {
-          item = /\brv[ :]+(\d+)/g.exec(ua) || [];
-          return {
-            browserName: "IE",
-            browserVersion: parseInt(item[1]) || 0,
-          };
+      /* epa template overrides */
+      button {
+        background-color: #0071bc;
+        border: 0;
+        border-radius: 3px;
+        color: #fff;
+        display: inline-block;
+        font-weight: bold;
+        line-height: 1;
+        padding: 0.5882em 1.1765em;
+        text-align: center;
+        text-decoration: none;
+        vertical-align: baseline;
+        white-space: normal;
+      }
+
+      button:disabled {
+        background-color: #c9c9c9;
+        color: #454545;
+        cursor: not-allowed;
+        opacity: 1;
+      }
+
+      button:not(:disabled):hover,
+      button:not(:disabled):focus {
+        color: #fff;
+        background-color: #40618e;
+      }
+
+      li {
+        margin-bottom: unset;
+      }
+
+      ul {
+        margin: unset;
+      }
+
+      ul:last-child {
+        margin-bottom: unset;
+      }
+
+      table {
+        font-size: inherit;
+      }
+
+      table td,
+      table th {
+        background-color: inherit;
+        border: 0;
+        border-top: 1px solid #dee2e6;
+      }
+
+      table thead th {
+        background-color: inherit;
+      }
+
+      .l-header {
+        z-index: 901;
+      }
+
+      .exit-disclaimer {
+        background-color: #aeb0b5;
+        border-radius: 3px;
+        color: #323a45 !important;
+        display: inline-block;
+        font-size: 88.2352941176%;
+        margin: 0 0.3333333333em;
+        padding: 0.0666666667em 0.4666666667em;
+        text-decoration: none;
+        text-transform: uppercase;
+      }
+
+      .back-to-top {
+        z-index: 2;
+      }
+
+      .js-glossary-search {
+        float: unset;
+      }
+
+      .unsupportedMessageContainer {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        top: 0;
+        z-index: 900;
+        display: none;
+      }
+
+      .unsupportedErrorBox {
+        padding: 1rem;
+        text-align: center;
+        border-color: #f5c6cb;
+        color: #721c24;
+        background-color: #f8d7da;
+      }
+
+      .unsupportedMessage {
+        margin-right: 1rem;
+      }
+
+      .unsupportedCloseButton {
+        position: absolute;
+        top: 0;
+        right: 0;
+        padding: 0;
+        border: none;
+        border-radius: 0;
+        width: 1.5rem;
+        height: 1.5rem;
+        color: white;
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+
+      .usa-banner__button:hover,
+      .usa-banner__button:focus {
+        background-color: inherit !important;
+        color: #1a4480 !important;
+      }
+
+      .highcharts-container *,
+      .visx-tooltip {
+        transition-property: opacity;
+      }
+
+      @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+        /* IE10 and IE11 styles */
+        .unsupportedMessageContainer {
+          display: block;
         }
-        if (M[1] === "Chrome") {
-          item = ua.match(/\b(Edg)\/(\d+)/);
-          if (item != null) {
-            item = item.slice(1);
-            return {
-              browserName: item[0].replace("Edg", "Edge"),
-              browserVersion: parseInt(item[1]) || 0,
-            };
-          }
+      }
+
+      @media screen {
+        main p {
+          margin-bottom: 0;
+          padding-bottom: 1.5em;
         }
+      }
+    </style>
 
-        M = M[2]
-          ? [M[1], M[2]]
-          : [navigator.appName, navigator.appVersion, "-?"];
-        if ((item = ua.match(/version\/(\d+)/i)) != null)
-          M.splice(1, 1, item[1]);
-
-        return {
-          browserName: M[0],
-          browserVersion: parseInt(M[1]) || 0,
-        };
-      })();
-
-      // fetch the supported browser list lookup file
-      const proxyUrl = `${origin}/proxy`;
-      const url = `${proxyUrl}?url=${origin}/data/config/supported-browsers.json`;
-      fetch(url)
-        .then((response) => {
-          if (response.status === 200) {
-            // parse the json
-            response.json().then((json) => {
-              let browserSupported = false;
-
-              // determine if the user's browser is supported
-              if (browserName === "Chrome" && browserVersion >= json.chrome) {
-                browserSupported = true;
-              }
-              if (browserName === "Firefox" && browserVersion >= json.firefox) {
-                browserSupported = true;
-              }
-              if (browserName === "Safari" && browserVersion >= json.safari) {
-                browserSupported = true;
-              }
-              if (browserName === "Edge" && browserVersion >= json.edge) {
-                browserSupported = true;
-              }
-
-              // hide/show the unsupported browser message
-              unsupportedMessage.style.display = browserSupported
-                ? "none"
-                : "block";
-            });
-          } else {
-            // show the unsupported browser message
-            unsupportedMessage.style.display = "block";
-          }
-        })
-        .catch((err) => {
-          console.error(err);
-
-          // show the unsupported browser message
-          unsupportedMessage.style.display = "block";
-        });
-    } else {
-      setTimeout(unsupportedBrowserMessage, 15);
-    }
-  }
-
-  // Allows the user to close the unsupported message.
-  function hideUnsupportedMessage() {
-    const unsupportedMessage = document.getElementById(
-      "unsupported-browser-message",
-    );
-    unsupportedMessage.style.display = "none";
-  }
-
-  unsupportedBrowserMessage();
-</script>
-<!-- Google Analytics -->
-<script>
-  // Prevent scroll restoration. This is used to avoid issues with browsers
-  // scrolling to odd positions after the page finishes loading
-  history.scrollRestoration = "manual";
-
-  function configureGoogleAnalytics(id, debug = false) {
-    const gaScript = document.createElement("script");
-    gaScript.async = 1;
-    gaScript.src = `//www.googletagmanager.com/gtag/js?id=${id}`;
-
-    const firstScript = document.getElementsByTagName("script")[0];
-    firstScript.parentNode.insertBefore(gaScript, firstScript);
-
-    window.dataLayer = window.dataLayer || [];
-    window.gtag =
-      window.gtag ||
-      function () {
-        dataLayer.push(arguments);
+    <!-- Set the page title dynamically -->
+    <script>
+      // map pathnames to a formatted title for SEO purposes
+      const pathnameMapping = {
+        default: "How's My Waterway - Home",
+        community: "How's My Waterway - Community",
+        'state-and-tribal': "How's My Waterway - State and Tribal",
+        state: "How's My Waterway - State",
+        tribe: "How's My Waterway - Tribe",
+        national: "How's My Waterway - National",
+        'waterbody-report': "How's My Waterway - Waterbody Report",
+        'plan-summary': "How's My Waterway - Plan Summary",
+        data: "How's My Waterway - Data",
+        about: "How's My Waterway - About",
+        swimming: "How's My Waterway - Explore - Swimming",
+        'eating-fish': "How's My Waterway - Explore - Eating Fish",
+        'aquatic-life': "How's My Waterway - Explore - Aquatic Life",
+        'drinking-water': "How's My Waterway - Explore - Drinking Water",
+        attains: "How's My Waterway - ATTAINS",
+        educators: "How's My Waterway - Educators",
+        'monitoring-report': "How's My Waterway - Water Monitoring Report",
       };
 
-    gtag("js", new Date());
+      const descriptionMapping = {
+        default:
+          'An application for learning the condition of local streams, lakes and other waters anywhere in the US... quickly and in plain language.',
+        community:
+          'Enter a location to learn about water quality in your community. Explore information about local stream conditions, watershed protection, restoration, drinking water and whether your waterways are suitable for swimming or eating fish and aquatic life.',
+        'state-and-tribal':
+          'Choose a state, tribe, or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites.',
+        state:
+          'Choose a state or territory to get the most recent information on water quality submitted to EPA, including success stories, documents, and links to organizational websites. Search for water conditions throughout your state with the advanced search tool.',
+        tribe:
+          'Choose a tribe to get the most recent information on water quality submitted to EPA, documents, and links to organizational websites.',
+        national:
+          'Explore information about overall water quality in the United State and the basics of EPA’s drinking water program.',
+        'waterbody-report':
+          'Use the waterbody report page to find information on individual waterbodies including uses, probable sources of impairments and plans to restore water quality. ',
+        'plan-summary':
+          'The restoration plan summary page includes basic plan information, submitted documents, impairments addressed, and waters covered. ',
+        educators:
+          'Find How’s My Waterway resources for educators including lesson plans and other materials.',
+        'monitoring-report':
+          'Use the water monitoring report page to find information on individual monitoring locations including historical data from the Water Quality Portal.',
+      };
 
-    const options = { ...(debug && { debug_mode: true }) };
-    gtag("config", id, options);
-  }
+      // update page title and description using mapping
+      function setPageTitle(pathnameMapping) {
+        const pageTitle = window.location.pathname.split('/')[1];
+        document.title = pathnameMapping[pageTitle] || pathnameMapping.default;
 
-  // get origin for mapping proxy calls
-  const loc = window.location;
-  const origin =
-    loc.hostname === "localhost"
-      ? `${loc.protocol}//${loc.hostname}:9091`
-      : loc.origin;
+        // remove old description tags if necessary
+        let oldDescTag = document.querySelector("[name='description']");
+        if (oldDescTag) oldDescTag.remove();
+        let oldDcDescTag = document.querySelector("[name='DC.description']");
+        if (oldDcDescTag) oldDcDescTag.remove();
 
-  // initialize the googleAnalyticsMapping window object so the calls to get
-  // the services lookup file are logged.
-  window.googleAnalyticsMapping = [
-    {
-      wildcardUrl: `${origin}/proxy?url=${origin}/data/config/services.json`,
-      name: "s3 lookup - config services",
-    },
-  ];
+        // create description tags
+        const descTag = document.createElement('meta');
+        descTag.setAttribute('name', 'description');
+        descTag.content =
+          descriptionMapping[pageTitle] || descriptionMapping.default;
+        document.getElementsByTagName('head')[0].appendChild(descTag);
 
-  // Configure analytics destinations.
-  let trackingId;
-  if (
-    window.location.hostname === 'mywaterway.epa.gov' ||
-    window.location.hostname === 'mywaterway-prod.app.cloud.gov'
-  ) {
-    //EPA (Production)
-    trackingId = "G-2SEC4V3SK9";
-    configureGoogleAnalytics(trackingId);
-  } else if (window.location.hostname === "mywaterway-stage.app.cloud.gov") {
-    // Stage
-    trackingId = "G-8ZG01NLPFL";
-    configureGoogleAnalytics(trackingId);
-  } else if (
-    window.location.hostname === "mywaterway-dev.app.cloud.gov" ||
-    window.location.hostname === "localhost"
-  ) {
-    // Dev
-    trackingId = "G-X6JSLPJCWP";
-    configureGoogleAnalytics(trackingId, true);
-  }
+        const dcDescTag = document.createElement('meta');
+        dcDescTag.setAttribute('name', 'DC.description');
+        dcDescTag.content =
+          descriptionMapping[pageTitle] || descriptionMapping.default;
+        document.getElementsByTagName('head')[0].appendChild(dcDescTag);
+      }
 
-  // Wrapper for logging to GA
-  function logToGa(name, parameters = {}) {
-    if (!window.gtag) return;
+      setPageTitle(pathnameMapping); // set page title when page loads
 
-    gtag("event", name, {
-      ...parameters,
-      ...(trackingId && { send_to: trackingId }),
-    });
-  }
-
-  function logErrorToGa(err, fatal = false) {
-    const description =
-      err instanceof Error ? `${err.name}:${err.message}:${err.stack}` : err;
-    window.logToGa("exception", {
-      description,
-      event_label: description,
-      fatal,
-    });
-  }
-
-  // create the locationChange event
-  const locationChangeEvent = new Event("locationchange");
-
-  // create the location change event listener
-  window.addEventListener("locationchange", function (event) {
-    logToGa("page_view", {
-      page_location: window.location,
-    });
-  });
-
-  // Modify the pushState, replaceState and popState events so they
-  // will trigger the locationchange event.
-  const pushState = history.pushState;
-  history.pushState = function () {
-    pushState.apply(history, arguments);
-    window.dispatchEvent(locationChangeEvent);
-  };
-  const replaceState = history.replaceState;
-  history.replaceState = function () {
-    replaceState.apply(this, arguments);
-    window.dispatchEvent(locationChangeEvent);
-  };
-  window.addEventListener("popstate", function () {
-    window.dispatchEvent(locationChangeEvent);
-  });
-
-  function wildcardIncludes(str, rule) {
-    const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\]\\])/g, "\\$1");
-    return new RegExp(
-      "^" + rule.split("*").map(escapeRegex).join(".*") + "$",
-    ).test(str);
-  }
-
-  window.addEventListener("click", function (event) {
-    //Button clicks
-    if (event.target.onclick && event.target.textContent) {
-      const text = event.target.textContent.trim();
-      const title = event.target.title.trim();
-
-      //Log to Google Analytics
-      const action = title
-        ? "ow-hmw2-" + text + " - " + title
-        : "ow-hmw2-" + text;
-      logToGa("button_click", {
-        event_action: action,
-        event_category: "buttonClick",
-        event_label: window.location.pathname,
+      // set page title when window location changes
+      window.addEventListener('locationchange', function (event) {
+        setPageTitle(pathnameMapping);
       });
-    }
+    </script>
 
-    //Link clicks
-    if (
-      event.target.tagName.toLowerCase() === "a" &&
-      event.target.target === "_blank"
-    ) {
-      const href = event.target.href;
+    <script>
+      /**
+       * This script is used for displaying a "browser unsupported"
+       * message. This script polls for the unsupported-browser-message
+       * div, when available it then checks the browser version and
+       * displays the message if necessary.
+       */
 
-      // combine the web service and map service mappings
-      const mapping = window.googleAnalyticsMapping;
-      let name = "";
-      mapping.forEach((item) => {
-        if (!name && wildcardIncludes(href, item.wildcardUrl)) {
-          name = item.name;
+      function unsupportedBrowserMessage() {
+        const unsupportedMessage = document.getElementById(
+          'unsupported-browser-message',
+        );
+
+        if (unsupportedMessage) {
+          // If fetch is supported, hide the unsupported browser message until
+          // we can get the supported browsers lookup file.
+          if ('fetch' in window) {
+            unsupportedMessage.style.display = 'none';
+          }
+
+          // Parse the user agent string to determine which browser the user is using.
+          const { browserName, browserVersion } = (function () {
+            const ua = navigator.userAgent;
+
+            let item;
+            let M =
+              ua.match(
+                /(opera|chrome|safari|firefox|edg|msie|trident(?=\/))\/?\s*(\d+)/i,
+              ) || [];
+            if (/trident/i.test(M[1])) {
+              item = /\brv[ :]+(\d+)/g.exec(ua) || [];
+              return {
+                browserName: 'IE',
+                browserVersion: parseInt(item[1]) || 0,
+              };
+            }
+            if (M[1] === 'Chrome') {
+              item = ua.match(/\b(Edg)\/(\d+)/);
+              if (item != null) {
+                item = item.slice(1);
+                return {
+                  browserName: item[0].replace('Edg', 'Edge'),
+                  browserVersion: parseInt(item[1]) || 0,
+                };
+              }
+            }
+
+            M = M[2]
+              ? [M[1], M[2]]
+              : [navigator.appName, navigator.appVersion, '-?'];
+            if ((item = ua.match(/version\/(\d+)/i)) != null)
+              M.splice(1, 1, item[1]);
+
+            return {
+              browserName: M[0],
+              browserVersion: parseInt(M[1]) || 0,
+            };
+          })();
+
+          // fetch the supported browser list lookup file
+          const proxyUrl = `${origin}/proxy`;
+          const url = `${proxyUrl}?url=${origin}/data/config/supported-browsers.json`;
+          fetch(url)
+            .then((response) => {
+              if (response.status === 200) {
+                // parse the json
+                response.json().then((json) => {
+                  let browserSupported = false;
+
+                  // determine if the user's browser is supported
+                  if (
+                    browserName === 'Chrome' &&
+                    browserVersion >= json.chrome
+                  ) {
+                    browserSupported = true;
+                  }
+                  if (
+                    browserName === 'Firefox' &&
+                    browserVersion >= json.firefox
+                  ) {
+                    browserSupported = true;
+                  }
+                  if (
+                    browserName === 'Safari' &&
+                    browserVersion >= json.safari
+                  ) {
+                    browserSupported = true;
+                  }
+                  if (browserName === 'Edge' && browserVersion >= json.edge) {
+                    browserSupported = true;
+                  }
+
+                  // hide/show the unsupported browser message
+                  unsupportedMessage.style.display = browserSupported
+                    ? 'none'
+                    : 'block';
+                });
+              } else {
+                // show the unsupported browser message
+                unsupportedMessage.style.display = 'block';
+              }
+            })
+            .catch((err) => {
+              console.error(err);
+
+              // show the unsupported browser message
+              unsupportedMessage.style.display = 'block';
+            });
+        } else {
+          setTimeout(unsupportedBrowserMessage, 15);
+        }
+      }
+
+      // Allows the user to close the unsupported message.
+      function hideUnsupportedMessage() {
+        const unsupportedMessage = document.getElementById(
+          'unsupported-browser-message',
+        );
+        unsupportedMessage.style.display = 'none';
+      }
+
+      unsupportedBrowserMessage();
+    </script>
+    <!-- Google Analytics -->
+    <script>
+      // Prevent scroll restoration. This is used to avoid issues with browsers
+      // scrolling to odd positions after the page finishes loading
+      history.scrollRestoration = 'manual';
+
+      function configureGoogleAnalytics(id, debug = false) {
+        const gaScript = document.createElement('script');
+        gaScript.async = 1;
+        gaScript.src = `//www.googletagmanager.com/gtag/js?id=${id}`;
+
+        const firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(gaScript, firstScript);
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag =
+          window.gtag ||
+          function () {
+            dataLayer.push(arguments);
+          };
+
+        gtag('js', new Date());
+
+        const options = { ...(debug && { debug_mode: true }) };
+        gtag('config', id, options);
+      }
+
+      // get origin for mapping proxy calls
+      const loc = window.location;
+      const origin =
+        loc.hostname === 'localhost'
+          ? `${loc.protocol}//${loc.hostname}:9091`
+          : loc.origin;
+
+      // initialize the googleAnalyticsMapping window object so the calls to get
+      // the services lookup file are logged.
+      window.googleAnalyticsMapping = [
+        {
+          wildcardUrl: `${origin}/proxy?url=${origin}/data/config/services.json`,
+          name: 's3 lookup - config services',
+        },
+      ];
+
+      // Configure analytics destinations.
+      let trackingId;
+      if (
+        window.location.hostname === 'mywaterway.epa.gov' ||
+        window.location.hostname === 'mywaterway-prod.app.cloud.gov'
+      ) {
+        //EPA (Production)
+        trackingId = 'G-2SEC4V3SK9';
+        configureGoogleAnalytics(trackingId);
+      } else if (
+        window.location.hostname === 'mywaterway-stage.app.cloud.gov'
+      ) {
+        // Stage
+        trackingId = 'G-8ZG01NLPFL';
+        configureGoogleAnalytics(trackingId);
+      } else if (
+        window.location.hostname === 'mywaterway-dev.app.cloud.gov' ||
+        window.location.hostname === 'localhost'
+      ) {
+        // Dev
+        trackingId = 'G-X6JSLPJCWP';
+        configureGoogleAnalytics(trackingId, true);
+      }
+
+      // Wrapper for logging to GA
+      function logToGa(name, parameters = {}) {
+        if (!window.gtag) return;
+
+        gtag('event', name, {
+          ...parameters,
+          ...(trackingId && { send_to: trackingId }),
+        });
+      }
+
+      function logErrorToGa(err, fatal = false) {
+        const description =
+          err instanceof Error
+            ? `${err.name}:${err.message}:${err.stack}`
+            : err;
+        window.logToGa('exception', {
+          description,
+          event_label: description,
+          fatal,
+        });
+      }
+
+      // create the locationChange event
+      const locationChangeEvent = new Event('locationchange');
+
+      // create the location change event listener
+      window.addEventListener('locationchange', function (event) {
+        logToGa('page_view', {
+          page_location: window.location,
+        });
+      });
+
+      // Modify the pushState, replaceState and popState events so they
+      // will trigger the locationchange event.
+      const pushState = history.pushState;
+      history.pushState = function () {
+        pushState.apply(history, arguments);
+        window.dispatchEvent(locationChangeEvent);
+      };
+      const replaceState = history.replaceState;
+      history.replaceState = function () {
+        replaceState.apply(this, arguments);
+        window.dispatchEvent(locationChangeEvent);
+      };
+      window.addEventListener('popstate', function () {
+        window.dispatchEvent(locationChangeEvent);
+      });
+
+      function wildcardIncludes(str, rule) {
+        const escapeRegex = (str) =>
+          str.replace(/([.*+?^=!:${}()|\]\\])/g, '\\$1');
+        return new RegExp(
+          '^' + rule.split('*').map(escapeRegex).join('.*') + '$',
+        ).test(str);
+      }
+
+      window.addEventListener('click', function (event) {
+        //Button clicks
+        if (event.target.onclick && event.target.textContent) {
+          const text = event.target.textContent.trim();
+          const title = event.target.title.trim();
+
+          //Log to Google Analytics
+          const action = title
+            ? 'ow-hmw2-' + text + ' - ' + title
+            : 'ow-hmw2-' + text;
+          logToGa('button_click', {
+            event_action: action,
+            event_category: 'buttonClick',
+            event_label: window.location.pathname,
+          });
+        }
+
+        //Link clicks
+        if (
+          event.target.tagName.toLowerCase() === 'a' &&
+          event.target.target === '_blank'
+        ) {
+          const href = event.target.href;
+
+          // combine the web service and map service mappings
+          const mapping = window.googleAnalyticsMapping;
+          let name = '';
+          mapping.forEach((item) => {
+            if (!name && wildcardIncludes(href, item.wildcardUrl)) {
+              name = item.name;
+            }
+          });
+          const action = 'ow-hmw2-' + (name || event.target.text.trim());
+
+          const extension = href.split('.').pop;
+          const category =
+            window.location.hostname === event.target.hostname
+              ? //Part of the HMW application
+                extension === '.pdf' || extension === '.zip'
+                ? 'Download'
+                : 'Internal'
+              : 'External'; //External EPA Hyperlink
+
+          //Log to Google Analytics
+          logToGa('link_click', {
+            event_action: action,
+            event_category: category,
+            event_label: href,
+          });
         }
       });
-      const action = "ow-hmw2-" + (name || event.target.text.trim());
 
-      const extension = href.split(".").pop;
-      const category =
-        window.location.hostname === event.target.hostname
-          ? //Part of the HMW application
-            extension === ".pdf" || extension === ".zip"
-            ? "Download"
-            : "Internal"
-          : "External"; //External EPA Hyperlink
+      window.addEventListener('error', function (event) {
+        if (
+          event.message ===
+            'ResizeObserver loop completed with undelivered notifications.' ||
+          event.message === 'ResizeObserver loop limit exceeded'
+        ) {
+          event.stopImmediatePropagation();
+          return;
+        }
+        window.logErrorToGa(event.error ?? event.message, true);
 
-      //Log to Google Analytics
-      logToGa("link_click", {
-        event_action: action,
-        event_category: category,
-        event_label: href,
+        return true;
       });
-    }
-  });
-
-  window.addEventListener("error", function (event) {
-    if (
-      event.message ===
-        "ResizeObserver loop completed with undelivered notifications." ||
-      event.message === "ResizeObserver loop limit exceeded"
-    ) {
-      event.stopImmediatePropagation();
-      return;
-    }
-    window.logErrorToGa(event.error ?? event.message, true);
-
-    return true;
-  });
-</script>
-<!-- End Google Analytics-->
-
+    </script>
+    <!-- End Google Analytics-->
   </head>
 
   <body class="" id="#top">
     <!-- Google Tag Manager -->
-    <noscript><iframe
+    <noscript
+      ><iframe
         title="google tag manager"
         src="//www.googletagmanager.com/ns.html?id=GTM-L8ZB"
         height="0"
         width="0"
         style="display: none; visibility: hidden"
-      ></iframe></noscript>
+      ></iframe
+    ></noscript>
     <!-- End Google Tag Manager -->
     <div class="skiplinks" role="navigation" aria-labelledby="skip-to-main">
       <a
         id="skip-to-main"
         href="#main-content"
         class="skiplinks__link visually-hidden focusable"
-      >Skip to main content</a>
+        >Skip to main content</a
+      >
     </div>
     <section
       class="usa-banner"
@@ -828,7 +849,8 @@
                   <br />
                   A
                   <strong>lock</strong>
-                  (<span class="icon-lock"><svg
+                  (<span class="icon-lock"
+                    ><svg
                       xmlns="http://www.w3.org/2000/svg"
                       width="52"
                       height="64"
@@ -843,7 +865,8 @@
                         fill="#000000"
                         fill-rule="evenodd"
                         d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
-                      ></path></svg></span>) or
+                      ></path></svg></span
+                  >) or
                   <strong>https://</strong>
                   means you’ve safely connected to the .gov website. Share
                   sensitive information only on official, secure websites.
@@ -1111,28 +1134,30 @@
                   <a
                     href="https://www.epa.gov/environmental-topics"
                     class="menu__link"
-                  >Environmental Topics</a>
+                    >Environmental Topics</a
+                  >
                 </li>
 
                 <li class="menu__item">
                   <a
                     href="https://www.epa.gov/laws-regulations"
                     class="menu__link"
-                  >Laws &amp; Regulations</a>
+                    >Laws &amp; Regulations</a
+                  >
                 </li>
 
                 <li class="menu__item">
                   <a
                     href="https://www.epa.gov/report-violation"
                     class="menu__link"
-                  >Report a Violation</a>
+                    >Report a Violation</a
+                  >
                 </li>
 
                 <li class="menu__item">
-                  <a
-                    href="https://www.epa.gov/aboutepa"
-                    class="menu__link"
-                  >About EPA</a>
+                  <a href="https://www.epa.gov/aboutepa" class="menu__link"
+                    >About EPA</a
+                  >
                 </li>
               </ul>
             </div>
@@ -1143,44 +1168,47 @@
 
     <main id="main-content" class="main" role="main" tabindex="-1">
       <noscript>You need to enable JavaScript to run this app.</noscript>
-<div id="unsupported-browser-message" class="unsupportedMessageContainer">
-  <div class="unsupportedErrorBox">
-    <div class="unsupportedMessage">
-      <strong
-        >You are using a browser that is not supported. How's My Waterway works
-        best on the latest versions of Chrome, Safari, Edge, or Firefox.</strong
-      >
-      <br />
-      How's My Waterway utilizes Esri's ArcGIS JavaScript API for advanced
-      mapping features, which are not supported by this browser. For more
-      information visit the following links:
-      <a
-        href="https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later"
-        >ArcGIS API for JavaScript System Requirements</a
-      >
-      and
-      <a
-        href="https://www.esri.com/arcgis-blog/products/arcgis/announcements/so-long-internet-explorer-11/"
-        target="_blank"
-        rel="noopener noreferrer"
-        >So Long Internet Explorer</a
-      >.
-      <a
-        class="exit-disclaimer"
-        href="https://www.epa.gov/home/exit-epa"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        EXIT
-      </a>
-    </div>
-    <button class="unsupportedCloseButton" onClick="hideUnsupportedMessage();">
-      x
-    </button>
-  </div>
-</div>
-<div id="root" role="presentation"></div>
-
+      <div id="unsupported-browser-message" class="unsupportedMessageContainer">
+        <div class="unsupportedErrorBox">
+          <div class="unsupportedMessage">
+            <strong
+              >You are using a browser that is not supported. How's My Waterway
+              works best on the latest versions of Chrome, Safari, Edge, or
+              Firefox.</strong
+            >
+            <br />
+            How's My Waterway utilizes Esri's ArcGIS JavaScript API for advanced
+            mapping features, which are not supported by this browser. For more
+            information visit the following links:
+            <a
+              href="https://developers.arcgis.com/javascript/latest/system-requirements/#:~:text=Supported%20browsers&text=Firefox%2093%20or%20later,Safari%2014%20or%20later"
+              >ArcGIS API for JavaScript System Requirements</a
+            >
+            and
+            <a
+              href="https://www.esri.com/arcgis-blog/products/arcgis/announcements/so-long-internet-explorer-11/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >So Long Internet Explorer</a
+            >.
+            <a
+              class="exit-disclaimer"
+              href="https://www.epa.gov/home/exit-epa"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              EXIT
+            </a>
+          </div>
+          <button
+            class="unsupportedCloseButton"
+            onClick="hideUnsupportedMessage();"
+          >
+            x
+          </button>
+        </div>
+      </div>
+      <div id="root" role="presentation"></div>
     </main>
 
     <footer class="footer" role="contentinfo">
@@ -1207,59 +1235,59 @@
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/planandbudget"
-                  class="menu__link"
-                >Budget &amp; Performance</a>
+                <a href="https://www.epa.gov/planandbudget" class="menu__link"
+                  >Budget &amp; Performance</a
+                >
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/contracts"
-                  class="menu__link"
-                >Contracting</a>
+                <a href="https://www.epa.gov/contracts" class="menu__link"
+                  >Contracting</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/home/wwwepagov-snapshots"
                   class="menu__link"
-                >EPA www Web Snapshot</a>
+                  >EPA www Web Snapshot</a
+                >
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/grants"
-                  class="menu__link"
-                >Grants</a>
+                <a href="https://www.epa.gov/grants" class="menu__link"
+                  >Grants</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/ocr/whistleblower-protections-epa-and-how-they-relate-non-disclosure-agreements-signed-epa"
                   class="menu__link"
-                >No FEAR Act Data</a>
+                  >No FEAR Act Data</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/web-policies-and-procedures/plain-writing"
                   class="menu__link"
-                >Plain Writing</a>
+                  >Plain Writing</a
+                >
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/privacy"
-                  class="menu__link"
-                >Privacy</a>
+                <a href="https://www.epa.gov/privacy" class="menu__link"
+                  >Privacy</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/privacy/privacy-and-security-notice"
                   class="menu__link"
-                >Privacy and Security Notice</a>
+                  >Privacy and Security Notice</a
+                >
               </li>
             </ul>
           </div>
@@ -1272,24 +1300,21 @@
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epaoig.gov"
-                  class="menu__link"
-                >Inspector General</a>
+                <a href="https://www.epaoig.gov" class="menu__link"
+                  >Inspector General</a
+                >
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/careers"
-                  class="menu__link"
-                >Jobs</a>
+                <a href="https://www.epa.gov/careers" class="menu__link"
+                  >Jobs</a
+                >
               </li>
 
               <li class="menu__item">
-                <a
-                  href="https://www.epa.gov/newsroom"
-                  class="menu__link"
-                >Newsroom</a>
+                <a href="https://www.epa.gov/newsroom" class="menu__link"
+                  >Newsroom</a
+                >
               </li>
 
               <li class="menu__item">
@@ -1308,11 +1333,13 @@
                 <a
                   href="https://www.epa.gov/newsroom/email-subscriptions-epa-news-releases"
                   class="menu__link"
-                >Subscribe</a>
+                  >Subscribe</a
+                >
               </li>
 
               <li class="menu__item">
-                <a href="https://www.usa.gov/" class="menu__link">USA.gov
+                <a href="https://www.usa.gov/" class="menu__link"
+                  >USA.gov
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
@@ -1323,8 +1350,8 @@
               </li>
 
               <li class="menu__item">
-                <a href="https://www.whitehouse.gov/" class="menu__link">White
-                  House
+                <a href="https://www.whitehouse.gov/" class="menu__link"
+                  >White House
                   <svg class="icon icon--exit is-spaced-before" role="img">
                     <title>Exit EPA's Website</title>
                     <use
@@ -1343,33 +1370,38 @@
                 <a
                   href="https://www.epa.gov/aboutepa/forms/contact-epa"
                   class="menu__link"
-                >Contact EPA</a>
+                  >Contact EPA</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/web-policies-and-procedures/epa-disclaimers"
                   class="menu__link"
-                >EPA Disclaimers</a>
+                  >EPA Disclaimers</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/aboutepa/epa-hotlines"
                   class="menu__link"
-                >Hotlines</a>
+                  >Hotlines</a
+                >
               </li>
 
               <li class="menu__item">
-                <a href="https://www.epa.gov/foia" class="menu__link">FOIA
-                  Requests</a>
+                <a href="https://www.epa.gov/foia" class="menu__link"
+                  >FOIA Requests</a
+                >
               </li>
 
               <li class="menu__item">
                 <a
                   href="https://www.epa.gov/aboutepa/frequent-questions-specific-epa-programstopics"
                   class="menu__link"
-                >Frequent Questions</a>
+                  >Frequent Questions</a
+                >
               </li>
             </ul>
 
@@ -1454,15 +1486,9 @@
       </svg>
     </a>
 
-    <script
-      src="%PUBLIC_URL%/epa-template-files/js/once.min.js"
-    ></script>
-    <script
-      src="%PUBLIC_URL%/epa-template-files/js/common.min.js"
-    ></script>
-    <script
-      src="%PUBLIC_URL%/epa-template-files/js/scripts.min.js"
-    ></script>
+    <script src="%PUBLIC_URL%/epa-template-files/js/once.min.js"></script>
+    <script src="%PUBLIC_URL%/epa-template-files/js/common.min.js"></script>
+    <script src="%PUBLIC_URL%/epa-template-files/js/scripts.min.js"></script>
     <!-- EPA template script mobile drawer fix -->
     <script>
       const searchButton = document.querySelector(
@@ -1483,32 +1509,31 @@
     </script>
     <!-- End EPA template script mobile drawer fix -->
     <style>
-  .l-header {
-    position: static;
-  }
+      .l-header {
+        position: static;
+      }
 
-  .external-link__tag {
-    font-size: 0.75rem;
-    padding: 0 0.5em;
-  }
+      .external-link__tag {
+        font-size: 0.75rem;
+        padding: 0 0.5em;
+      }
 
-  @media (min-width: 64em) {
-    nav.usa-nav--epa {
-      float: none;
-    }
-  }
-</style>
+      @media (min-width: 64em) {
+        nav.usa-nav--epa {
+          float: none;
+        }
+      }
+    </style>
 
-<script>
-  (function () {
-    var sz = document.createElement("script");
-    sz.type = "text/javascript";
-    sz.async = true;
-    sz.src = "//siteimproveanalytics.com/js/siteanalyze_38950.js";
-    var s = document.getElementsByTagName("script")[0];
-    s.parentNode.insertBefore(sz, s);
-  })();
-</script>
-
+    <script>
+      (function () {
+        var sz = document.createElement('script');
+        sz.type = 'text/javascript';
+        sz.async = true;
+        sz.src = '//siteimproveanalytics.com/js/siteanalyze_38950.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(sz, s);
+      })();
+    </script>
   </body>
 </html>

--- a/app/client/src/components/shared/ColumnChart.tsx
+++ b/app/client/src/components/shared/ColumnChart.tsx
@@ -91,7 +91,6 @@ function ColumnChart({
   yMax,
   zoomType,
 }: ColumnChartProps) {
-  console.log(JSON.stringify(series[0].zones));
   const options = useMemo<Highcharts.Options>(() => {
     return {
       caption: {

--- a/app/client/src/components/shared/ColumnChart.tsx
+++ b/app/client/src/components/shared/ColumnChart.tsx
@@ -91,6 +91,7 @@ function ColumnChart({
   yMax,
   zoomType,
 }: ColumnChartProps) {
+  console.log(JSON.stringify(series[0].zones));
   const options = useMemo<Highcharts.Options>(() => {
     return {
       caption: {
@@ -203,7 +204,8 @@ function ColumnChart({
                 },
                 title: {
                   style: {
-                    fontSize: baseFontSize,
+                    fontFamily: fonts.tertiary,
+                    fontSize: smallFontSize,
                   },
                 },
               },
@@ -215,7 +217,8 @@ function ColumnChart({
                 },
                 title: {
                   style: {
-                    fontSize: mediumFontSize,
+                    fontFamily: fonts.tertiary,
+                    fontSize: smallFontSize,
                   },
                 },
               },

--- a/app/client/src/components/shared/VisxGraph.tsx
+++ b/app/client/src/components/shared/VisxGraph.tsx
@@ -25,8 +25,8 @@ const DEFAULT_COLOR = '#2C2E43';
 */
 
 const axisTitleStyles = {
-  fontFamily: fonts.primary,
-  fontSize: '1rem',
+  fontFamily: fonts.tertiary,
+  fontSize: '0.85rem',
   fontWeight: 'bold',
 };
 

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -279,6 +279,13 @@ const buttonsContainer = css`
   }
 `;
 
+const slimTextBoxStyles = css`
+  ${textBoxStyles};
+
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+`;
+
 const buttonStyles = css`
   color: ${colors.white()};
   background-color: ${colors.blue()};
@@ -1670,7 +1677,7 @@ function CyanDailyContent({
           />
         )}
 
-        <div css={textBoxStyles}>
+        <div css={slimTextBoxStyles}>
           <ListContent
             rows={[
               {
@@ -2144,7 +2151,7 @@ function CyanContent({
 
   return (
     <>
-      <div css={textBoxStyles}>
+      <div css={slimTextBoxStyles}>
         <ListContent
           rows={[
             {

--- a/app/client/src/styles/index.ts
+++ b/app/client/src/styles/index.ts
@@ -83,6 +83,7 @@ export const iconStyles = css`
 export const fonts = {
   primary: `'Source Sans Pro Web', 'Helvetica Neue', 'Helvetica', 'Roboto', 'Arial', sans-serif`,
   secondary: `'Roboto Slab', serif`,
+  tertiary: `'Merriweather Web', Georgia, Cambria, 'Times New Roman'`,
 };
 
 export const groupHeadingStyles: CSSObjectWithLabel = {


### PR DESCRIPTION
## Related Issues:
* [HMW-724](https://jira.epa.gov/browse/HMW-724)

## Main Changes:
* Added a CSS rule for Highcharts graps to override a transition that is being set in `epa.css`. The transition was causing the CyAN charts tooltip text to drift from its container.
  * This change is in line 350 of `index.html`. All other changes in that file are due to running Prettier.
* Updated the `highcharts` package to fix a bug where "zones" were being dropped from the CyAN histogram, described in [this issue](https://github.com/highcharts/highcharts/issues/20613).
* Removed extra Y padding from two text boxes in the CyAN accordion content.
* Switched the axis title font for the Highcharts column charts and the Visx scatter/line graph (`Source Sans Pro Web` was rendering poorly).

## Steps To Test:
1. Navigate to the CyAN content of http://localhost:3000/community/lake%20mattamuskeet/monitoring. 
2. Verify the chart tooltips follow the mouse without drift, and the axis titles look appropriate.
3. Go to http://localhost:3000/monitoring-report/STORET/21NC03WQ/21NC03WQ-0208458892/ and repeat step 2.
4. Go to http://localhost:3000/state/FL/water-quality-overview, select the **Drinking Water** topic, and make sure the charts look as expected.