### PR TITLE
Bugfix/943 monitoring location search error

### DIFF
--- a/app/client/src/components/shared/LocationSearch.tsx
+++ b/app/client/src/components/shared/LocationSearch.tsx
@@ -41,7 +41,7 @@ import {
 } from 'config/errorMessages';
 // types
 import type { ReactElement, ReactNode } from 'react';
-import { MonitoringLocationsData } from 'types';
+import { MonitoringLocationsResponse } from 'types';
 
 // --- utils ---
 
@@ -800,8 +800,8 @@ function LocationSearch({ route, label }: Readonly<Props>) {
       // query WQP's station service to get the lat/long
       const url = `${services.waterQualityPortal.stationSearch}mimeType=geojson&zip=no&siteid=${result.key}`;
       try {
-        const res = (await fetchCheck(url)) as MonitoringLocationsData;
-        const feature = res[0];
+        const res = (await fetchCheck(url)) as MonitoringLocationsResponse;
+        const feature = res.features[0];
         if (!feature) {
           setErrorMessage(webServiceErrorMessage);
           return;
@@ -818,7 +818,8 @@ function LocationSearch({ route, label }: Readonly<Props>) {
           target: `/monitoring-report/${ProviderName}/${OrganizationIdentifier}/${MonitoringLocationIdentifier}`,
         });
         if (callback && result.text) callback(result.text);
-      } catch (_err) {
+      } catch (err) {
+        console.error(err);
         setErrorMessage(webServiceErrorMessage);
       }
     },

--- a/app/cypress/e2e/home.cy.ts
+++ b/app/cypress/e2e/home.cy.ts
@@ -67,6 +67,34 @@ describe('Homepage search', () => {
     cy.findByText('Go').click();
     cy.findByText('Invalid search. Please try a new search.').should('exist');
   });
+
+  it('Searching for a monitoring location correctly routes to the Monitoring Report page', () => {
+    const siteId = 'HBMI_WQX-0.5CBR';
+
+    cy.window().then((win) => {
+      cy.stub(win, 'open').as('windowOpen');
+    });
+
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(siteId);
+    cy.findByRole('menuitem', { name: (name) => name.includes(siteId) }).click();
+
+    cy.get('@windowOpen').should('have.been.called');
+    cy.get('@windowOpen').should('have.been.calledWithMatch', /\/monitoring-report/);
+  });
+
+  it('Searching for a waterbody correctly routes to the Waterbody Report page', () => {
+    const waterbodyId = 'DCAKL00L_00';
+
+    cy.window().then((win) => {
+      cy.stub(win, 'open').as('windowOpen');
+    });
+
+    cy.findByPlaceholderText('Search by address', { exact: false }).type(waterbodyId);
+    cy.findByRole('menuitem', { name: (name) => name.includes(waterbodyId) }).click();
+
+    cy.get('@windowOpen').should('have.been.called');
+    cy.get('@windowOpen').should('have.been.calledWithMatch', /\/waterbody-report/);
+  });
 });
 
 describe('Homepage disclaimer and glossary', () => {


### PR DESCRIPTION
## Related Issues:
* [HMW-943](https://jira.epa.gov/browse/HMW-943)

## Main Changes:
* Fixed the handling of the WQP Station search response in the `LocationSearch` component.
* Added E2E tests for waterbody and monitoring location searches.

## Steps To Test:
1. Navigate to http://localhost:3000/.
2. In the search bar, type "HBMI_WQX-0.5CBR".
3. Select the single menu item that appears under the _Monitoring Location_ category.
4. Confirm a new tab is opened to the Monitoring Report page with the URL http://localhost:3000/monitoring-report/STORET/HBMI_WQX/HBMI_WQX-0.5CBR.
