### PR TITLE
Bugfix/915 print map legend issue

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -661,7 +661,7 @@ function MapWidgets({
     const syncedDiv = document.createElement('div');
 
     const syncContent = () => {
-      syncedDiv.innerHTML = legendNode?.innerHTML || '';
+      syncedDiv.innerHTML = legendNode?.innerHTML ?? '';
     }
     syncContent();
 


### PR DESCRIPTION
## Related Issues:
* [HMW-915](https://jira.epa.gov/browse/HMW-915)

## Main Changes:
* Fixed issue with "Failed to load image" in legend section of print map output.
  * Esri changed how the items in the expand widget are hidden. They now set the element to `inert` which `html-to-image` package can't access.
  * I ended up fixing this by displaying the legend off screen and hidden from screen readers, then I sync that legend with the div in the expand widget. 

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/overview
2. Open the legend
3. Verify it works
4. Turn on more layers
5. Verify those items show up in the legend
6. Print the map
7. Verify the output file has images in the legend and doesn't say `Failed to load image`
