### PR TITLE
Bugfix/921 save data widget layers

### DIFF
--- a/app/client/src/components/shared/MapWidgets.tsx
+++ b/app/client/src/components/shared/MapWidgets.tsx
@@ -372,6 +372,7 @@ function MapWidgets({
     setAddSaveDataWidgetVisible,
     setSaveAsName,
     setSaveDescription,
+    setSaveLayersList,
     widgetLayers,
   } = useAddSaveDataWidgetState();
 
@@ -1211,11 +1212,13 @@ function MapWidgets({
     setAddSaveDataWidgetVisible(false);
     setSaveAsName('');
     setSaveDescription('');
+    setSaveLayersList(null);
   }, [
     setActiveTabIndex,
     setAddSaveDataWidgetVisible,
     setSaveAsName,
     setSaveDescription,
+    setSaveLayersList,
   ]);
 
   if (!addSaveDataWidget) return null;


### PR DESCRIPTION
## Related Issues:
* [HMW-921](https://jira.epa.gov/browse/HMW-921)

## Main Changes:
* Reset the `saveLayersList` state when navigating to a different page.

## Steps To Test:
1. On the Community page's map, navigate to the Protect tab and turn on the Watershed Health Scores and Protected Areas layers.
2. Click the main "How's My Waterway?" logo to return to the homepage.
3. Return to the Community page.
4. Open the Add & Save Data widget, and open the Save tab.
5. The Protected Areas layer and the State Watershed Health Index layer should **not** be toggled.
