### PR TITLE
Feature/881 waterbody report eq error

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -444,7 +444,6 @@ function WaterbodyReport() {
       } catch (err) {
         console.error(err);
         setAllReportingCycles({ status: 'failure', data: [] });
-        handleError();
       }
     }
 
@@ -492,7 +491,6 @@ function WaterbodyReport() {
   useEffect(() => {
     if (assessmentsCalled || mapLayer.status === 'fetching') return;
     if (!reportingCycle && mapLayer.status === 'fetching') return;
-    if (allReportingCycles.status !== 'success') return;
 
     let hasGisData =
       mapLayer.status === 'success' && mapLayer.layer.graphics.length > 0;

--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -1023,7 +1023,7 @@ function WaterbodyReport() {
         {(allReportingCycles.status === 'failure' ||
           reportingCycleFetch.status === 'failure') && (
           <div css={modifiedErrorBoxStyles}>
-            <p>{waterbodyReportError('Assessment')}</p>
+            <p>{waterbodyReportError('Other Years Reported')}</p>
           </div>
         )}
         {allReportingCycles.status === 'success' &&
@@ -1198,14 +1198,14 @@ function WaterbodyReport() {
       <div css={containerStyles} data-content="container">
         {reportingCycleFetch.status === 'success' &&
           allReportingCycles.status === 'success' &&
-          latestReportingCycle > reportingCycleFetch.year && (
+          (latestReportingCycle > reportingCycleFetch.year) || (reportingCycleGis > reportingCycleFetch.year) && (
             <div css={infoBoxContainerStyles}>
               <div css={infoBoxStyles}>
                 There is more recent data available for this waterbody. Please
                 use the following link to view the latest information:
                 <br />
                 <a
-                  href={`/waterbody-report/${orgId}/${auId}/${latestReportingCycle}`}
+                  href={`/waterbody-report/${orgId}/${auId}/${latestReportingCycle ?? reportingCycleGis}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -1214,7 +1214,7 @@ function WaterbodyReport() {
                     className="fas fa-file-alt"
                     aria-hidden="true"
                   />
-                  View Waterbody Report for {latestReportingCycle}
+                  View Waterbody Report for {latestReportingCycle ?? reportingCycleGis}
                 </a>
                 &nbsp;&nbsp;
                 <small css={disclaimerStyles}>(opens new browser tab)</small>


### PR DESCRIPTION
## Related Issues:
* [HMW-881](https://jira.epa.gov/browse/HMW-881)

## Main Changes:
* Fixed issue of entire waterbody report page being down when Expert Query is down.

## Steps To Test:
1. Open dev tools and go to network tab
2. Navigate to http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205-Mainstem/2024
3. Verify the page loads as expected and shows values for Other Years Reported
4. Block `https://api.epa.gov/expertquery`
5. Refresh the page
6. Verify the majority of the page loads 
7. Verify the Other Years Reported section shows an error
8. Unblock `https://api.epa.gov/expertquery`
9. Navigate to http://localhost:3000/waterbody-report/MDE_EASP/MD-02140205-Mainstem/
10. Repeat steps 3 - 7

