### PR TITLE
Feature/717 search by monitor location

### DIFF
--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -169,6 +169,7 @@ function LocationSearch({ route, label }: Props) {
   const { searchText, watershed, huc12 } = useContext(LocationSearchContext);
   const [searchWidget, setSearchWidget] = useState(null);
 
+  // Store the waterbody suggestions to avoid a second fetch.
   const waterbodySuggestions = useRef(null);
 
   const allPlaceholder = 'Search by address, zip code, or place...';

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -695,7 +695,7 @@ function LocationSearch({ route, label }: Props) {
                     setErrorMessage(webServiceErrorMessage);
                   });
               } else if (source.source.name === 'Waterbodies') {
-                const item = waterbodySuggestions.current.find(
+                const item = waterbodySuggestions.current?.find(
                   (wb) => wb.assessmentUnitId === result.key,
                 );
                 if (!item) {

--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -169,6 +169,8 @@ function LocationSearch({ route, label }: Props) {
   const { searchText, watershed, huc12 } = useContext(LocationSearchContext);
   const [searchWidget, setSearchWidget] = useState(null);
 
+  const waterbodySuggestions = useRef(null);
+
   const allPlaceholder = 'Search by address, zip code, or place...';
   const allSources = useMemo(
     () => [
@@ -329,7 +331,7 @@ function LocationSearch({ route, label }: Props) {
               return fetchPost(
                 `${services.data.expertQuery.attains}/assessmentUnits/values/assessmentUnitId`,
                 {
-                  additionalColumns: ['assessmentUnitName'],
+                  additionalColumns: ['assessmentUnitName', 'organizationId'],
                   direction: 'asc',
                   limit: maxSuggestions,
                   text: suggestTerm,
@@ -347,6 +349,8 @@ function LocationSearch({ route, label }: Props) {
                     console.error('Source "Waterbodies" not found');
                     return [];
                   }
+
+                  waterbodySuggestions.current = res;
 
                   return res.map(
                     ({ assessmentUnitId, assessmentUnitName }) => ({
@@ -690,40 +694,17 @@ function LocationSearch({ route, label }: Props) {
                     setErrorMessage(webServiceErrorMessage);
                   });
               } else if (source.source.name === 'Waterbodies') {
-                const url = `${services.data.expertQuery.attains}/assessmentUnits`;
-                fetchPost(
-                  url,
-                  {
-                    columns: [
-                      'assessmentUnitId',
-                      'organizationId',
-                      'reportingCycle',
-                    ],
-                    filters: {
-                      assessmentUnitId: [result.key],
-                    },
-                    options: { format: 'json' },
-                  },
-                  {
-                    'Content-Type': 'application/json',
-                    'X-Api-Key': services.data.expertQuery.apiKey,
-                  },
-                )
-                  .then((res) => {
-                    const item = res.data[0];
-                    if (!item) {
-                      setErrorMessage(webServiceErrorMessage);
-                      return;
-                    }
-                    const { assessmentUnitId, organizationId, reportingCycle } =
-                      item;
-                    formSubmit({
-                      target: `waterbody-report/${organizationId}/${assessmentUnitId}/${reportingCycle}`,
-                    });
-                  })
-                  .catch((_err) => {
-                    setErrorMessage(webServiceErrorMessage);
-                  });
+                const item = waterbodySuggestions.current.find(
+                  (wb) => wb.assessmentUnitId === result.key,
+                );
+                if (!item) {
+                  setErrorMessage(webServiceErrorMessage);
+                  return;
+                }
+                const { assessmentUnitId, organizationId } = item;
+                formSubmit({
+                  target: `waterbody-report/${organizationId}/${assessmentUnitId}`,
+                });
               } else {
                 // query to get the feature and search based on the centroid
                 const params = result.source.layer.createQuery();


### PR DESCRIPTION
## Related Issues:
* [HMW-717](https://jira.epa.gov/browse/HMW-717)

## Main Changes:
* Updated the waterbody suggestion click handler to use previously-fetched data rather than making a second call to Expert Query. This avoids the issue of zero results being returns if the assessment unit is not in the containing organization's latest reporting cycle.

## Steps To Test:
1. On the application's front page, search by the assessment unit ID `AK-20302-011`.
2. In the results that appear, select _Cooper Creek (AK-20302-011)_. Confirm the application opens a new tab to the correct waterbody report page.