### PR TITLE
Feature/916 save test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ app/cypress/downloads/
 app/cypress/screenshots/
 app/cypress/videos/
 app/combined_coverage_reports
+app/combined_results_reports
 cypress.env.json
 
 

--- a/app/client/index.html
+++ b/app/client/index.html
@@ -16,8 +16,6 @@
       content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
     />
     <meta name="DC.title" content="How&#x27;s My Waterway?" />
-    <meta property="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta property="DC.type" content="Overviews and Factsheets" />
     <meta property="DC.date.created" content="2021-12-06" />
     <meta property="DC.date.modified" content="2023-12-22" />
     <meta property="DC.date.reviewed" content="" />

--- a/app/combine_coverage_reports.js
+++ b/app/combine_coverage_reports.js
@@ -12,6 +12,7 @@ const { exec } = require('child_process');
 const serverCoveragePath = './server/coverage/coverage-final.json';
 const cyprusCoveragePath = './coverage/coverage-final.json';
 const combinedCoverageDir = 'combined_coverage_reports';
+const combinedResultsDir = 'combined_results_reports';
 
 function copyFile(sourcePath, destinationPath, newFileName) {
   try {
@@ -62,4 +63,20 @@ function createCombinedCoverageReport() {
   );
 }
 
+function createCombinedResultsReport() {
+  exec(
+    `npx allure generate ${combinedResultsDir}/results --clean -o ${combinedResultsDir}/final_report --single-file`,
+    (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error executing npx allure generate: ${error}`);
+      } else {
+        console.log(
+          `Combined test results report generated successfully. Please review ${combinedResultsDir}/final_report`,
+        );
+      }
+    },
+  );
+}
+
 createCombinedCoverageReport();
+createCombinedResultsReport();

--- a/app/cypress.config.ts
+++ b/app/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin';
+import { allureCypress } from 'allure-cypress/reporter';
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -21,6 +22,9 @@ export default defineConfig({
       require('@cypress/code-coverage/task')(on, config);
 
       addMatchImageSnapshotPlugin(on, config);
+      allureCypress(on, config, {
+        resultsDir: 'combined_results_reports/results',
+      });
 
       return config;
     },

--- a/app/cypress/e2e/community.IdentifiedIssues.cy.ts
+++ b/app/cypress/e2e/community.IdentifiedIssues.cy.ts
@@ -46,7 +46,7 @@ describe('Identified Issues Tab', () => {
     cy.findByRole('tab', { name: /Permitted Dischargers/ }).click({
       force: true,
     });
-    cy.findByRole('switch', { name: /85 Permitted Dischargers/ }).should(
+    cy.findByRole('switch', { name: /84 Permitted Dischargers/ }).should(
       'have.attr',
       'aria-checked',
       'true',

--- a/app/cypress/support/e2e.ts
+++ b/app/cypress/support/e2e.ts
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import 'allure-cypress';
 import '@cypress/code-coverage/support';
 
 // Alternatively you can use CommonJS syntax:

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,8 @@
         "@types/cypress-image-snapshot": "3.1.9",
         "@types/node": "22.15.23",
         "@types/testing-library__cypress": "5.0.13",
+        "allure-commandline": "2.34.0",
+        "allure-cypress": "3.2.2",
         "concurrently": "9.1.2",
         "cypress": "14.4.0",
         "cypress-image-snapshot": "4.0.1",
@@ -883,6 +885,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/allure-commandline": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.34.0.tgz",
+      "integrity": "sha512-+SgVJ9+o7OH43KVCln0KT7VIsXCfMVEvFuYArIFNtS0fWu61UFdeiCYvrlQPC9trEoFhOe2e5i8Xhghwo46iRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "allure": "bin/allure"
+      }
+    },
+    "node_modules/allure-cypress": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.2.2.tgz",
+      "integrity": "sha512-h0oq6NcYK0EJtWfBrV5tLJcVjV9Zl6791KH1zHfmFq9YP5GTeCIs5/GWLz3+hVgwBzWvNffs1Hmu3f77h0fSkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "allure-js-commons": "3.2.2"
+      },
+      "peerDependencies": {
+        "cypress": ">=12.17.4"
+      },
+      "peerDependenciesMeta": {
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-js-commons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.2.2.tgz",
+      "integrity": "sha512-qr9r9+HpyNmbaaAtNDK6qXXar7RcYQECf8hOtH/e8DFKZNahIkfFYU0LP4Q7SPbqyAZsGbocTKikVx9L2po+eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.2.2"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1479,6 +1527,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -1828,6 +1886,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cypress": {
@@ -2999,6 +3067,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3686,6 +3761,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/merge-stream": {
@@ -5844,6 +5931,30 @@
         "indent-string": "^4.0.0"
       }
     },
+    "allure-commandline": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.34.0.tgz",
+      "integrity": "sha512-+SgVJ9+o7OH43KVCln0KT7VIsXCfMVEvFuYArIFNtS0fWu61UFdeiCYvrlQPC9trEoFhOe2e5i8Xhghwo46iRQ==",
+      "dev": true
+    },
+    "allure-cypress": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-cypress/-/allure-cypress-3.2.2.tgz",
+      "integrity": "sha512-h0oq6NcYK0EJtWfBrV5tLJcVjV9Zl6791KH1zHfmFq9YP5GTeCIs5/GWLz3+hVgwBzWvNffs1Hmu3f77h0fSkw==",
+      "dev": true,
+      "requires": {
+        "allure-js-commons": "3.2.2"
+      }
+    },
+    "allure-js-commons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.2.2.tgz",
+      "integrity": "sha512-qr9r9+HpyNmbaaAtNDK6qXXar7RcYQECf8hOtH/e8DFKZNahIkfFYU0LP4Q7SPbqyAZsGbocTKikVx9L2po+eg==",
+      "dev": true,
+      "requires": {
+        "md5": "^2.3.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -6254,6 +6365,12 @@
         }
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -6506,6 +6623,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true
     },
     "cypress": {
       "version": "14.4.0",
@@ -7339,6 +7462,12 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7838,6 +7967,17 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "cypress": "concurrently -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server\" \"npm:client\" \"cypress open --env coverage=false\"",
     "client_coverage": "npx rimraf .nyc_output/out.json && npx rimraf coverage && concurrently -s first -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server_coverage\" \"npm:client\" \"cypress run --browser electron\"",
     "coverage_spec_ex": "npx rimraf .nyc_output/out.json && concurrently -s first -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server_coverage\" \"npm:client\" \"cypress run --browser electron --spec 'cypress/e2e/educational-materials.cy.ts'\" && echo REMINDER Manually delete CYPRESS-TEST",
-    "coverage": "cd server && npm run test && cd .. && npm run client_coverage && node combine_coverage_reports.js && echo REMINDER Manually delete CYPRESS-TEST",
+    "coverage": "npx rimraf combined_results_reports/results && cd server && npm run test && cd .. && npm run client_coverage && node combine_coverage_reports.js && echo REMINDER Manually delete CYPRESS-TEST",
     "glossary": "cd server && npm run glossary"
   },
   "devDependencies": {
@@ -45,6 +45,8 @@
     "@types/cypress-image-snapshot": "3.1.9",
     "@types/node": "22.15.23",
     "@types/testing-library__cypress": "5.0.13",
+    "allure-commandline": "2.34.0",
+    "allure-cypress": "3.2.2",
     "concurrently": "9.1.2",
     "cypress": "14.4.0",
     "cypress-image-snapshot": "4.0.1",

--- a/app/server/app/public/404.html
+++ b/app/server/app/public/404.html
@@ -16,8 +16,6 @@
       content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
     />
     <meta name="DC.title" content="How&#x27;s My Waterway? | Page Not Found" />
-    <meta property="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta property="DC.type" content="Overviews and Factsheets" />
     <meta property="DC.date.created" content="2021-12-06" />
     <meta property="DC.date.modified" content="2023-12-22" />
     <meta property="DC.date.reviewed" content="" />

--- a/app/server/app/public/500.html
+++ b/app/server/app/public/500.html
@@ -19,8 +19,6 @@
       name="DC.title"
       content="How&#x27;s My Waterway? | Internal Server Error"
     />
-    <meta property="DC.Subject.epachannel" content="Learn the Issues" />
-    <meta property="DC.type" content="Overviews and Factsheets" />
     <meta property="DC.date.created" content="2021-12-06" />
     <meta property="DC.date.modified" content="2023-12-22" />
     <meta property="DC.date.reviewed" content="" />

--- a/app/server/jest.config.js
+++ b/app/server/jest.config.js
@@ -1,6 +1,18 @@
+const os = require('node:os');
+
 module.exports = {
   setupFiles: ['./jest_setup.js'],
   roots: ['tests'],
+  testEnvironment: 'allure-jest/node',
+  testEnvironmentOptions: {
+    resultsDir: '../combined_results_reports/results',
+    environmentInfo: {
+      os_platform: os.platform(),
+      os_release: os.release(),
+      os_version: os.version(),
+      node_version: process.version,
+    },
+  },
   testPathIgnorePatterns: [
     'node_modules/',
     'dist/',

--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@cypress/code-coverage": "3.14.3",
+        "allure-jest": "3.2.2",
         "browser-sync": "3.0.4",
         "husky": "9.1.7",
         "jest": "29.7.0",
@@ -5229,6 +5230,58 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/allure-jest": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-jest/-/allure-jest-3.2.2.tgz",
+      "integrity": "sha512-61PSm/U+AKVR/nPITbz35M4kHqK7vkGHiM4wKvTciU4QgFKWNLyQ8dX2rHvHaLVS9WqJfQCjQoIgOoX1OEidrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "allure-js-commons": "3.2.2"
+      },
+      "peerDependencies": {
+        "jest": ">=24.8.0",
+        "jest-circus": ">=24.8.0",
+        "jest-cli": ">=24.8.0",
+        "jest-environment-jsdom": ">=24.8.0",
+        "jest-environment-node": ">=24.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        },
+        "jest-circus": {
+          "optional": true
+        },
+        "jest-cli": {
+          "optional": true
+        },
+        "jest-environment-jsdom": {
+          "optional": true
+        },
+        "jest-environment-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-js-commons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.2.2.tgz",
+      "integrity": "sha512-qr9r9+HpyNmbaaAtNDK6qXXar7RcYQECf8hOtH/e8DFKZNahIkfFYU0LP4Q7SPbqyAZsGbocTKikVx9L2po+eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.2.2"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -6198,6 +6251,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -6679,6 +6742,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cypress": {
@@ -9066,6 +9139,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -10957,6 +11037,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -18046,6 +18138,24 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "allure-jest": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-jest/-/allure-jest-3.2.2.tgz",
+      "integrity": "sha512-61PSm/U+AKVR/nPITbz35M4kHqK7vkGHiM4wKvTciU4QgFKWNLyQ8dX2rHvHaLVS9WqJfQCjQoIgOoX1OEidrQ==",
+      "dev": true,
+      "requires": {
+        "allure-js-commons": "3.2.2"
+      }
+    },
+    "allure-js-commons": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.2.2.tgz",
+      "integrity": "sha512-qr9r9+HpyNmbaaAtNDK6qXXar7RcYQECf8hOtH/e8DFKZNahIkfFYU0LP4Q7SPbqyAZsGbocTKikVx9L2po+eg==",
+      "dev": true,
+      "requires": {
+        "md5": "^2.3.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -18719,6 +18829,12 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true
+    },
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
@@ -19050,6 +19166,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true
     },
     "cypress": {
       "version": "13.14.2",
@@ -20680,6 +20802,12 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
     "is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -21982,6 +22110,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "media-typer": {
       "version": "1.1.0",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@cypress/code-coverage": "3.14.3",
+    "allure-jest": "3.2.2",
     "browser-sync": "3.0.4",
     "husky": "9.1.7",
     "jest": "29.7.0",

--- a/app/server/tests/api.test.js
+++ b/app/server/tests/api.test.js
@@ -1,7 +1,7 @@
 const supertest = require('supertest');
 const app = require('../app/app');
 
-describe('Test example', () => {
+describe('API Tests', () => {
   test('GET /api/health should return UP', async () => {
     const response = await supertest(app)
       .get('/api/health')
@@ -44,14 +44,14 @@ describe('Test example', () => {
   });
 
   test('GET test checkClientRouteExists middleware', async () => {
-    const response = await supertest(app)
+    await supertest(app)
       .get('/community/lake%20okeechobee/overview')
       .expect(404);
   });
 
-  test('GET test checkClientRouteExists middleware', async () => {
+  test('POST test checkClientRouteExists middleware', async () => {
     await supertest(app)
-      .get('/communityTest/lake%20okeechobee/overview')
+      .post('/communityTest/lake%20okeechobee/overview')
       .expect(404);
   });
 
@@ -63,7 +63,7 @@ describe('Test example', () => {
     await supertest(app).delete('/api/health').expect(401);
   });
 
-  test('GET nonexistent rout', async () => {
+  test('GET nonexistent route', async () => {
     await supertest(app)
       .get('/bogusRoute')
       .expect(404)

--- a/widgets/community.html
+++ b/widgets/community.html
@@ -35,8 +35,6 @@
       name="keywords"
       content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
     />
-    <meta name="DC.type" content="Data and Tools" />
-    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
     <meta name="DC.creator" content="US EPA" />
     <meta name="DC.language" content="en" />
     <!--googleoff: all-->

--- a/widgets/widgets-example.html
+++ b/widgets/widgets-example.html
@@ -29,8 +29,6 @@
       name="keywords"
       content="Clean Water Act (CWA), Safe Drinking Water Act (SDWA), pollution, impaired waterbodies"
     />
-    <meta name="DC.type" content="Data and Tools" />
-    <meta name="DC.Subject.epachannel" content="Learn the Issues" />
     <meta name="DC.creator" content="US EPA" />
     <meta name="DC.language" content="en" />
     <!--googleoff: all-->


### PR DESCRIPTION
## Related Issues:
* [HMW-916](https://jira.epa.gov/browse/HMW-916)
* [HMW-923](https://jira.epa.gov/browse/HMW-923)

## Main Changes:
* Added the ability for coverage to save out a report of test results. This is so we can provide proof that all tests provided to our prime and or client.
* Renamed some of the server side tests.
* Fixed an issue where the `GET test checkClientRouteExists middleware` test was in there twice. I think the intention was for one of these to test GET and the other to test POST, so I changed the second one to test POST.
* Removed the `DC.type` and `DC.Subject.epachannel` meta tags.

## Steps To Test:
1. Install app and server dependencies
2. In the `app/package.json` file, change line 37 to `"client_coverage": "npx rimraf .nyc_output/out.json && npx rimraf coverage && concurrently -s first -kc \"blue.dim,green.dim,yellow.dim\" -n server,client,cypress \"npm:server_coverage\" \"npm:client\" \"cypress run --browser electron --spec 'cypress/e2e/educational-materials.cy.ts'\"",`
3. Run `npm run coverage`
4. Open the `app/combined_results_reports/final_report/index.html` file in your browser
5. Verify test results are shown
6. Break one of the tests
7. Run `npm run coverage`
8. Verify the failed test is shown in the report

