### PR TITLE
Feature/779 drinking water zoom shifting

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.js
@@ -312,7 +312,8 @@ function DrinkingWater() {
     // zooming, so it can be reset when switching away from the subtab
     if (
       drinkingWaterTabIndex === providersTabIndex &&
-      mapZoom !== currentExtent
+      JSON.stringify(mapZoom?.toJSON()) !==
+        JSON.stringify(currentExtent?.toJSON())
     ) {
       setMapZoom(currentExtent);
       mapView.goTo(countyGraphic);

--- a/app/client/src/components/shared/AboutContent.js
+++ b/app/client/src/components/shared/AboutContent.js
@@ -9,10 +9,19 @@ import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { tabsStyles } from 'components/shared/ContentTabs';
 import { largeTabStyles } from 'components/shared/ContentTabs.LargeTab.js';
 // styles
+import { infoBoxStyles } from 'components/shared/MessageBoxes';
 import { fonts } from 'styles/index';
 
 const containerStyles = css`
   padding: 1rem;
+`;
+
+const modifiedInfoBoxStyles = css`
+  ${infoBoxStyles}
+  margin-top: 1rem;
+  h4 {
+    margin-bottom: 0.5em;
+  }
 `;
 
 const modifiedTabsStyles = css`
@@ -412,6 +421,18 @@ function AboutContent() {
             </TabPanel>
           </TabPanels>
         </Tabs>
+
+        <div css={modifiedInfoBoxStyles}>
+          For the latest changes in How's My Waterway, view our{' '}
+          <a
+            href="https://www.epa.gov/waterdata/hows-my-waterway-updates"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            update page
+          </a>
+          .
+        </div>
       </div>
     </div>
   );

--- a/app/client/src/components/shared/LocationMap.js
+++ b/app/client/src/components/shared/LocationMap.js
@@ -118,6 +118,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
     orphanFeatures,
     setOrphanFeatures,
     hucBoundaries,
+    atHucBoundaries,
     areasData,
     linesData,
     pointsData,
@@ -1267,6 +1268,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       boundariesLayer.graphics.removeAll();
       boundariesLayer.graphics.add(graphic);
       setHucBoundaries(graphic);
+      setAtHucBoundaries(false);
 
       // queryNonprofits(boundaries); // re-add when EPA approves RiverNetwork service for HMW
 
@@ -1320,6 +1322,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       getWildScenicRivers,
       handleMapServiceError,
       handleMapServices,
+      setAtHucBoundaries,
       setHucBoundaries,
       setStatesData,
       setWatershed,
@@ -1764,7 +1767,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   }, [searchText, setHuc12]);
 
   useEffect(() => {
-    if (!mapView || !hucBoundaries) {
+    if (!mapView || !hucBoundaries || atHucBoundaries) {
       return;
     }
 
@@ -1787,14 +1790,14 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       });
     }
   }, [
+    atHucBoundaries,
     getTemplate,
     getTitle,
-    mapView,
-    hucBoundaries,
-    boundariesLayer,
-    setCurrentExtent,
-    setAtHucBoundaries,
     homeWidget,
+    hucBoundaries,
+    mapView,
+    setAtHucBoundaries,
+    setCurrentExtent,
   ]);
 
   const [location, setLocation] = useState(null);


### PR DESCRIPTION
## Related Issues:
* [HMW-779](https://jira.epa.gov/browse/HMW-779)
* [HMW-780](https://jira.epa.gov/browse/HMW-780)

## Main Changes:
* Fixed issue of map shifting around on drinking water tab.
* Added an info message about the changelog to the bottom of the about page that.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/drinking-water
2. Verify the map zooms to the county once and doesn't shift around
3. Refresh and repeat step 2 a couple of times
4. Go to a different tab
5. Verify the map zooms to the huc
6. Navigate to http://localhost:3000/about
7. Verify there is a message at the bottom that links to the changelog page

