### PR TITLE
Bugfix/802 add to client routes

### DIFF
--- a/app/client/public/sitemap.xml
+++ b/app/client/public/sitemap.xml
@@ -60,4 +60,12 @@
         <loc>https://mywaterway.epa.gov/waterbody-report/TDECWR/TN03150101012_0100/2024</loc>
         <changefreq>weekly</changefreq>
     </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/state/FL</loc>
+        <changefreq>weekly</changefreq>
+    </url>
+    <url>
+        <loc>https://mywaterway.epa.gov/tribe/PUEBLOOFTESUQUE</loc>
+        <changefreq>weekly</changefreq>
+    </url>
 </urlset>

--- a/app/server/app/middleware.js
+++ b/app/server/app/middleware.js
@@ -16,6 +16,8 @@ function checkClientRouteExists(req, res, next) {
     'monitoring-report',
     'plan-summary',
     'waterbody-report',
+    'state',
+    'tribe',
   ];
 
   if (


### PR DESCRIPTION
## Related Issues:
* [HMW-802](https://jira.epa.gov/browse/HMW-802)

## Main Changes:
* Added 'state' and 'tribe' to the list of allowed client routes.
* Added representative URLs for each page to the sitemap.

## Steps To Test:
1. Navigate directly to http://localhost:9090/state/CA. The message "Unfortunately, this web application is not available at this time" should be displayed (i.e. **not** the 404 page).
2. Repeat step one for http://localhost:9090/tribe/PUEBLOOFTESUQUE.