### PR TITLE
Feature/844 845 remove county from text

### DIFF
--- a/app/client/src/components/pages/Community.Tabs.DrinkingWater.tsx
+++ b/app/client/src/components/pages/Community.Tabs.DrinkingWater.tsx
@@ -642,7 +642,7 @@ function DrinkingWater() {
                         <div css={infoBoxStyles}>
                           <p css={centeredTextStyles}>
                             There are no public drinking water systems serving{' '}
-                            {county} county/municipality.
+                            {county}.
                           </p>
                         </div>
                       )}
@@ -685,7 +685,7 @@ function DrinkingWater() {
                                 There {providers.length === 1 ? 'is' : 'are'}{' '}
                                 <strong>{providers.length}</strong> public water{' '}
                                 {providers.length === 1 ? 'system' : 'systems'}{' '}
-                                serving <em>{county}</em> county.
+                                serving <em>{county}</em>.
                               </>
                             }
                             onSortChange={(sortBy) =>

--- a/app/client/src/components/pages/Community.Tabs.ExtremeWeather.tsx
+++ b/app/client/src/components/pages/Community.Tabs.ExtremeWeather.tsx
@@ -944,8 +944,12 @@ function ExtremeWeather() {
             headerElm={
               <p css={subheadingStyles}>
                 <HelpTooltip label="Adjust the slider handles to filter location data by the selected year range" />
-                &nbsp;&nbsp; Date range for the <em>{countySelected?.label}</em>{' '}
-                county{' '}
+                &nbsp;&nbsp; Date range for{' '}
+                {countySelected ? (
+                  <em>{countySelected?.label}</em>
+                ) : (
+                  'the selected county'
+                )}
               </p>
             }
           />
@@ -1168,7 +1172,7 @@ function ExtremeWeather() {
                 <>
                   <span css={paragraphStyles}>
                     Read more about how to adapt, mitigate, and build resiliency
-                    to extreme events and climate and climate:
+                    to extreme events and climate change:
                   </span>
                   <ul>
                     <li>

--- a/app/client/src/components/pages/Community.Tabs.ExtremeWeather.tsx
+++ b/app/client/src/components/pages/Community.Tabs.ExtremeWeather.tsx
@@ -946,7 +946,7 @@ function ExtremeWeather() {
                 <HelpTooltip label="Adjust the slider handles to filter location data by the selected year range" />
                 &nbsp;&nbsp; Date range for{' '}
                 {countySelected ? (
-                  <em>{countySelected?.label}</em>
+                  <em>{countySelected.label}</em>
                 ) : (
                   'the selected county'
                 )}
@@ -1306,6 +1306,15 @@ function ExtremeWeather() {
                             rel="noopener noreferrer"
                           >
                             Wildfires and Water Quality Research
+                          </a>
+                        </li>
+                        <li>
+                          <a
+                            href="https://www.epa.gov/watershedacademy/understanding-climate-change-impacts-water-resources-module"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Understanding Climate Change Impacts on Water Resources
                           </a>
                         </li>
                       </ul>


### PR DESCRIPTION
## Related Issues:
* [HMW-844](https://jira.epa.gov/browse/HMW-844)
* [HMW-845](https://jira.epa.gov/browse/HMW-845)

## Main Changes:
* Removed the word "county" from several places on the Drinking Water and Extreme Weather tabs:
  * The count sentence above the drinking water providers accordion list.
  * The informational message shown when there are no drinking water providers.
  * The date slider in the _Historical Risk and Potential Future Scenarios_ section of the Extreme Weather tab.
* Added a resource link to the list of resources at the bottom of the Extreme Weather tab.
