### PR TITLE
Feature/848 849 850 algal toxins

### DIFF
--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
@@ -1133,7 +1133,7 @@ function AdvancedSearch() {
                 ? configFiles.data.reportStatusMapping[
                     organizationData.data.reportStatusCode
                   ]
-                : organizationData.data.reportStatusCode}
+                : organizationData.data.reportStatusCode}{' '}
             </>
           )}
           / {currentReportingCycle.status === 'fetching' && <LoadingSpinner />}

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.SiteSpecific.tsx
@@ -23,7 +23,10 @@ import { formatNumber } from 'utils/utils';
 import { fonts, colors } from 'styles/index';
 import { h3Styles } from 'styles/stateTribal';
 // errors
-import { fishingAdvisoryError } from 'config/errorMessages';
+import {
+  fishingAdvisoryError,
+  status303dShortError,
+} from 'config/errorMessages';
 
 // add exporting features to highcharts
 highchartsExporting(Highcharts);
@@ -112,7 +115,9 @@ function SiteSpecific({
   fishingAdvisoryData,
 }: Props) {
   const configFiles = useConfigFilesState();
-  const { currentReportingCycle } = useContext(StateTribalTabsContext);
+  const { currentReportingCycle, organizationData } = useContext(
+    StateTribalTabsContext,
+  );
 
   let waterTypeUnits = null;
   if (waterTypeData?.length) {
@@ -414,9 +419,31 @@ function SiteSpecific({
                 />
               </div>
               <p css={chartFooterStyles}>
-                <strong>Year Last Reported:</strong>
+                <strong>
+                  <GlossaryTerm term="303(d) listed impaired waters (Category 5)">
+                    303(d) List Status
+                  </GlossaryTerm>{' '}
+                  / Year Last Reported:
+                </strong>
+                &nbsp;&nbsp;
+                {organizationData.status === 'fetching' && <LoadingSpinner />}
+                {organizationData.status === 'failure' && (
+                  <>{status303dShortError}</>
+                )}
+                {organizationData.status === 'success' && (
+                  <>
+                    {configFiles.data.reportStatusMapping.hasOwnProperty(
+                      organizationData.data.reportStatusCode,
+                    )
+                      ? configFiles.data.reportStatusMapping[
+                          organizationData.data.reportStatusCode
+                        ]
+                      : organizationData.data.reportStatusCode}{' '}
+                  </>
+                )}
+                /{' '}
                 {currentReportingCycle.status === 'success' && (
-                  <>&nbsp;{currentReportingCycle.reportingCycle}</>
+                  <>{currentReportingCycle.reportingCycle}</>
                 )}
                 {currentReportingCycle.status === 'fetching' && (
                   <LoadingSpinner />

--- a/app/client/src/components/shared/PastWaterConditionsFilters.tsx
+++ b/app/client/src/components/shared/PastWaterConditionsFilters.tsx
@@ -3,6 +3,7 @@
 import { css } from '@emotion/react';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
+import { GlossaryTerm } from 'components/shared/GlossaryPanel';
 import { HelpTooltip } from 'components/shared/HelpTooltip';
 import LoadingSpinner from 'components/shared/LoadingSpinner';
 import Slider from 'components/shared/Slider';
@@ -445,17 +446,30 @@ export function PastWaterConditionsFilters({
                   locationCount++;
                 }
               });
+              const mapping = configFiles.data.characteristicGroupMappings.find(
+                (mapping) => mapping.label === group.label,
+              );
+              const groupLabelId = `${group.label.replaceAll(' ', '-')}-label`;
 
               return (
                 <tr key={group.label}>
                   <td>
-                    <label css={toggleStyles}>
+                    <div css={toggleStyles}>
                       <Switch
                         checked={group.toggled}
                         onChange={groupToggleHandlers?.[group.label]}
+                        ariaLabelledBy={groupLabelId}
                       />
-                      <span>{group.label}</span>
-                    </label>
+                      <span id={groupLabelId}>
+                        {mapping?.glossaryTerm ? (
+                          <GlossaryTerm term={mapping.glossaryTerm}>
+                            {group.label}
+                          </GlossaryTerm>
+                        ) : (
+                          group.label
+                        )}
+                      </span>
+                    </div>
                   </td>
                   <td colSpan={2}>{locationCount.toLocaleString()}</td>
                   <td>{measurementCount.toLocaleString()}</td>

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -148,6 +148,7 @@ export interface ChangeLocationAttributes {
 
 export type CharacteristicGroupMappings = {
   label: string;
+  glossaryTerm?: string;
   groupNames: string[];
 }[];
 

--- a/app/server/app/public/data/community/characteristicGroupMappings.json
+++ b/app/server/app/public/data/community/characteristicGroupMappings.json
@@ -4,6 +4,11 @@
     "groupNames": []
   },
   {
+    "label": "Algal Toxins",
+    "groupNames": ["Cyanotoxins, Phytotoxins"],
+    "glossaryTerm": "Algal Toxins"
+  },
+  {
     "label": "Nutrients",
     "groupNames": ["Nutrient"]
   },


### PR DESCRIPTION
## Related Issues:
* [HMW-848](https://jira.epa.gov/browse/HMW-848)
* [HMW-849](https://jira.epa.gov/browse/HMW-849)
* [HMW-850](https://jira.epa.gov/browse/HMW-850)

## Main Changes:
* Added a missing space after the reporting cycle status in the map footer on the State Advanced Search page.
* Added an "Algal Toxins" top-level characteristic group for WQP Past Water Conditions locations.
* Added the reporting cycle status to the Site-Specific section of the State/Tribe Overview page, to match the Advanced Search page map footer.
  * While I see that this status is provided for tribes in the response from the Assessments service, it looks like this is not shown on the Tribal Map. Is there a reason for this, or should it also be added to the Tribal map?
  * The upcoming changes to the "usesStateSummary" service (demoed at https://attains-demo.epa-ow-cloud.com/attains-public/api/usesStateSummary?organizationId=DOEE) include the addition of a `cycleStatus` field that could be used instead of the `reportStatusCode` from the Assessments service. However, the Assessments service is also used for documents data that is used on the same page. We could use the `cycleStatus` from the updated service so that the reporting cycle and status are drawn from the same response, but doing so will _not_ remove a service call.

## Steps To Test:
1. Go to http://localhost:3000/state/AZ/water-quality-overview. Verify the cycle status is displayed beneath the bar chart alongside the latest reporting cycle.
2. Go to the Advanced Search page and execute a search. Check that the map footer spacing is correct.
3. Go to http://localhost:3000/community/010801060401/monitoring. An "Algal Toxins" toggle row should be present, and it should be linked to the Glossary (there is no glossary entry for it yet).