### PR TITLE
Feature/749 old cycles waterbody report

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -686,6 +686,7 @@ function WaterbodyReport() {
     status: 'fetching',
     data: [],
   });
+  console.log(allReportingCycles);
   useEffect(() => {
     if (services.status !== 'success') return;
 
@@ -845,6 +846,10 @@ function WaterbodyReport() {
     waterbodyTypes,
   ]);
 
+  const otherReportingCycles = allReportingCycles.data.filter(
+    (year) => year !== parseInt(reportingCycleFetch.year),
+  );
+
   const infoBox = (
     <div css={boxStyles} ref={measuredRef}>
       <h3 css={infoBoxHeadingStyles}>
@@ -957,12 +962,9 @@ function WaterbodyReport() {
           reportingCycleFetch.status === 'success' && (
             <p>
               &nbsp;{' '}
-              {allReportingCycles.data.length > 0 ? (
+              {otherReportingCycles.length > 0 ? (
                 <>
-                  {allReportingCycles.data
-                    .filter(
-                      (year) => year !== parseInt(reportingCycleFetch.year),
-                    )
+                  {otherReportingCycles
                     .map((year) => (
                       <a
                         href={`/waterbody-report/${orgId}/${auId}/${year}`}

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -960,7 +960,9 @@ function WaterbodyReport() {
               {allReportingCycles.data.length > 0 ? (
                 <>
                   {allReportingCycles.data
-                    .filter((year) => year !== reportingCycleFetch.year)
+                    .filter(
+                      (year) => year !== parseInt(reportingCycleFetch.year),
+                    )
                     .map((year) => (
                       <a
                         href={`/waterbody-report/${orgId}/${auId}/${year}`}

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -1,7 +1,8 @@
 {
   "expertQuery": {
     "apiKey": "bNb8SnGYVFouUMF8SnIsQGwb3y5ywIhJBZXnrDy7",
-    "attains": "https://api.epa.gov/expertquery-dev/api/attains"
+    "attains": "https://api.epa.gov/expertquery-dev/api/attains",
+    "valuesLimit": 100
   },
   "locatorUrl": "//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
   "esriWebMapBase": "https://www.arcgis.com/sharing/rest/content/items",


### PR DESCRIPTION
## Related Issues:
* [HMW-749](https://jira.epa.gov/browse/HMW-749)

## Main Changes:
* Updated the "There is more recent data available" section at the top of the waterbody report page to use EQ's values service instead of the geospatial service.
* Added a "Other Years Reported" row below the current "Year Reported" row that contains a comma-delimited list of other reporting years for the waterbody, each of which is a hyperlink to the corresponding report.

## Steps To Test:
1. Go to http://localhost:3000/waterbody-report/AKDECWQ/AK-20302-011/2018.
2. Confirm the "more recent data available" banner is visible at the top of the page, with a hyperlink to the most recent reporting cycle, even though there is no map data.
3. Confirm the "Other Years Reported" row is populated with years that do not include the current report's year.
4. Go to http://localhost:3000/waterbody-report/CT_DEP01/CT2000-36_01.
5. Confirm "None" is shown for the value of the "Other Years Reported" row.
