### PR TITLE
Feature/773 monitoring report timeseries

### DIFF
--- a/app/client/src/components/shared/VisxGraph.tsx
+++ b/app/client/src/components/shared/VisxGraph.tsx
@@ -63,9 +63,9 @@ const tickLabelStyles = {
 
 interface Datum {
   type: 'point' | 'line';
-  x: string;
+  x: number;
   y: number;
-  [meta: string]: string | number;
+  [meta: string]: unknown;
 }
 
 /*
@@ -92,8 +92,8 @@ const theme = buildChartTheme({
   tickLength: 8,
 });
 
-const xAccessor = (d: Datum) => d.x;
-const yAccessor = (d: Datum) => d.y;
+const xAccessor = (d: Datum) => d?.x;
+const yAccessor = (d: Datum) => d?.y;
 
 type VisxGraphProps = {
   buildTooltip?: (tooltipData?: TooltipData<Datum>) => ReactNode;
@@ -105,8 +105,7 @@ type VisxGraphProps = {
   pointColorAccessor?: (d: Datum, index: number) => string;
   pointData?: { [key: string]: Datum[] };
   pointsVisible?: boolean;
-  range?: number[];
-  xTickFormat?: (val: string | number) => string;
+  xTickFormat?: (val: number) => string;
   xTitle?: string;
   yScale?: 'log' | 'linear';
   yTickFormat?: (val: number) => string;
@@ -128,7 +127,6 @@ export function VisxGraph({
   pointColorAccessor,
   pointData = {},
   pointsVisible = true,
-  range,
   xTickFormat = (val: string | number) => val.toLocaleString(),
   xTitle,
   yScale = 'linear',
@@ -204,10 +202,14 @@ export function VisxGraph({
         height={height}
         margin={{ top: 20, bottom: 55, left: 100, right: 50 }}
         theme={theme}
-        xScale={{ type: 'band', paddingInner: 1, paddingOuter: 0.5 }}
+        xScale={{
+          type: 'linear',
+          paddingInner: 1,
+          paddingOuter: 0.5,
+          zero: false,
+        }}
         yScale={{
           type: yScale,
-          domain: range,
         }}
       >
         <Axis


### PR DESCRIPTION
## Related Issues:
* [HMW-773](https://jira.epa.gov/browse/HMW-773)

## Main Changes:
* Updated the chart on the **Monitoring Report** page to use a `linear` rather than `band` scale on the X-axis. Instead of passing string dates as the X values, the epoch timestamps are now used. This way, points are placed along the axis according to the magnitude of their values.

## Steps To Test:
1. Go to http://localhost:3000/monitoring-report/STORET/21AWIC/21AWIC-1171. This is a monitoring location with continuous data (i.e. it is tagged with the _EPACONTINUOUS_ project ID, as discussed at a recent meeting).
2. In the table of characteristics, select **Turbidity**.
3. Scroll to the chart. Confirm the data points are _not_ spaced evenly along the X axis (it may help to use the time slider to limit the years shown).
