### PR TITLE
Feature/819 download link updates

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Monitoring.tsx
@@ -846,7 +846,13 @@ function PastConditionsTab({ setMonitoringDisplayed }) {
                   monitoring sample locations
                   {selectedCharacteristics.length > 0 &&
                     ' with the selected characteristic'}
-                  {selectedCharacteristics.length > 1 && 's'} in the{' '}
+                  {selectedCharacteristics.length > 1 && 's'}
+                  {selectedOrganizations.length > 0 &&
+                    selectedCharacteristics.length > 0 &&
+                    ' and'}
+                  {selectedOrganizations.length > 0 &&
+                    ' in the selected organization'}
+                  {selectedOrganizations.length > 1 && 's'} in the{' '}
                   <em>{watershed.name}</em> watershed
                   {annualRecordsReady && (
                     <>

--- a/app/client/src/components/pages/Community.Tabs.Overview.tsx
+++ b/app/client/src/components/pages/Community.Tabs.Overview.tsx
@@ -738,6 +738,15 @@ function MonitoringAndSensorsTab({
     setPrevHuc12(huc12);
     setSelectedCharacteristicOptions([]);
   }
+
+  const monitoringLocationsFilteredBy = [];
+  if (selectedCharacteristics.length) {
+    monitoringLocationsFilteredBy.push('characteristics');
+  }
+  if (selectedOrganizations.length) {
+    monitoringLocationsFilteredBy.push('organizations');
+  }
+
   if (
     cyanWaterbodiesStatus === 'failure' &&
     streamgagesStatus === 'failure' &&
@@ -947,12 +956,12 @@ function MonitoringAndSensorsTab({
                   <strong>{filteredMonitoringAndSensors.length}</strong> of{' '}
                   <strong>{allMonitoringAndSensors.length}</strong> locations{' '}
                   with data in the <em>{watershed.name}</em> watershed.
-                  {selectedCharacteristics.length > 0 && (
+                  {monitoringLocationsFilteredBy.length > 0 && (
                     <>
                       <br />
                       <small>
-                        (Past Water Conditions filtered by one or more
-                        characteristics)
+                        (Past Water Conditions filtered by one or more{' '}
+                        {monitoringLocationsFilteredBy.join(' and ')})
                       </small>
                     </>
                   )}

--- a/app/client/src/components/shared/WaterbodyDownload.tsx
+++ b/app/client/src/components/shared/WaterbodyDownload.tsx
@@ -98,7 +98,7 @@ export function WaterbodyDownload({
                     options: {
                       format: fileType,
                     },
-                    columns: configFiles.eqProfileColumns.assessmentUnits,
+                    columns: configFiles.eqProfileColumns[profile],
                   }}
                   fileBaseName={fileBaseName}
                   fileType={fileType}

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -795,7 +795,7 @@ function WaterbodyInfo({
                 configFiles={configFiles}
                 fileBaseName={`Waterbody-${attributes.assessmentunitname.replace(/\s/g, '_')}`}
                 filters={baseDownloadFilters}
-                profile="assessmentUnits"
+                profile="assessments"
               />
             )}
             {path.includes('/identified-issues') && (

--- a/app/client/src/components/shared/WaterbodyList.tsx
+++ b/app/client/src/components/shared/WaterbodyList.tsx
@@ -144,7 +144,7 @@ function WaterbodyList({ waterbodies, title, fieldName }: Props) {
                   (graphic) => graphic.attributes.assessmentunitidentifier,
                 ),
               }}
-              profile="assessmentUnits"
+              profile="assessments"
             />
           )
         }

--- a/app/cypress/e2e/community.Overview.cy.ts
+++ b/app/cypress/e2e/community.Overview.cy.ts
@@ -159,7 +159,7 @@ describe('Overview Tab', () => {
     // Check the request made to Expert Query when downloading CSV data for all waterbodies in the list.
     cy.intercept(
       'POST',
-      'https://api.epa.gov/expertquery/api/attains/assessmentUnits',
+      'https://api.epa.gov/expertquery/api/attains/assessments',
     ).as('eq-data');
     cy.findByRole('button', {
       name: /Download selected data as a CSV file/,


### PR DESCRIPTION
## Related Issues:
* [HMW-819](https://jira.epa.gov/browse/HMW-819)
* [HMW-824](https://jira.epa.gov/browse/HMW-824)

## Main Changes:
* Changed from using the Assessment Units profile to the Assessments profile in the download links on the Overview tab.
* Updated the language in the accordion title when using the organizations filter (for Past Water Conditions).
* Fixed a bug in the waterbody download component where the profile name was hard-coded.

## Steps To Test:
1. Test the download links on the Overview tab. Data from the Assessments profile should be returned, with all the right columns.
