### PR TITLE
Feature/693 add sitemap entries

### DIFF
--- a/app/client/public/sitemap.xml
+++ b/app/client/public/sitemap.xml
@@ -48,4 +48,16 @@
         <loc>https://mywaterway.epa.gov/educators</loc>
         <changefreq>weekly</changefreq>
     </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/monitoring-report/STORET/KIOWA_WQX/KIOWA_WQX-JMC</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/plan-summary/TDECWR/TN03150101_2020_ecoli</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/waterbody-report/TDECWR/TN03150101012_0100/2024</loc>
+        <changefreq>weekly</changefreq>
+    </url>
 </urlset>


### PR DESCRIPTION
## Related Issues:
* [HMW-693](https://jira.epa.gov/browse/HMW-693)

## Main Changes:
* Added three entries to `sitemap.xml`: one for the Waterbody Report page, one for the Plan Summary page, and one for the Monitoring Report page.

## Steps To Test:
1. For each of the new entries ([Monitoring Report](https://mywaterway.epa.gov/monitoring-report/STORET/KIOWA_WQX/KIOWA_WQX-JMC), [Plan Summary](https://mywaterway.epa.gov/plan-summary/TDECWR/TN03150101_2020_ecoli), [Waterbody Report](https://mywaterway.epa.gov/waterbody-report/TDECWR/TN03150101012_0100/2024)), make sure the page is representative of all, or most (some message boxes won't be shown), of the content possible for the page.
