### PR TITLE
Feature/870 remove cejst data

### DIFF
--- a/app/server/app/public/data/community/extreme-weather.json
+++ b/app/server/app/public/data/community/extreme-weather.json
@@ -827,22 +827,6 @@
       "text": ""
     },
     {
-      "id": "disadvantagedCommunities",
-      "checked": false,
-      "disabled": false,
-      "layerId": "disadvantagedCommunitiesLayer",
-      "label": "Overburdened, Underserved, and Disadvantaged Communities",
-      "text": "",
-      "queries": [
-        {
-          "query": {
-            "outFields": ["SN_C", "SN_T"],
-            "where": "GEOID10 LIKE '{HMW_COUNTY_FIPS}%'"
-          }
-        }
-      ]
-    },
-    {
       "id": "wells",
       "checked": false,
       "disabled": false,

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -114,8 +114,8 @@
   },
   "wells": "https://geodata.epa.gov/arcgis/rest/services/ORD/PrivateDomesticWells2020/MapServer/6",
   "disadvantagedCommunities": {
-    "portalId": "f95344889cab44bd84207052f44cb940",
-    "url": "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/usa_november_2022/FeatureServer"
+    "portalId": "f95344889cab44bd84207052f44cb940_TEMPORARILY_BREAK",
+    "url": "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/usa_november_2022/FeatureServer_TEMPORARILY_BREAK"
   },
   "googleAnalyticsMapping": [
     {

--- a/app/server/app/public/data/dataPage.json
+++ b/app/server/app/public/data/dataPage.json
@@ -13,16 +13,6 @@
       "title": "Assessment, Total Maximum Daily Load Tracking and Implementation System (ATTAINS)"
     },
     {
-      "description": "The Climate and Economic Justice Screening Tool (CEJST) data highlights disadvantaged census tracts across all 50 states, the District of Columbia, and the U.S. territories. Communities are considered disadvantaged: <ul><li>If they are in census tracts that meet the thresholds for at least one of the tool’s categories of burden, or</li><li>If they are on land within the boundaries of Federally Recognized Tribes</li></ul>",
-      "extraContent": null,
-      "id": "cejst",
-      "linkHref": "https://screeningtool.geoplatform.gov",
-      "linkLabel": "CEJST Data/System",
-      "shortName": "CEJST",
-      "siteLocation": "Information from CEJST can be found on the Community Page in the Extreme Weather tab at the \"Overburdened, Underserved, and Disadvantaged Communities\" row under \"Potentially Vulnerable Waters, Infrastructure or Communities\".",
-      "title": "Climate and Economic Justice Screening Tool (CEJST)"
-    },
-    {
       "description": "The Climate Mapping Resilience and Adaptation (CMRA) data provides information to help understand past, current and future exposure to various climate hazards.",
       "extraContent": null,
       "id": "cmra",


### PR DESCRIPTION
## Related Issues:
* [HMW-879](https://jira.epa.gov/browse/HMW-879)

## Main Changes:
* Removed CEJST data/services, since the app was recently taken offline.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/extreme-weather
2. Verify `Overburdened, Underserved, and Disadvantaged Communities` is no longer in the layer list or in the content on the right side panel.
3. Click on the `Data` button in the panel
4. Verify `Climate and Economic Justice Screening Tool (CEJST)` is no longer in the list.

