### PR TITLE
Bugfix/896 monitoring report download issue

### DIFF
--- a/app/client/src/components/pages/MonitoringReport.tsx
+++ b/app/client/src/components/pages/MonitoringReport.tsx
@@ -2084,7 +2084,7 @@ function DownloadSection({ charcs, charcsStatus, site, siteStatus }) {
                     fileBaseName="wqp-results"
                     fileType={fileType}
                     setError={setDownloadError}
-                    url={`${configFiles.data.services.waterQualityPortal.resultSearch}zip=yes&mimeType=${fileType}`}
+                    url={`${configFiles.data.services.waterQualityPortal.resultSearch}zip=no&mimeType=${fileType}`}
                   />
                 </Fragment>
               ))}


### PR DESCRIPTION
## Related Issues:
* [HMW-896](https://jira.epa.gov/browse/HMW-896)

## Main Changes:
* Removed zipping of wqp downloads.

## Steps To Test:
1. Navigate to http://localhost:3000/monitoring-report/STORET/21VASWCB/21VASWCB-8-YRK001.64/
2. Download a xlsx and csv 
3. Verify they download and you can open them

