### PR TITLE
Feature/824 organization filter

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
@@ -30,6 +30,7 @@ import OrganizationsSelect from 'components/shared/OrganizationsSelect';
 import PastWaterConditionsFilters from 'components/shared/PastWaterConditionsFilters';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
+import TogglePanel from 'components/shared/TogglePanel';
 import ViewOnMapButton from 'components/shared/ViewOnMapButton';
 import VirtualizedList from 'components/shared/VirtualizedList';
 import WaterbodyInfo from 'components/shared/WaterbodyInfo';
@@ -860,16 +861,18 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                 </span>
               }
               extraListHeaderContent={
-                <div css={selectColumnStyles}>
-                  <CharacteristicsSelect
-                    selected={selectedCharacteristicOptions}
-                    onChange={setSelectedCharacteristicOptions}
-                  />
-                  <OrganizationsSelect
-                    selected={selectedOrganizationOptions}
-                    onChange={setSelectedOrganizationOptions}
-                  />
-                </div>
+                <TogglePanel defaultOpen title="Filter By:">
+                  <div css={selectColumnStyles}>
+                    <CharacteristicsSelect
+                      selected={selectedCharacteristicOptions}
+                      onChange={setSelectedCharacteristicOptions}
+                    />
+                    <OrganizationsSelect
+                      selected={selectedOrganizationOptions}
+                      onChange={setSelectedOrganizationOptions}
+                    />
+                  </div>
+                </TogglePanel>
               }
               onSortChange={handleSortChange}
               onExpandCollapse={handleExpandCollapse}

--- a/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
@@ -26,6 +26,7 @@ import {
   waterwayIcon,
 } from 'components/shared/MapLegend';
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
+import OrganizationsSelect from 'components/shared/OrganizationsSelect';
 import PastWaterConditionsFilters from 'components/shared/PastWaterConditionsFilters';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import Switch from 'components/shared/Switch';
@@ -53,6 +54,8 @@ import {
 } from 'config/errorMessages';
 // styles
 import { colors, tabLegendStyles, toggleTableStyles } from 'styles/index';
+// types
+import type { MonitoringLocationAttributes, Option } from 'types';
 
 /*
  * Styles
@@ -75,6 +78,13 @@ const modifiedErrorBoxStyles = css`
   ${errorBoxStyles};
   margin-bottom: 1em;
   text-align: center;
+`;
+
+const selectColumnStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
 `;
 
 const showLessMoreStyles = css`
@@ -592,7 +602,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
   const [
     locationsFilteredByCharcGroupAndTime,
     setLocationsFilteredByCharcGroupAndTime,
-  ] = useState([]);
+  ] = useState<MonitoringLocationAttributes[]>([]);
   const [sortBy, setSortBy] = useState('locationName');
 
   const sortedMonitoringLocations = useMemo(() => {
@@ -605,11 +615,21 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
     });
   }, [locationsFilteredByCharcGroupAndTime, sortBy]);
 
-  const [selectedCharacteristics, setSelectedCharacteristics] = useState([]);
+  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
+    useState<Readonly<Option[]>>([]);
+  const selectedCharacteristics = selectedCharacteristicOptions.map(
+    (opt) => opt.value,
+  );
+
+  const [selectedOrganizationOptions, setSelectedOrganizationOptions] =
+    useState<Readonly<Option[]>>([]);
+  const selectedOrganizations = selectedOrganizationOptions.map(
+    (option) => option.value,
+  );
 
   // Filter the displayed locations by selected characteristics
-  const filteredMonitoringLocations = sortedMonitoringLocations.filter(
-    (location) => {
+  const filteredMonitoringLocations = sortedMonitoringLocations
+    .filter((location) => {
       if (!selectedCharacteristics.length) {
         return true;
       }
@@ -617,8 +637,14 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
         if (selectedCharacteristics.includes(characteristic)) return true;
       }
       return false;
-    },
-  );
+    })
+    .filter((location) => {
+      if (!selectedOrganizations.length) {
+        return true;
+      }
+      if (selectedOrganizations.includes(location.orgId)) return true;
+      return false;
+    });
 
   const totalLocationsCount = monitoringGroups['All']?.stations.length;
   const displayedLocationsCount =
@@ -743,7 +769,7 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
   const [prevHuc12, setPrevHuc12] = useState(huc12);
   if (huc12 !== prevHuc12) {
     setPrevHuc12(huc12);
-    setSelectedCharacteristics([]);
+    setSelectedCharacteristicOptions([]);
   }
 
   if (monitoringLocations.status === 'pending') return <LoadingSpinner />;
@@ -834,10 +860,16 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                 </span>
               }
               extraListHeaderContent={
-                <CharacteristicsSelect
-                  selected={selectedCharacteristics}
-                  onChange={setSelectedCharacteristics}
-                />
+                <div css={selectColumnStyles}>
+                  <CharacteristicsSelect
+                    selected={selectedCharacteristicOptions}
+                    onChange={setSelectedCharacteristicOptions}
+                  />
+                  <OrganizationsSelect
+                    selected={selectedOrganizationOptions}
+                    onChange={setSelectedOrganizationOptions}
+                  />
+                </div>
               }
               onSortChange={handleSortChange}
               onExpandCollapse={handleExpandCollapse}

--- a/app/client/src/components/pages/Community.Tabs.Overview.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Overview.tsx
@@ -960,7 +960,10 @@ function MonitoringAndSensorsTab({
               }
               extraListHeaderContent={
                 monitoringLocationsDisplayed && (
-                  <TogglePanel defaultOpen title="Filter By:">
+                  <TogglePanel
+                    defaultOpen
+                    title="Filter Past Water Conditions By:"
+                  >
                     <div css={selectColumnStyles}>
                       <CharacteristicsSelect
                         selected={selectedCharacteristicOptions}

--- a/app/client/src/components/pages/Community.Tabs.Overview.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Overview.tsx
@@ -33,6 +33,7 @@ import {
 } from 'components/shared/KeyMetrics';
 import ShowLessMore from 'components/shared/ShowLessMore';
 import { tabsStyles } from 'components/shared/ContentTabs';
+import TogglePanel from 'components/shared/TogglePanel';
 import VirtualizedList from 'components/shared/VirtualizedList';
 // contexts
 import { useConfigFilesState } from 'contexts/ConfigFiles';
@@ -959,16 +960,18 @@ function MonitoringAndSensorsTab({
               }
               extraListHeaderContent={
                 monitoringLocationsDisplayed && (
-                  <div css={selectColumnStyles}>
-                    <CharacteristicsSelect
-                      selected={selectedCharacteristicOptions}
-                      onChange={setSelectedCharacteristicOptions}
-                    />
-                    <OrganizationsSelect
-                      selected={selectedOrganizationOptions}
-                      onChange={setSelectedOrganizationOptions}
-                    />
-                  </div>
+                  <TogglePanel defaultOpen title="Filter By:">
+                    <div css={selectColumnStyles}>
+                      <CharacteristicsSelect
+                        selected={selectedCharacteristicOptions}
+                        onChange={setSelectedCharacteristicOptions}
+                      />
+                      <OrganizationsSelect
+                        selected={selectedOrganizationOptions}
+                        onChange={setSelectedOrganizationOptions}
+                      />
+                    </div>
+                  </TogglePanel>
                 )
               }
               onSortChange={handleSortChange}

--- a/app/client/src/components/pages/Community.Tabs.Overview.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Overview.tsx
@@ -18,6 +18,7 @@ import {
   squareIcon,
   waterwayIcon,
 } from 'components/shared/MapLegend';
+import OrganizationsSelect from 'components/shared/OrganizationsSelect';
 import Switch from 'components/shared/Switch';
 import WaterbodyList from 'components/shared/WaterbodyList';
 import TabErrorBoundary from 'components/shared/ErrorBoundary.TabErrorBoundary';
@@ -58,6 +59,8 @@ import {
 } from 'config/errorMessages';
 // styles
 import { colors, tabLegendStyles, toggleTableStyles } from 'styles/index';
+// types
+import type { Option } from 'types';
 
 const containerStyles = css`
   @media (min-width: 960px) {
@@ -91,6 +94,13 @@ const centeredTextStyles = css`
 
 const accordionContentStyles = css`
   padding: 0.4375em 0.875em 0.875em;
+`;
+
+const selectColumnStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
 `;
 
 const showLessMoreStyles = css`
@@ -460,7 +470,17 @@ function MonitoringAndSensorsTab({
     },
   );
 
-  const [selectedCharacteristics, setSelectedCharacteristics] = useState([]);
+  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
+    useState<Readonly<Option[]>>([]);
+  const selectedCharacteristics = selectedCharacteristicOptions.map(
+    (option) => option.value,
+  );
+
+  const [selectedOrganizationOptions, setSelectedOrganizationOptions] =
+    useState<Readonly<Option[]>>([]);
+  const selectedOrganizations = selectedOrganizationOptions.map(
+    (option) => option.value,
+  );
 
   const filteredMonitoringAndSensors = sortedMonitoringAndSensors
     .filter((item) => {
@@ -490,6 +510,16 @@ function MonitoringAndSensorsTab({
       for (let characteristic of Object.keys(item.totalsByCharacteristic)) {
         if (selectedCharacteristics.includes(characteristic)) return true;
       }
+      return false;
+    })
+    .filter((item) => {
+      if (
+        item.monitoringType !== 'Past Water Conditions' ||
+        !selectedOrganizations.length
+      ) {
+        return true;
+      }
+      if (selectedOrganizations.includes(item.orgId)) return true;
       return false;
     });
 
@@ -705,7 +735,7 @@ function MonitoringAndSensorsTab({
   const [prevHuc12, setPrevHuc12] = useState(huc12);
   if (huc12 !== prevHuc12) {
     setPrevHuc12(huc12);
-    setSelectedCharacteristics([]);
+    setSelectedCharacteristicOptions([]);
   }
   if (
     cyanWaterbodiesStatus === 'failure' &&
@@ -929,10 +959,16 @@ function MonitoringAndSensorsTab({
               }
               extraListHeaderContent={
                 monitoringLocationsDisplayed && (
-                  <CharacteristicsSelect
-                    selected={selectedCharacteristics}
-                    onChange={setSelectedCharacteristics}
-                  />
+                  <div css={selectColumnStyles}>
+                    <CharacteristicsSelect
+                      selected={selectedCharacteristicOptions}
+                      onChange={setSelectedCharacteristicOptions}
+                    />
+                    <OrganizationsSelect
+                      selected={selectedOrganizationOptions}
+                      onChange={setSelectedOrganizationOptions}
+                    />
+                  </div>
                 )
               }
               onSortChange={handleSortChange}

--- a/app/client/src/components/shared/Accordion.tsx
+++ b/app/client/src/components/shared/Accordion.tsx
@@ -149,6 +149,12 @@ function AccordionList({
       {(includeSort || title || contentExpandCollapse || !expandDisabled) && (
         <div css={listHeaderStyles(includeSort || !!title)}>
           {title && !displayTitleInFlex && <p css={titleStyles}>{title}</p>}
+          {extraListHeaderContent && (
+            <>
+              <hr />
+              {extraListHeaderContent}
+            </>
+          )}
           <div css={columnsStyles}>
             <div
               css={accordionOptionsContainerStyles(
@@ -198,12 +204,6 @@ function AccordionList({
               )}
             </div>
           </div>
-          {extraListHeaderContent && (
-            <>
-              <hr />
-              {extraListHeaderContent}
-            </>
-          )}
         </div>
       )}
 

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -1,16 +1,12 @@
 /** @jsxImportSource @emotion/react */
 
 import { useContext, useMemo } from 'react';
-import { css } from '@emotion/react';
 // components
-import { GlossaryTerm } from 'components/shared/GlossaryPanel';
-import PaginatedSelect from 'components/shared/PaginatedSelect';
+import { CountSelect } from 'components/shared/CountSelect';
 // contexts
 import { LocationSearchContext } from 'contexts/locationSearch';
 // utils
 import { useMonitoringLocations } from 'utils/hooks';
-// styles
-import { groupHeadingStyles } from 'styles/index';
 // types
 import type { Option } from 'types';
 
@@ -42,72 +38,25 @@ export function CharacteristicsSelect({
         );
       });
     });
-    return [
-      {
-        label: 'Group',
-        options: Object.entries(uniqueCharacteristics)
-          .map(([key, value]) => ({
-            label: key,
-            value: key,
-            count: value.size,
-          }))
-          .sort((a, b) => a.label.localeCompare(b.label)),
-      },
-    ];
+    return Object.entries(uniqueCharacteristics)
+      .map(([key, value]) => ({
+        label: key,
+        value: key,
+        count: value.size,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, [monitoringPeriodOfRecordStatus, monitoringLocations]);
 
-  const displayedSelected = selected.map((option) => ({
-    label: option.label,
-    value: option.value,
-  }));
-
   return (
-    <div css={selectContainerStyles}>
-      <span css={selectLabelStyles}>
-        Filter by{' '}
-        <GlossaryTerm term="Characteristics">Characteristics</GlossaryTerm>:
-      </span>
-      <PaginatedSelect
-        aria-label="Filter by Characteristics"
-        formatGroupLabel={formatGroupLabel}
-        formatOptionLabel={formatOptionLabel}
-        isDisabled={monitoringPeriodOfRecordStatus === 'failure'}
-        isLoading={monitoringPeriodOfRecordStatus === 'pending'}
-        onChange={onChange}
-        options={allCharacteristicOptions}
-        placeholder="Select one or more characteristics..."
-        styles={{
-          groupHeading: (defaultStyles) => ({
-            ...defaultStyles,
-            ...groupHeadingStyles,
-            padding: 0,
-            color: '#000',
-            backgroundColor: '#fff',
-          }),
-          option: (defaultStyles) => ({ ...defaultStyles, padding: 0 }),
-        }}
-        value={displayedSelected}
-      />
-    </div>
-  );
-}
-
-function formatGroupLabel() {
-  return (
-    <div css={gridHeaderStyles}>
-      <div>Characteristic</div>
-      <div># of Locations with Characteristic</div>
-    </div>
-  );
-}
-
-function formatOptionLabel(option: Option) {
-  if (!option.count) return option.label;
-  return (
-    <div css={gridStyles}>
-      <div>{option.label}</div>
-      <div>{option.count}</div>
-    </div>
+    <CountSelect
+      countLabel="Locations with Characteristic"
+      glossaryTerm="Characteristics"
+      label="characteristic"
+      onChange={onChange}
+      options={allCharacteristicOptions}
+      selected={selected}
+      status={monitoringPeriodOfRecordStatus}
+    />
   );
 }
 
@@ -115,39 +64,5 @@ type CharacteristicsSelectProps = {
   selected: Readonly<Option[]>;
   onChange: (selected: Readonly<Option[]>) => void;
 };
-
-const gridStyles = css`
-  display: grid;
-  grid-template-columns: repeat(2, 75% 25%);
-
-  div {
-    display: flex;
-    align-items: center;
-    padding: 8px 12px;
-  }
-
-  div:last-of-type {
-    text-align: right;
-    justify-content: flex-end;
-  }
-`;
-
-const gridHeaderStyles = css`
-  ${gridStyles}
-
-  border-bottom: 2px solid #dee2e6;
-  font-weight: bold;
-`;
-
-const selectContainerStyles = css`
-  width: 100%;
-`;
-
-const selectLabelStyles = css`
-  display: inline-block;
-  margin-bottom: 0.25rem;
-  font-size: 0.875rem;
-  font-weight: bold;
-`;
 
 export default CharacteristicsSelect;

--- a/app/client/src/components/shared/CharacteristicsSelect.tsx
+++ b/app/client/src/components/shared/CharacteristicsSelect.tsx
@@ -11,8 +11,9 @@ import { LocationSearchContext } from 'contexts/locationSearch';
 import { useMonitoringLocations } from 'utils/hooks';
 // styles
 import { groupHeadingStyles } from 'styles/index';
+// types
+import type { Option } from 'types';
 
-export default CharacteristicsSelect;
 export function CharacteristicsSelect({
   selected,
   onChange,
@@ -55,9 +56,10 @@ export function CharacteristicsSelect({
     ];
   }, [monitoringPeriodOfRecordStatus, monitoringLocations]);
 
-  const selectedOptions = useMemo(() => {
-    return selected.map((s) => ({ label: s, value: s }));
-  }, [selected]);
+  const displayedSelected = selected.map((option) => ({
+    label: option.label,
+    value: option.value,
+  }));
 
   return (
     <div css={selectContainerStyles}>
@@ -71,7 +73,7 @@ export function CharacteristicsSelect({
         formatOptionLabel={formatOptionLabel}
         isDisabled={monitoringPeriodOfRecordStatus === 'failure'}
         isLoading={monitoringPeriodOfRecordStatus === 'pending'}
-        onChange={(options) => onChange(options.map((option) => option.value))}
+        onChange={onChange}
         options={allCharacteristicOptions}
         placeholder="Select one or more characteristics..."
         styles={{
@@ -84,7 +86,7 @@ export function CharacteristicsSelect({
           }),
           option: (defaultStyles) => ({ ...defaultStyles, padding: 0 }),
         }}
-        value={selectedOptions}
+        value={displayedSelected}
       />
     </div>
   );
@@ -99,7 +101,7 @@ function formatGroupLabel() {
   );
 }
 
-function formatOptionLabel(option: OptionType) {
+function formatOptionLabel(option: Option) {
   if (!option.count) return option.label;
   return (
     <div css={gridStyles}>
@@ -110,14 +112,8 @@ function formatOptionLabel(option: OptionType) {
 }
 
 type CharacteristicsSelectProps = {
-  selected: string[];
-  onChange: (selected: string[]) => void;
-};
-
-type OptionType = {
-  count?: number;
-  label: string;
-  value: string;
+  selected: Readonly<Option[]>;
+  onChange: (selected: Readonly<Option[]>) => void;
 };
 
 const gridStyles = css`
@@ -153,3 +149,5 @@ const selectLabelStyles = css`
   font-size: 0.875rem;
   font-weight: bold;
 `;
+
+export default CharacteristicsSelect;

--- a/app/client/src/components/shared/CountSelect.tsx
+++ b/app/client/src/components/shared/CountSelect.tsx
@@ -1,0 +1,137 @@
+/** @jsxImportSource @emotion/react */
+
+import { useMemo } from 'react';
+import { css } from '@emotion/react';
+// components
+import { GlossaryTerm } from 'components/shared/GlossaryPanel';
+import PaginatedSelect from 'components/shared/PaginatedSelect';
+// styles
+import { groupHeadingStyles } from 'styles/index';
+// types
+import type { FetchStatus, Option } from 'types';
+// utils
+import { titleCase } from 'utils/utils';
+
+const gridStyles = css`
+  display: grid;
+  grid-template-columns: repeat(2, 75% 25%);
+
+  div {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+  }
+
+  div:last-of-type {
+    text-align: right;
+    justify-content: flex-end;
+  }
+`;
+
+const gridHeaderStyles = css`
+  ${gridStyles}
+
+  border-bottom: 2px solid #dee2e6;
+  font-weight: bold;
+`;
+
+const selectContainerStyles = css`
+  width: 100%;
+`;
+
+const selectLabelStyles = css`
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+`;
+
+function formatGroupLabel(label: string, countLabel: string) {
+  return () => (
+    <div css={gridHeaderStyles}>
+      <div>{titleCase(label)}</div>
+      <div># of {countLabel}</div>
+    </div>
+  );
+}
+
+function formatOptionLabel(option: Option) {
+  if (!option.count) return option.label;
+  return (
+    <div css={gridStyles}>
+      <div>{option.label}</div>
+      <div>{option.count}</div>
+    </div>
+  );
+}
+
+export function CountSelect({
+  countLabel,
+  glossaryTerm,
+  label,
+  onChange,
+  options,
+  selected,
+  status,
+}: Readonly<CountSelectProps>) {
+  const groupedOptions = useMemo(() => {
+    return [
+      {
+        label: 'Group',
+        options,
+      },
+    ];
+  }, [options]);
+
+  const displayedSelected = selected.map((option) => ({
+    label: option.label,
+    value: option.value,
+  }));
+
+  return (
+    <div css={selectContainerStyles}>
+      <span css={selectLabelStyles}>
+        Filter by{' '}
+        {glossaryTerm ? (
+          <GlossaryTerm term={glossaryTerm}>{titleCase(label)}s</GlossaryTerm>
+        ) : (
+          `${titleCase(label)}s`
+        )}
+        :
+      </span>
+      <PaginatedSelect
+        aria-label={`Filter by ${titleCase(label)}s`}
+        formatGroupLabel={formatGroupLabel(label, countLabel)}
+        formatOptionLabel={formatOptionLabel}
+        isDisabled={status === 'failure'}
+        isLoading={status === 'pending'}
+        onChange={onChange}
+        options={groupedOptions}
+        placeholder={`Select one or more ${label}s...`}
+        styles={{
+          groupHeading: (defaultStyles) => ({
+            ...defaultStyles,
+            ...groupHeadingStyles,
+            padding: 0,
+            color: '#000',
+            backgroundColor: '#fff',
+          }),
+          option: (defaultStyles) => ({ ...defaultStyles, padding: 0 }),
+        }}
+        value={displayedSelected}
+      />
+    </div>
+  );
+}
+
+type CountSelectProps = {
+  countLabel: string;
+  glossaryTerm?: string;
+  label: string;
+  onChange: (selected: Readonly<Option[]>) => void;
+  options: Readonly<Option[]>;
+  selected: Readonly<Option[]>;
+  status: FetchStatus;
+};
+
+export default CountSelect;

--- a/app/client/src/components/shared/OrganizationsSelect.tsx
+++ b/app/client/src/components/shared/OrganizationsSelect.tsx
@@ -1,0 +1,139 @@
+/** @jsxImportSource @emotion/react */
+
+import { useMemo } from 'react';
+import { css } from '@emotion/react';
+// components
+import PaginatedSelect from 'components/shared/PaginatedSelect';
+// utils
+import { useMonitoringLocations } from 'utils/hooks';
+// styles
+import { groupHeadingStyles } from 'styles/index';
+// types
+import type { Option } from 'types';
+
+const gridStyles = css`
+  display: grid;
+  grid-template-columns: repeat(2, 75% 25%);
+
+  div {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+  }
+
+  div:last-of-type {
+    text-align: right;
+    justify-content: flex-end;
+  }
+`;
+
+const gridHeaderStyles = css`
+  ${gridStyles}
+
+  border-bottom: 2px solid #dee2e6;
+  font-weight: bold;
+`;
+
+const selectContainerStyles = css`
+  width: 100%;
+`;
+
+const selectLabelStyles = css`
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+`;
+
+function formatGroupLabel() {
+  return (
+    <div css={gridHeaderStyles}>
+      <div>Organization</div>
+      <div># of Locations in Organization</div>
+    </div>
+  );
+}
+
+function formatOptionLabel(option: Option) {
+  if (!option.count) return option.label;
+  return (
+    <div css={gridStyles}>
+      <div>{option.label}</div>
+      <div>{option.count}</div>
+    </div>
+  );
+}
+
+export function OrganizationsSelect({
+  selected,
+  onChange,
+}: Readonly<OrganizationsSelectProps>) {
+  const { monitoringLocations, monitoringLocationsStatus } =
+    useMonitoringLocations();
+
+  const organizationOptions = useMemo(() => {
+    if (monitoringLocationsStatus !== 'success') return [];
+
+    return [
+      {
+        label: 'Group',
+        options: Object.values(
+          monitoringLocations.reduce<Record<string, Option>>(
+            (acc, location) => {
+              if (!acc.hasOwnProperty(location.orgId)) {
+                acc[location.orgId] = {
+                  label: location.orgName,
+                  value: location.orgId,
+                  count: 1,
+                };
+              } else {
+                acc[location.orgId].count!++;
+              }
+              return acc;
+            },
+            {},
+          ),
+        ).sort((a, b) => a.label.localeCompare(b.label)),
+      },
+    ];
+  }, [monitoringLocations]);
+
+  const displayedSelected = selected.map((option) => ({
+    label: option.label,
+    value: option.value,
+  }));
+
+  return (
+    <div css={selectContainerStyles}>
+      <span css={selectLabelStyles}>Filter by Organizations:</span>
+      <PaginatedSelect
+        aria-label="Filter by Organizations"
+        formatGroupLabel={formatGroupLabel}
+        formatOptionLabel={formatOptionLabel}
+        isDisabled={monitoringLocationsStatus === 'failure'}
+        isLoading={monitoringLocationsStatus === 'pending'}
+        onChange={onChange}
+        options={organizationOptions}
+        placeholder="Select one or more organizations..."
+        styles={{
+          groupHeading: (defaultStyles) => ({
+            ...defaultStyles,
+            ...groupHeadingStyles,
+            padding: 0,
+            color: '#000',
+            backgroundColor: '#fff',
+          }),
+          option: (defaultStyles) => ({ ...defaultStyles, padding: 0 }),
+        }}
+        value={displayedSelected}
+      />
+    </div>
+  );
+}
+
+type OrganizationsSelectProps = {
+  selected: Readonly<Option[]>;
+  onChange: (selected: Readonly<Option[]>) => void;
+};
+
+export default OrganizationsSelect;

--- a/app/client/src/components/shared/OrganizationsSelect.tsx
+++ b/app/client/src/components/shared/OrganizationsSelect.tsx
@@ -1,68 +1,12 @@
 /** @jsxImportSource @emotion/react */
 
 import { useMemo } from 'react';
-import { css } from '@emotion/react';
 // components
-import PaginatedSelect from 'components/shared/PaginatedSelect';
+import CountSelect from 'components/shared/CountSelect';
 // utils
 import { useMonitoringLocations } from 'utils/hooks';
-// styles
-import { groupHeadingStyles } from 'styles/index';
 // types
 import type { Option } from 'types';
-
-const gridStyles = css`
-  display: grid;
-  grid-template-columns: repeat(2, 75% 25%);
-
-  div {
-    display: flex;
-    align-items: center;
-    padding: 8px 12px;
-  }
-
-  div:last-of-type {
-    text-align: right;
-    justify-content: flex-end;
-  }
-`;
-
-const gridHeaderStyles = css`
-  ${gridStyles}
-
-  border-bottom: 2px solid #dee2e6;
-  font-weight: bold;
-`;
-
-const selectContainerStyles = css`
-  width: 100%;
-`;
-
-const selectLabelStyles = css`
-  display: inline-block;
-  margin-bottom: 0.25rem;
-  font-size: 0.875rem;
-  font-weight: bold;
-`;
-
-function formatGroupLabel() {
-  return (
-    <div css={gridHeaderStyles}>
-      <div>Organization</div>
-      <div># of Locations in Organization</div>
-    </div>
-  );
-}
-
-function formatOptionLabel(option: Option) {
-  if (!option.count) return option.label;
-  return (
-    <div css={gridStyles}>
-      <div>{option.label}</div>
-      <div>{option.count}</div>
-    </div>
-  );
-}
 
 export function OrganizationsSelect({
   selected,
@@ -74,60 +18,31 @@ export function OrganizationsSelect({
   const organizationOptions = useMemo(() => {
     if (monitoringLocationsStatus !== 'success') return [];
 
-    return [
-      {
-        label: 'Group',
-        options: Object.values(
-          monitoringLocations.reduce<Record<string, Option>>(
-            (acc, location) => {
-              if (!acc.hasOwnProperty(location.orgId)) {
-                acc[location.orgId] = {
-                  label: location.orgName,
-                  value: location.orgId,
-                  count: 1,
-                };
-              } else {
-                acc[location.orgId].count!++;
-              }
-              return acc;
-            },
-            {},
-          ),
-        ).sort((a, b) => a.label.localeCompare(b.label)),
-      },
-    ];
+    return Object.values(
+      monitoringLocations.reduce<Record<string, Option>>((acc, location) => {
+        if (!acc.hasOwnProperty(location.orgId)) {
+          acc[location.orgId] = {
+            label: location.orgName,
+            value: location.orgId,
+            count: 1,
+          };
+        } else {
+          acc[location.orgId].count!++;
+        }
+        return acc;
+      }, {}),
+    ).sort((a, b) => a.label.localeCompare(b.label));
   }, [monitoringLocations]);
 
-  const displayedSelected = selected.map((option) => ({
-    label: option.label,
-    value: option.value,
-  }));
-
   return (
-    <div css={selectContainerStyles}>
-      <span css={selectLabelStyles}>Filter by Organizations:</span>
-      <PaginatedSelect
-        aria-label="Filter by Organizations"
-        formatGroupLabel={formatGroupLabel}
-        formatOptionLabel={formatOptionLabel}
-        isDisabled={monitoringLocationsStatus === 'failure'}
-        isLoading={monitoringLocationsStatus === 'pending'}
-        onChange={onChange}
-        options={organizationOptions}
-        placeholder="Select one or more organizations..."
-        styles={{
-          groupHeading: (defaultStyles) => ({
-            ...defaultStyles,
-            ...groupHeadingStyles,
-            padding: 0,
-            color: '#000',
-            backgroundColor: '#fff',
-          }),
-          option: (defaultStyles) => ({ ...defaultStyles, padding: 0 }),
-        }}
-        value={displayedSelected}
-      />
-    </div>
+    <CountSelect
+      countLabel="Locations in Organization"
+      label="organization"
+      onChange={onChange}
+      options={organizationOptions}
+      selected={selected}
+      status={monitoringLocationsStatus}
+    />
   );
 }
 

--- a/app/client/src/components/shared/TogglePanel.tsx
+++ b/app/client/src/components/shared/TogglePanel.tsx
@@ -1,0 +1,70 @@
+/** @jsxImportSource @emotion/react */
+
+import { useState } from 'react';
+import { css } from '@emotion/react';
+// types
+import type { ReactNode } from 'react';
+
+const arrowStyles = css`
+  font-size: 1.25em;
+  color: #526571;
+`;
+
+const childrenContainerStyles = css`
+  margin: 1em auto;
+  width: 90%;
+`;
+
+const controlStyles = css`
+  display: flex;
+  gap: 1em;
+  margin: auto;
+
+  button {
+    align-items: center;
+    background: none;
+    background-color: transparent !important;
+    border: none;
+    color: inherit;
+    display: flex;
+    font-size: 0.875rem;
+    gap: 1em;
+    margin: 0;
+    outline: inherit;
+    padding: 0;
+
+    &:hover,
+    &:focus {
+      color: inherit !important;
+      background-color: inherit !important;
+    }
+  }
+`;
+
+export function TogglePanel({ children, defaultOpen = false, title }: Props) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <>
+      <div css={controlStyles}>
+        <button onClick={(_ev) => setIsOpen((prev) => !prev)}>
+          {title}{' '}
+          <i
+            css={arrowStyles}
+            className={`fa fa-angle-${isOpen ? 'down' : 'right'}`}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+      {isOpen && <div css={childrenContainerStyles}>{children}</div>}
+    </>
+  );
+}
+
+type Props = {
+  children: ReactNode;
+  defaultOpen?: boolean;
+  title: string;
+};
+
+export default TogglePanel;

--- a/app/client/src/components/shared/TogglePanel.tsx
+++ b/app/client/src/components/shared/TogglePanel.tsx
@@ -41,7 +41,11 @@ const controlStyles = css`
   }
 `;
 
-export function TogglePanel({ children, defaultOpen = false, title }: Props) {
+export function TogglePanel({
+  children,
+  defaultOpen = false,
+  title,
+}: Readonly<Props>) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (

--- a/app/client/src/components/shared/TribalMapList.tsx
+++ b/app/client/src/components/shared/TribalMapList.tsx
@@ -81,6 +81,7 @@ import {
 import { tabsStyles } from 'components/shared/ContentTabs';
 // types
 import type { ReactNode } from 'react';
+import type { Option } from 'types';
 
 const mapPadding = 20;
 
@@ -309,13 +310,17 @@ function TribalMapList({ activeState, windowHeight }: Props) {
     setListShown(true);
   }, [width]);
 
-  const [selectedCharacteristics, setSelectedCharacteristics] = useState([]);
+  const [selectedCharacteristicOptions, setSelectedCharacteristicOptions] =
+    useState<Readonly<Option[]>>([]);
+  const selectedCharacteristics = selectedCharacteristicOptions.map(
+    (opt) => opt.value,
+  );
 
   // Reset data if the user switches locations
   const [prevState, setPrevState] = useState(activeState);
   if (activeState !== prevState) {
     setPrevState(activeState);
-    setSelectedCharacteristics([]);
+    setSelectedCharacteristicOptions([]);
     if (monitoringLocationsLayer) {
       monitoringLocationsLayer.definitionExpression = '';
     }
@@ -575,8 +580,10 @@ function TribalMapList({ activeState, windowHeight }: Props) {
                 <MonitoringTab
                   activeState={activeState}
                   monitoringLocations={filteredMonitoringLocations}
-                  selectedCharacteristics={selectedCharacteristics}
-                  setSelectedCharacteristics={setSelectedCharacteristics}
+                  selectedCharacteristicOptions={selectedCharacteristicOptions}
+                  setSelectedCharacteristicOptions={
+                    setSelectedCharacteristicOptions
+                  }
                 />
               </TabPanel>
             </TabPanels>
@@ -972,15 +979,15 @@ function TribalMap({
 type MonitoringTabProps = {
   activeState: Object;
   monitoringLocations: Object[];
-  selectedCharacteristics: string[];
-  setSelectedCharacteristics: (selected: string[]) => void;
+  selectedCharacteristicOptions: Readonly<Option[]>;
+  setSelectedCharacteristicOptions: (selected: Readonly<Option[]>) => void;
 };
 
 function MonitoringTab({
   activeState,
   monitoringLocations,
-  selectedCharacteristics,
-  setSelectedCharacteristics,
+  selectedCharacteristicOptions,
+  setSelectedCharacteristicOptions,
 }: MonitoringTabProps) {
   const configFiles = useConfigFilesState();
 
@@ -1010,17 +1017,17 @@ function MonitoringTab({
         <>
           <strong>{sortedMonitoringAndSensors.length}</strong> of{' '}
           <strong>{monitoringLocations.length}</strong> locations with{' '}
-          {selectedCharacteristics.length > 0
+          {selectedCharacteristicOptions.length > 0
             ? 'the selected characteristic'
             : 'data'}
-          {selectedCharacteristics.length > 1 && 's'} in the{' '}
+          {selectedCharacteristicOptions.length > 1 && 's'} in the{' '}
           <em>{activeState.label}</em> watershed.
         </>
       }
       extraListHeaderContent={
         <CharacteristicsSelect
-          selected={selectedCharacteristics}
-          onChange={setSelectedCharacteristics}
+          selected={selectedCharacteristicOptions}
+          onChange={setSelectedCharacteristicOptions}
         />
       }
       onSortChange={({ value }) => setMonitoringLocationsSortedBy(value)}

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -441,6 +441,12 @@ export interface NonProfitAttributes {
   type: 'nonprofit';
 }
 
+export type Option = {
+  count?: number;
+  label: string;
+  value: string;
+};
+
 export type ParameterToggleObject = { [key: string]: boolean };
 
 export type ParentLayer = __esri.GroupLayer | SuperLayer;


### PR DESCRIPTION
## Related Issues:
* [HMW-824](https://jira.epa.gov/browse/HMW-824)

## Main Changes:
* Added a multi-select box to filter Past Water Conditions locations by organization. This is visible on the Overview and Monitoring tabs of the Community page (it was not added to the tribal page because each tribe is an organization).
* Moved the characteristics filter and the new organizations filter inside a toggle-able panel when both are present.
* Moved the **Sort By** and **Expand All** accordion controls to the bottom of the accordion header (just above the list).

## Steps To Test:
1. Go to http://localhost:3000/community/dc/overview.
2. In the _Waterbodies_ list header, verify the **Expand All** button is located below the **Download All Waterbody Data** links.
3. Select the _Water Monitoring Locations_ panel.
4. Verify the Characteristics and Organizations filters are initially visible and that they function appropriately. Confirm the toggle button hides the filters. Confirm the filters are located above the **Sort By** and **Expand All** controls.
5. Go to http://localhost:3000/community/dc/monitoring and repeat step 2.
6. Go to http://localhost:3000/tribe/PUEBLOOFTESUQUE, then navigate to the _Water Monitoring Locations_ panel.
7. Confirm that only the Characteristics filter is present.
