### PR TITLE
HMW-837 Reordered content in AccordionList header

### DIFF
--- a/app/client/src/components/shared/Accordion.tsx
+++ b/app/client/src/components/shared/Accordion.tsx
@@ -12,15 +12,11 @@ const accordionListContainerStyles = css`
   border-bottom: 1px solid #d8dfe2;
 `;
 
-const accordionOptionsContainerStyles = (
-  includeTopMargin: boolean,
-  displayTitleInFlex: boolean,
-) => css`
+const accordionOptionsContainerStyles = (displayTitleInFlex: boolean) => css`
   display: flex;
   justify-content: flex-end;
   width: 100%;
   margin-bottom: 0;
-  ${includeTopMargin ? 'margin-top: 0.625rem;' : ''}
   ${displayTitleInFlex
     ? 'justify-content: space-between; align-items: center;'
     : ''}
@@ -81,6 +77,17 @@ const listHeaderStyles = (includePadding: boolean) => css`
   border-top: 1px solid #d8dfe2;
   border-bottom: 1px solid #d8dfe2;
   background-color: #f0f6f9;
+`;
+
+const listHeaderBottomStyles = (includePadding: boolean) => css`
+  ${listHeaderStyles(includePadding)}
+  ${columnsStyles}
+`;
+
+const listHeaderContainerStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
 `;
 
 const titleStyles = css`
@@ -146,22 +153,24 @@ function AccordionList({
       className={`hmw-accordions ${className}`}
       role="list"
     >
-      {(includeSort || title || contentExpandCollapse || !expandDisabled) && (
-        <div css={listHeaderStyles(includeSort || !!title)}>
-          {title && !displayTitleInFlex && <p css={titleStyles}>{title}</p>}
-          {extraListHeaderContent && (
-            <>
-              <hr />
-              {extraListHeaderContent}
-            </>
-          )}
-          <div css={columnsStyles}>
-            <div
-              css={accordionOptionsContainerStyles(
-                includeSort && !!title,
-                displayTitleInFlex,
-              )}
-            >
+      <div css={listHeaderContainerStyles}>
+        {((title && !displayTitleInFlex) || extraListHeaderContent) && (
+          <div css={listHeaderStyles(!!title && !displayTitleInFlex)}>
+            {extraListHeaderContent}
+            {title && !displayTitleInFlex && extraListHeaderContent && <hr />}
+            {title && !displayTitleInFlex && <p css={titleStyles}>{title}</p>}
+          </div>
+        )}
+        {(includeSort ||
+          (title && displayTitleInFlex) ||
+          contentExpandCollapse ||
+          !expandDisabled) && (
+          <div
+            css={listHeaderBottomStyles(
+              includeSort || (!!title && displayTitleInFlex),
+            )}
+          >
+            <div css={accordionOptionsContainerStyles(displayTitleInFlex)}>
               {title && displayTitleInFlex && <p css={titleStyles}>{title}</p>}
 
               {includeSort && (
@@ -204,8 +213,8 @@ function AccordionList({
               )}
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* implicitly pass 'allExpanded' prop down to children (AccordionItem's) */}
       {Children.map(children, (childElement) => {

--- a/app/client/src/components/shared/WaterbodiesDownload.tsx
+++ b/app/client/src/components/shared/WaterbodiesDownload.tsx
@@ -24,7 +24,7 @@ const waterbodiesDownloadSectionStyles = css`
   font-weight: bold;
   gap: 0.5em;
   justify-content: flex-end;
-  margin-bottom: 0.5em;
+  margin: 0.5em 0;
 `;
 
 const profileKeyToTitle: Record<AttainsProfile, string> = {


### PR DESCRIPTION
## Related Issues:
* [HMW-837](https://jira.epa.gov/browse/HMW-837)

## Main Changes:
* Moved extra content in accordion list headers above the title and adjusted spacing. This was done primarily so the Past Water Conditions filters would be displayed above the location count.

## Steps To Test:
1. Go to the _Past Water Conditions_ section of http://localhost:3000/community/dc/monitoring. Confirm the location count is displayed below the "Filter By" section, but above the "Sort By"/"Expand All" controls.
2. Test all other accordion lists and make sure they have an acceptable appearance.
