### PR TITLE
Feature/819 download link updates

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -1077,14 +1077,21 @@ function WaterbodyReport() {
       {configFiles.status === 'success' && (
         <div css={modifiedBoxSectionStyles}>
           <hr />
-          <WaterbodyDownload
-            configFiles={configFiles.data}
-            fileBaseName={`Waterbody-${auId}`}
-            filters={{
-              assessmentUnitId: auId!,
-            }}
-            profile={'assessments'}
-          />
+          {reportingCycleFetch.status === 'fetching' ? (
+            <LoadingSpinner />
+          ) : (
+            <WaterbodyDownload
+              configFiles={configFiles.data}
+              fileBaseName={`Waterbody-${auId}`}
+              filters={{
+                assessmentUnitId: auId!,
+                ...(reportingCycleFetch.status === 'success' && {
+                  reportingCycle: reportingCycleFetch.year,
+                }),
+              }}
+              profile={'assessments'}
+            />
+          )}
         </div>
       )}
     </div>

--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -16,6 +16,7 @@ import { AccordionList, AccordionItem } from 'components/shared/Accordion';
 import MapVisibilityButton from 'components/shared/MapVisibilityButton';
 import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import DynamicExitDisclaimer from 'components/shared/DynamicExitDisclaimer';
+import WaterbodyDownload from 'components/shared/WaterbodyDownload';
 // styled components
 import { errorBoxStyles, infoBoxStyles } from 'components/shared/MessageBoxes';
 import {
@@ -1072,6 +1073,20 @@ function WaterbodyReport() {
           <p>{waterbodyLocation.text}</p>
         )}
       </div>
+
+      {configFiles.status === 'success' && (
+        <div css={modifiedBoxSectionStyles}>
+          <hr />
+          <WaterbodyDownload
+            configFiles={configFiles.data}
+            fileBaseName={`Waterbody-${auId}`}
+            filters={{
+              assessmentUnitId: auId!,
+            }}
+            profile={'assessments'}
+          />
+        </div>
+      )}
     </div>
   );
 

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -596,10 +596,21 @@ function WaterbodyInfo({
 
     const path = window.location.pathname;
 
-    const baseDownloadFilters: Record<string, Primitive | Primitive[]> = {
+    const downloadFilters: Record<string, Primitive | Primitive[]> = {
       assessmentUnitId: [attributes.assessmentunitidentifier],
       reportingCycle: attributes.reportingcycle,
     };
+    let fileBaseNameBase = 'Waterbody';
+    if (path.includes('identified-issues')) {
+      fileBaseNameBase = 'Identified_Issues';
+      downloadFilters.overallStatus = 'Not Supporting';
+    } else if (field) {
+      const useField = configFiles?.useFields.find((uf) => uf.value === field);
+      if (useField) {
+        fileBaseNameBase = useField.label.replace(/\s/g, '_');
+        downloadFilters.useGroup = useField.value.toUpperCase();
+      }
+    }
 
     return (
       <>
@@ -790,26 +801,15 @@ function WaterbodyInfo({
 
         {configFiles && (
           <div css={waterbodyDownloadContainerStyles}>
-            {path.includes('/overview') && (
-              <WaterbodyDownload
-                configFiles={configFiles}
-                fileBaseName={`Waterbody-${attributes.assessmentunitname.replace(/\s/g, '_')}`}
-                filters={baseDownloadFilters}
-                profile="assessments"
-              />
-            )}
-            {path.includes('/identified-issues') && (
-              <WaterbodyDownload
-                configFiles={configFiles}
-                descriptor="impairment"
-                fileBaseName={`Identified_Issues-${attributes.assessmentunitname.replace(/\s/g, '_')}`}
-                filters={{
-                  ...baseDownloadFilters,
-                  overallStatus: 'Not Supporting',
-                }}
-                profile="assessments"
-              />
-            )}
+            <WaterbodyDownload
+              configFiles={configFiles}
+              descriptor={
+                path.includes('/identified-issues') ? 'impairment' : undefined
+              }
+              fileBaseName={`${fileBaseNameBase}-${attributes.assessmentunitname.replace(/\s/g, '_')}`}
+              filters={downloadFilters}
+              profile="assessments"
+            />
           </div>
         )}
 

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -806,7 +806,7 @@ function WaterbodyInfo({
               descriptor={
                 path.includes('/identified-issues') ? 'impairment' : undefined
               }
-              fileBaseName={`${fileBaseNameBase}-${attributes.assessmentunitname.replace(/\s/g, '_')}`}
+              fileBaseName={`${fileBaseNameBase}-${attributes.assessmentunitidentifier}`}
               filters={downloadFilters}
               profile="assessments"
             />


### PR DESCRIPTION
## Related Issues:
* [HMW-819](https://jira.epa.gov/browse/HMW-819)

## Main Changes:
* Added EQ download/portal links to the _Swimming, Eating Fish, Aquatic Life_, & _Drinking Water_ tabs on the Community page, and to the _Waterbody Report_ page.

## Steps To Test:
1. Go to http://localhost:3000/community/dc/swimming.
2. Test the list-level and item-level links and downloads. Both should utilize EQ's _Assessments_ profile, filtering on `useGroup = 'RECREATION_USE'`.
3. Go to http://localhost:3000/community/dc/eating-fish. Repeat step 2, but with `useGroup = 'FISHCONSUMPTION_USE'`.
4. Go to http://localhost:3000/community/dc/aquatic-life. Repeat step 2, but with `useGroup = 'ECOLOGICAL_USE'`.
5. Go to http://localhost:3000/community/dc/drinking-water. Repeat step 2, but with `useGroup = 'DRINKINGWATER_USE'`.
6. Go to http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205/2022. The portal and download links should point to the _Assessments_ profile, filtered by `assessmentUnitId` and `reportingCycle`.
