### PR TITLE
Bugfix/731 land cover scrunched

### DIFF
--- a/app/client/src/styles/mapStyles.css
+++ b/app/client/src/styles/mapStyles.css
@@ -47,6 +47,10 @@
   margin: unset;
 }
 
+.esri-legend__layer-cell--info:empty {
+  display: none;
+}
+
 .esri-print__header-title {
   font-size: 1.25em;
   font-weight: 500;


### PR DESCRIPTION
## Related Issues:
* [HMW-731](https://jira.epa.gov/browse/HMW-731)

## Main Changes:
* Fixed issue of land cover legend being scrunched.
  * I tried upgrading to the latest version of the ArcGIS JS API and that didn't fix it. This simple style change seemed to do the trick. It didn't break any of the legend items in HMW, including the suggested content in the add data widget. I also tested several layers from ArcGIS Online and they all seemed good.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/monitoring
2. Turn on the land cover layer
3. Verify it is no longer scrunched in the legend
4. Turn on other layers and verify they look good in the legend
5. Add layers via the add data widget and verify they look good in the legend
