### PR TITLE
Feature/599 increase chart granularity

### DIFF
--- a/app/client/src/components/pages/MonitoringReport.js
+++ b/app/client/src/components/pages/MonitoringReport.js
@@ -517,22 +517,6 @@ const treeStyles = (level, styles) => {
 
 const MAX_NUM_CHARTS = 4;
 const MEASUREMENT_PRECISION = 5;
-const TZ_CODE_TO_OFFSET = {
-  EDT: -4,
-  EST: -5,
-  AKDT: -8,
-  AKS: -9,
-  AST: -4,
-  CDT: -5,
-  CST: -6,
-  ChST: 10,
-  HST: -10,
-  MDT: -6,
-  MST: -7,
-  PDT: -7,
-  PST: -8,
-  SST: -11,
-};
 
 const Checkbox = {
   checked: 1,
@@ -569,7 +553,12 @@ function buildTooltip(unit) {
         : null;
     return (
       <div css={chartTooltipStyles}>
-        <p>{new Date(datum.x).toLocaleTimeString('en-US', dateOptions)}:</p>
+        <p>
+          {datum.x.includes('T') // If the x-axis is a date-time string rather than just a date
+            ? new Date(datum.x).toLocaleTimeString('en-US', dateOptions)
+            : new Date(datum.x).toLocaleDateString('en-US', dateOptions)}
+          :
+        </p>
         <p>
           <em>{datum.type === 'line' && 'Average '}Measurement</em>:{' '}
           {`${formatNumber(datum.y)} ${unit}`}
@@ -942,15 +931,6 @@ function useCharacteristics(provider, orgId, siteId, characteristicsByGroup) {
     let timestamp = record.ActivityStartDate;
     if (record['ActivityStartTime/Time']) {
       timestamp += `T${record['ActivityStartTime/Time']}`;
-      if (record['ActivityStartTime/TimeZoneCode']) {
-        const offset =
-          TZ_CODE_TO_OFFSET[record['ActivityStartTime/TimeZoneCode']];
-        if (offset !== undefined) {
-          timestamp += `${offset < 0 ? '-' : '+'}${Math.abs(offset).toString().padStart(2, '0')}:00`;
-        } else {
-          timestamp += 'Z';
-        }
-      }
     }
     return timestamp;
   };

--- a/app/client/src/components/shared/VisxGraph.tsx
+++ b/app/client/src/components/shared/VisxGraph.tsx
@@ -106,6 +106,7 @@ type VisxGraphProps = {
   pointData?: { [key: string]: Datum[] };
   pointsVisible?: boolean;
   range?: number[];
+  xTickFormat?: (val: number) => string;
   xTitle?: string;
   yScale?: 'log' | 'linear';
   yTickFormat?: (val: number) => string;
@@ -128,6 +129,7 @@ export function VisxGraph({
   pointData = {},
   pointsVisible = true,
   range,
+  xTickFormat = (val: number) => val.toLocaleString(),
   xTitle,
   yScale = 'linear',
   yTickFormat = (val: number) => val.toLocaleString(),
@@ -219,6 +221,7 @@ export function VisxGraph({
           numTicks={width ? Math.floor(width / 120) : 4}
           orientation="bottom"
           strokeWidth={2}
+          tickFormat={xTickFormat}
           tickLabelProps={{
             angle: 15,
             dx: -5,

--- a/app/client/src/components/shared/VisxGraph.tsx
+++ b/app/client/src/components/shared/VisxGraph.tsx
@@ -106,7 +106,7 @@ type VisxGraphProps = {
   pointData?: { [key: string]: Datum[] };
   pointsVisible?: boolean;
   range?: number[];
-  xTickFormat?: (val: number) => string;
+  xTickFormat?: (val: string | number) => string;
   xTitle?: string;
   yScale?: 'log' | 'linear';
   yTickFormat?: (val: number) => string;
@@ -129,7 +129,7 @@ export function VisxGraph({
   pointData = {},
   pointsVisible = true,
   range,
-  xTickFormat = (val: number) => val.toLocaleString(),
+  xTickFormat = (val: string | number) => val.toLocaleString(),
   xTitle,
   yScale = 'linear',
   yTickFormat = (val: number) => val.toLocaleString(),


### PR DESCRIPTION
## Related Issues:

- [HMW-599](https://jira.epa.gov/browse/HMW-599)

## Main Changes:

- On the **Monitoring Report** page, switched to using the date **AND** time for the x-axis instead of just the date. This affects how the points are "grouped": if measurements share the same x value, they are distinguished by their depth when viewing the scatterplot but averaged together when viewing the line graph. If no time is provided by the service, only the date is shown.

## Steps To Test:

1. Go to http://localhost:3000/monitoring-report/STORET/CBP_WQX/CBP_WQX-ANA21/.
2. ~~Verify that points taken at different times on the same day are not averaged in the line graph.~~ I haven't found a good example of measurements being taken at different times on the same day (will update if I do).
3. Verify that the timesliders still work as they did before.
4. Hover over the chart, and confirm the time is shown as well as the date.
5. Go to http://localhost:3000/monitoring-report/NWIS/USGS-KY/USGS-390435084345101/.
6. Hover over the chart for _Nitrate_, and confirm that only the date is shown.

## NOTE:

There is an `ActivityStartTime/TimeZoneCode` field as well. I initially started to take this into consideration, but decided against it because the time field is already inconsistently supplied, the time zone field is often inacurrate with regard to daylight savings time, and the time zone is not really relevant in the context of one location.