### PR TITLE
Feature/789 waterbody non existent cycle

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -257,6 +257,47 @@ function WaterbodyReport() {
     layer: null,
   });
 
+  function handleError() {
+    setAllParameterActionIds({
+      status: 'failure',
+      data: [],
+    });
+    setReportingCycleFetch({ status: 'failure', year: '' });
+    setWaterbodyStatus({ status: 'failure', data: [] });
+    setWaterbodyUses({ status: 'failure', data: [] });
+    setWaterbodySources({ status: 'failure', data: [] });
+    setDocuments({ status: 'failure', data: [] });
+    setOrganizationName({
+      status: 'failure',
+      name: '',
+    });
+  }
+
+  function handleNoAssessments() {
+    setWaterbodyStatus({
+      status: 'no-data',
+      data: { condition: '', planForRestoration: '', listed303d: '' },
+    });
+    setReportingCycleFetch({
+      status: 'success',
+      year: '',
+    });
+    setWaterbodyUses({
+      status: 'success',
+      data: [],
+    });
+    setOrganizationName({
+      status: 'success',
+      name: '',
+    });
+    setAllParameterActionIds({
+      status: 'success',
+      data: [],
+    });
+    setWaterbodySources({ status: 'success', data: [] });
+    setDocuments({ status: 'success', data: [] });
+  }
+
   // fetch waterbody name, location, types from attains 'assessmentUnits' web service
   useEffect(() => {
     const url =
@@ -358,6 +399,49 @@ function WaterbodyReport() {
     );
   }, [auId, configFiles, orgId]);
 
+  // get all reporting cycles for the waterbody
+  const [allReportingCycles, setAllReportingCycles] = useState({
+    status: 'fetching',
+    data: [],
+  });
+  useEffect(() => {
+    // recursive function to page through all reporting cycles
+    async function fetchCycles(acc = []) {
+      try {
+        const res = await fetchPost(
+          `${configFiles.data.services.expertQuery.attains}/assessmentUnits/values/reportingCycle`,
+          {
+            direction: 'asc',
+            filters: { assessmentUnitId: auId },
+            limit: configFiles.data.services.expertQuery.valuesLimit,
+            ...(acc.length > 0 && { comparand: acc[acc.length - 1] }),
+          },
+          {
+            'Content-Type': 'application/json',
+            'X-Api-Key': configFiles.data.services.expertQuery.apiKey,
+          },
+        );
+        const newValues = res.map((item) => item.reportingCycle);
+        if (
+          newValues.length === configFiles.data.services.expertQuery.valuesLimit
+        ) {
+          fetchCycles(acc.concat(newValues));
+        } else {
+          setAllReportingCycles({
+            status: 'success',
+            data: acc.concat(newValues),
+          });
+        }
+      } catch (err) {
+        console.error(err);
+        setAllReportingCycles({ status: 'failure', data: [] });
+        handleError();
+      }
+    }
+
+    fetchCycles();
+  }, [auId, configFiles]);
+
   const [reportingCycleFetch, setReportingCycleFetch] = useState({
     status: 'fetching',
     year: '',
@@ -394,6 +478,7 @@ function WaterbodyReport() {
   useEffect(() => {
     if (assessmentsCalled) return;
     if (!reportingCycle && mapLayer.status === 'fetching') return;
+    if (allReportingCycles.status !== 'success') return;
 
     let reportingCycleParam = '';
     if (reportingCycle) {
@@ -404,6 +489,12 @@ function WaterbodyReport() {
     ) {
       reportingCycleParam =
         mapLayer.layer.graphics.items[0].attributes.reportingcycle;
+    } else if (allReportingCycles.data.length > 0) {
+      reportingCycleParam =
+        allReportingCycles.data[allReportingCycles.data.length - 1];
+    } else {
+      handleNoAssessments();
+      return;
     }
 
     setAssessmentsCalled(true);
@@ -417,28 +508,7 @@ function WaterbodyReport() {
     fetchCheck(url).then(
       (res) => {
         if (res.items.length === 0) {
-          setWaterbodyStatus({
-            status: 'no-data',
-            data: { condition: '', planForRestoration: '', listed303d: '' },
-          });
-          setReportingCycleFetch({
-            status: 'success',
-            year: '',
-          });
-          setWaterbodyUses({
-            status: 'success',
-            data: [],
-          });
-          setOrganizationName({
-            status: 'success',
-            name: '',
-          });
-          setAllParameterActionIds({
-            status: 'success',
-            data: [],
-          });
-          setWaterbodySources({ status: 'success', data: [] });
-          setDocuments({ status: 'success', data: [] });
+          handleNoAssessments();
           return;
         }
 
@@ -664,64 +734,18 @@ function WaterbodyReport() {
       },
       (err) => {
         console.error(err);
-        setAllParameterActionIds({
-          status: 'failure',
-          data: [],
-        });
-        setReportingCycleFetch({ status: 'failure', year: '' });
-        setWaterbodyStatus({ status: 'failure', data: [] });
-        setWaterbodyUses({ status: 'failure', data: [] });
-        setWaterbodySources({ status: 'failure', data: [] });
-        setDocuments({ status: 'failure', data: [] });
-        setOrganizationName({
-          status: 'failure',
-          name: '',
-        });
+        handleError();
       },
     );
-  }, [auId, configFiles, orgId, reportingCycle, mapLayer, assessmentsCalled]);
-
-  // get all reporting cycles for the waterbody
-  const [allReportingCycles, setAllReportingCycles] = useState({
-    status: 'fetching',
-    data: [],
-  });
-  useEffect(() => {
-    // recursive function to page through all reporting cycles
-    async function fetchCycles(acc = []) {
-      try {
-        const res = await fetchPost(
-          `${configFiles.data.services.expertQuery.attains}/assessmentUnits/values/reportingCycle`,
-          {
-            direction: 'asc',
-            filters: { assessmentUnitId: auId },
-            limit: configFiles.data.services.expertQuery.valuesLimit,
-            ...(acc.length > 0 && { comparand: acc[acc.length - 1] }),
-          },
-          {
-            'Content-Type': 'application/json',
-            'X-Api-Key': configFiles.data.services.expertQuery.apiKey,
-          },
-        );
-        const newValues = res.map((item) => item.reportingCycle);
-        if (
-          newValues.length === configFiles.data.services.expertQuery.valuesLimit
-        ) {
-          fetchCycles(acc.concat(newValues));
-        } else {
-          setAllReportingCycles({
-            status: 'success',
-            data: acc.concat(newValues),
-          });
-        }
-      } catch (err) {
-        console.error(err);
-        setAllReportingCycles({ status: 'failure', data: [] });
-      }
-    }
-
-    fetchCycles();
-  }, [auId, configFiles]);
+  }, [
+    allReportingCycles,
+    auId,
+    configFiles,
+    orgId,
+    reportingCycle,
+    mapLayer,
+    assessmentsCalled,
+  ]);
 
   const [waterbodyActions, setWaterbodyActions] = useState({
     status: 'fetching',

--- a/app/client/src/components/pages/WaterbodyReport.js
+++ b/app/client/src/components/pages/WaterbodyReport.js
@@ -513,6 +513,11 @@ function WaterbodyReport() {
         }
 
         const firstItem = res.items[0];
+        if (firstItem.assessments.length === 0) {
+          handleNoAssessments();
+          return;
+        }
+
         setReportingCycleFetch({
           status: 'success',
           year: firstItem.reportingCycleText,

--- a/app/cypress/e2e/alert-message.cy.ts
+++ b/app/cypress/e2e/alert-message.cy.ts
@@ -83,7 +83,7 @@ describe('Alert message tests', () => {
   it('Verify notifications on the state page', () => {
     setupInterceptors();
 
-    cy.visit('/state/AL');
+    cy.visit('/state/AL/water-quality-overview');
 
     cy.wait(urlInterceptPath);
 

--- a/app/cypress/e2e/waterbody_report.cy.ts
+++ b/app/cypress/e2e/waterbody_report.cy.ts
@@ -35,8 +35,8 @@ describe('Waterbody Report page', () => {
   });
 
   it('For waterbodies without GIS data, display the "No map data is available" message', () => {
-    const orgId = '21GAEPD';
-    const auId = 'GAR_A-33_5_00';
+    const orgId = 'AKDECWQ';
+    const auId = 'AK-10102-001_00';
 
     cy.visit(`/waterbody-report/${orgId}/${auId}`);
 
@@ -82,7 +82,7 @@ describe('Waterbody Report page', () => {
   });
 
   it('Test waterbody report with empty attains assessments array', () => {
-    cy.visit('/waterbody-report/DOEE/DC_02_DCANA00E_02');
+    cy.visit('/waterbody-report/AKDECWQ/AK-10102-001_00');
 
     // wait for the web services to finish (attains/plans is sometimes slow)
     // the timeout chosen is the same timeout used for the attains/plans fetch
@@ -90,7 +90,7 @@ describe('Waterbody Report page', () => {
       'not.exist',
     );
 
-    cy.findAllByText('DC_02_DCANA00E_02').should('be.visible');
+    cy.findAllByText('AK-10102-001_00').should('be.visible');
   });
 
   it('Verify the maps height does not go below 400 pixels', () => {


### PR DESCRIPTION
## Related Issues:
* [HMW-789](https://jira.epa.gov/browse/HMW-789)

## Main Changes:
* Fixed issue of waterbody report page sometimes showing non existent reporting cycles. I also updated the assessments service check to check for items[0].assessments array having atleast 1 item. 
* Updated cypress tests for waterbody report. Our tests were running into a similar issue as defined by the ticket. The above changes fixed those items as well, but broke the cypress tests.

## Steps To Test:
1. Navigate to http://localhost:3000/waterbody-report/AKDECWQ/AK-10102-001_00
2. Verify it shows 2020 as the year reported, instead of 2022.
3. Test out the other years reported links
4. Navigate to http://localhost:3000/waterbody-report/AKDECWQ/AK-10102-001_00/2022
5. Verify it shows an error about that cycle not existing.

