### PR TITLE
Feature/717 search by monitor location

### DIFF
--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -305,7 +305,7 @@ function LocationSearch({ route, label }: Props) {
 
                   return res.codes.map(({ desc, value }) => ({
                     key: value,
-                    text: `${desc} (${value})`,
+                    text: `${desc ?? value} (${value})`,
                     sourceIndex,
                   }));
                 })

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -304,7 +304,7 @@ function LocationSearch({ route, label }: Props) {
                   const sourceIndex = searchWidget?.sources.findIndex(
                     (source) => source.name === 'Monitoring Locations',
                   );
-                  if (!sourceIndex) return [];
+                  if (!Number.isFinite(sourceIndex)) return [];
 
                   return res.codes.map((code) => ({
                     key: code.value,

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -285,7 +285,7 @@ function LocationSearch({ route, label }: Props) {
         type: 'webservice',
         name: 'Monitoring Location',
         menuHeaderExtra:
-          '(Below items open into the Monitoring Report page in a new tab)',
+          '(Below items open into the Monitoring Report page in a new browser tab)',
         placeholder: 'Search monitoring locations...',
         sources: [
           {
@@ -320,7 +320,7 @@ function LocationSearch({ route, label }: Props) {
         type: 'webservice',
         name: 'Waterbody',
         menuHeaderExtra:
-          '(Below items open into the Waterbody Report page in a new tab)',
+          '(Below items open into the Waterbody Report page in a new browser tab)',
         placeholder: 'Search waterbodies...',
         sources: [
           {

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2844,12 +2844,12 @@ function MonitoringLocationsContent({
                   <td>{groups[key].resultCount.toLocaleString()}</td>
                   <td>
                     <Modal
-                      label={`Detailed Uses for ${key}`}
+                      label={`Detailed Characteristics for ${key}`}
                       maxWidth="36em"
                       triggerElm={
                         <button
-                          aria-label={`View detailed uses for ${key}`}
-                          title={`View detailed uses for ${key}`}
+                          aria-label={`View detailed characteristics for ${key}`}
+                          title={`View detailed characteristics for ${key}`}
                           css={modifiedIconButtonStyles}
                           onClick={() => {
                             setSelectedGroupLabel(key);

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -1,4 +1,8 @@
 {
+  "expertQuery": {
+    "apiKey": "bNb8SnGYVFouUMF8SnIsQGwb3y5ywIhJBZXnrDy7",
+    "attains": "https://api.epa.gov/expertquery-dev/api/attains"
+  },
   "locatorUrl": "//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
   "wbd": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/6",
   "wbdUnconstrained": "https://gispub.epa.gov/arcgis/rest/services/OW/HydrologicUnits/MapServer/19",
@@ -71,6 +75,11 @@
     "url": "https://services9.arcgis.com/RHVPKKiFTONKtxq3/arcgis/rest/services/USA_Wildfires_v1/FeatureServer/"
   },
   "googleAnalyticsMapping": [
+    {
+      "urlLookup": "expertQuery.attains",
+      "wildcardUrl": "{urlLookup}/*",
+      "name": "expert query - attains"
+    },
     {
       "urlLookup": "attains.serviceUrl",
       "wildcardUrl": "{urlLookup}actions*",

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -20,6 +20,7 @@
   },
   "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/vocabs/name/HMW%20Glossary/terms/full",
   "waterQualityPortal": {
+    "domainValues": "https://www.waterqualitydata.us/Codes",
     "userInterface": "https://www.waterqualitydata.us/",
     "stationSearch": "https://www.waterqualitydata.us/data/Station/search?",
     "resultSearch": "https://www.waterqualitydata.us/data/Result/search?",
@@ -175,6 +176,12 @@
       "wildcardUrl": "{urlLookup}*",
       "name": "echodata - echo metadata"
     },
+    {
+      "urlLookup": "waterQualityPortal.domainValues",
+      "wildcardUrl": "{urlLookup}/*?mimeType=json",
+      "name": "wqp - domain values"
+    },
+
     {
       "urlLookup": "waterQualityPortal.monitoringLocation",
       "wildcardUrl": "{urlLookup}search?mimeType=geojson&zip=no&huc=*",


### PR DESCRIPTION
## Related Issues:
* [HMW-717](https://jira.epa.gov/browse/HMW-717)

## Main Changes:
* Added monitoring locations and waterbodies to the location search bar. When a suggestion is selected, the user is sent to either the Monitoring Report or the Waterbody Report page (in a new tab).

## Steps To Test:
1. Test searching for and navigating to monitoring locations.
2. Test searching for and navigating to waterbodies / assessment units.
3. Confirm the other search types still work as expected.

## TODO:
- [ ] Update the Expert Query URL and API key when the domain values service is available in production.
