### PR TITLE
Bugfix/828 graphics not loading plans

### DIFF
--- a/app/client/src/components/pages/Actions.tsx
+++ b/app/client/src/components/pages/Actions.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { Fragment, useCallback, useContext, useEffect, useState } from 'react';
+import { Fragment, useContext, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
 import { WindowSize } from '@reach/window-size';
@@ -481,10 +481,11 @@ function Actions() {
 
   // calculate height of div holding actions info
   const [infoHeight, setInfoHeight] = useState(0);
-  const measuredRef = useCallback((node) => {
-    if (!node) return;
-    setInfoHeight(node.getBoundingClientRect().height);
-  }, []);
+  const measuredRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!measuredRef?.current) return;
+    setInfoHeight(measuredRef.current.getBoundingClientRect().height);
+  }, [measuredRef.current]);
 
   const infoBox = (
     <div css={boxStyles} ref={measuredRef}>

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -9,7 +9,7 @@
       "linkHref": "https://www.epa.gov/waterdata/attains",
       "linkLabel": "ATTAINS Data/System",
       "shortName": "ATTAINS",
-      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='overall waterbody condition'>waterbody condition</span> list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues ( <span data-glossary-term data-term='impairment'>impairments</span> ), Restore ( <span data-glossary-term data-term='restoration plan'>restoration plans</span>), Drinking Water (Which waters have been assessed for drinking water use?). It can also be found on the State & Tribal tab under the State or Tribal Water Quality Overview and the Advanced Search tabs.",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='overall waterbody condition'>waterbody condition</span> list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues ( <span data-glossary-term data-term='impairment'>impairments</span> ), Restore ( <span data-glossary-term data-term='restoration plan'>restoration plans</span>), Protect (Protection Projects), Drinking Water (Which waters have been assessed for drinking water use?).It can also be found on the State & Tribal tab under the State or Tribal Water Quality Overview and the Advanced Search tabs.",
       "title": "Assessment, Total Maximum Daily Load Tracking and Implementation System (ATTAINS)"
     },
     {
@@ -51,6 +51,16 @@
       "shortName": "ECHO",
       "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='dischargers'>permitted dischargers</span> ), Extreme Weather (Combined Sewer Overflows) and Identified Issues ( <span data-glossary-term data-term='significant violations'> dischargers with significant effluent violations</span> ).",
       "title": "Enforcement and Compliance History Online (ECHO)"
+    },
+    {
+      "description": "Expert Query provides a way to interact with public Assessment, Total Maximum Daily Load Tracking and Implementation System (ATTAINS) data, by allowing users to filter and download ATTAINS data either within an organization (state or tribe) or across multiple organizations.",
+      "extraContent": null,
+      "id": "eq",
+      "linkHref": "https://owapps.epa.gov/expertquery/attains",
+      "linkLabel": "EQ Data/System",
+      "shortName": "EQ",
+      "siteLocation": "Information from this database can be found on the Community page on the following tabs; Overview ( <span data-glossary-term data-term='overall waterbody condition'>waterbody condition</span> list and map), Swimming, Eating Fish, Aquatic Life, Identified Issues ( <span data-glossary-term data-term='impairment'>impairments</span> ), Restore ( <span data-glossary-term data-term='restoration plan'>restoration plans</span>), Protect (Protection Projects), Drinking Water (Which waters have been assessed for drinking water use?).",
+      "title": "Expert Query (EQ)"
     },
     {
       "description": "GRTS is the primary tool for management and oversight of the EPA’s <span data-glossary-term data-term='Nonpoint Source Pollution'>Nonpoint Source (NPS) Pollution</span> Control Program. Under Clean Water Act Section 319(h), EPA awards grants for implementation of state NPS management programs.",


### PR DESCRIPTION
## Related Issues:
* [HMW-828](https://jira.epa.gov/browse/HMW-828)
* [HMW-833](https://jira.epa.gov/browse/HMW-833)

## Main Changes:
* Fixed issue of graphics not showing on the plan summary page. 
  * The useCallback method for measuring the ref was causing a double render. So the layer we added the graphics to wasn't actually on the map. I mimicked the logic we use on the waterbody report page, which uses the same ActionsMap component.
* Added Expert query to the data page

## Steps To Test:
1. Navigate to http://localhost:3000/plan-summary/DOEE/40594
2. Refresh the page several times and verify the graphic loads on the map
3. Open the data page
4. Verify expert query is in there and the text looks good

