### PR TITLE
Bugfix/751 search waterbody issue

### DIFF
--- a/app/client/src/components/shared/LocationSearch.js
+++ b/app/client/src/components/shared/LocationSearch.js
@@ -638,7 +638,7 @@ function LocationSearch({ route, label }: Props) {
       }
       const { assessmentUnitId, organizationId } = item;
       formSubmit({
-        target: `waterbody-report/${organizationId}/${assessmentUnitId}`,
+        target: `/waterbody-report/${organizationId}/${assessmentUnitId}`,
       });
 
       if (callback) callback(result.text);


### PR DESCRIPTION
## Related Issues:
* [HMW-761](https://jira.epa.gov/browse/HMW-761)

## Main Changes:
* Fixed issue of waterbody search not always redirecting to correct url.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Clear out the search menu
3. Type `shoal creek` in the search box
4. Select one of the waterbody search suggestions
5. Verify it correctly opens the waterbody report page
6. Navigate to http://localhost:3000/community
7. Repeat steps 3 - 5 

