### PR TITLE
HMW-691 Added 'advanced' param to WQP links

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.js
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.js
@@ -918,7 +918,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
     `${charGroupFilters}`;
 
   const portalUrl =
-    `${services.data.waterQualityPortal.userInterface}#huc=${huc12}` +
+    `${services.data.waterQualityPortal.userInterface}#advanced=true&huc=${huc12}` +
     `${charGroupFilters}&mimeType=xlsx&dataProfile=resultPhysChem` +
     `&providers=NWIS&providers=STEWARDS&providers=STORET`;
 

--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -1893,7 +1893,7 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
         );
       else queryPartial += `&${key}=${encodeURIComponent(value)}`;
       return query + queryPartial;
-    }, `${services.data.waterQualityPortal.userInterface}#dataProfile=resultPhysChem`);
+    }, `${services.data.waterQualityPortal.userInterface}#advanced=true&dataProfile=resultPhysChem`);
 
   if (checkboxes.all === Checkbox.indeterminate) {
     const selectedGroups = Object.values(checkboxes.groups)

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -2790,7 +2790,7 @@ function MonitoringLocationsContent({
     services?.status === 'success'
       ? `${services.data.waterQualityPortal.userInterface}#` +
         `siteid=${siteId}${charGroupFilters}` +
-        `&mimeType=xlsx&dataProfile=resultPhysChem` +
+        `&advanced=true&mimeType=xlsx&dataProfile=resultPhysChem` +
         `&providers=NWIS&providers=STEWARDS&providers=STORET`
       : null;
 


### PR DESCRIPTION
## Related Issues:
* [HMW-691](https://jira.epa.gov/browse/HMW-691)

## Main Changes:
* Added an `advanced=true` query argument to all links to WQP advanced search form.

## Steps To Test:
1. Test the _Advanced Filtering_ links on the [monitoring tab](http://localhost:3000/community/dc/monitoring) (two occurrences) and on the [monitoring report page](http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-01651770/) (one occurrence). They should drop the user directly to the advanced page of the WQP search form, with inputs pre-filled.