### PR TITLE
HMW-775 Updated 'checkClientRouteExists' to handle sub-paths

### DIFF
--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -2,26 +2,31 @@ const path = require('node:path');
 
 function checkClientRouteExists(req, res, next) {
   const clientRoutes = [
-    '/aquatic-life',
-    '/community',
-    '/drinking-water',
-    '/eating-fish',
-    '/national',
-    '/state-and-tribal',
-    '/swimming',
-    '/about',
-    '/data',
-    '/attains',
-    '/educators',
-    '/monitoring-report',
-    '/plan-summary',
-    '/waterbody-report',
-  ].reduce((acc, cur) => {
-    return acc.concat([`${cur}`, `${cur}/`]);
-  }, []);
-  clientRoutes.push('/');
+    'aquatic-life',
+    'community',
+    'drinking-water',
+    'eating-fish',
+    'national',
+    'state-and-tribal',
+    'swimming',
+    'about',
+    'data',
+    'attains',
+    'educators',
+    'monitoring-report',
+    'plan-summary',
+    'waterbody-report',
+  ];
 
-  if (!clientRoutes.includes(req.path)) {
+  if (
+    req.path !== '/' &&
+    !clientRoutes.some((route) => {
+      const head = '^\\/';
+      const tail = '(\\/.*)?$';
+      const regex = new RegExp(head + route + tail);
+      return regex.test(req.path);
+    })
+  ) {
     return res.status(404).sendFile(path.join(__dirname, 'public', '404.html'));
   }
 


### PR DESCRIPTION
## Related Issues:
* [HMW-775](https://jira.epa.gov/browse/HMW-775)

## Main Changes:
* Updated the server middleware `checkClientRouteExists` to accept sub-paths of the listed routes. Previously, the middleware checked for an exact match against the list.

## Steps To Test:
1. Go to http://localhost:9090/bogus. The 404 page should be displayed with the message "Sorry, but this web page does not exist".
2. Navigate to http://localhost:9090/community. The message "Unfortunately, this web application is not available at this time" should be displayed (i.e. **not** the 404 page).
3. Repeat the previous step for the other allowed routes.
4. Repeat the previous step with a slash added to the end.
5. Repeat the previous step with additional characters added to the end.