### PR TITLE
Feature/1021 new attains route

### DIFF
--- a/app/client/src/components/pages/Actions.tsx
+++ b/app/client/src/components/pages/Actions.tsx
@@ -72,7 +72,9 @@ function getAssessmentUnitNames(services: any, orgId: string, action: Object) {
         `${services.attains.serviceUrl}` +
         `assessmentUnits?organizationId=${orgId}` +
         `&assessmentUnitIdentifier=${chunk}`;
-      const request = fetchCheck(url);
+      const request = fetchCheck(url, null, {
+        'X-Api-Key': services.attains.apiKey,
+      });
       requests.push(request);
     });
 
@@ -295,7 +297,9 @@ function Actions() {
       console.error(err);
     }
 
-    fetchCheck(url)
+    fetchCheck(url, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    })
       .then((res) => {
         if (res.items.length < 1) {
           setLoading(false);

--- a/app/client/src/components/pages/Actions.tsx
+++ b/app/client/src/components/pages/Actions.tsx
@@ -72,9 +72,16 @@ function getAssessmentUnitNames(services: any, orgId: string, action: Object) {
         `${services.attains.serviceUrl}` +
         `assessmentUnits?organizationId=${orgId}` +
         `&assessmentUnitIdentifier=${chunk}`;
-      const request = fetchCheck(url, null, {
-        'X-Api-Key': services.attains.apiKey,
-      });
+      const apiKey = services.attains.apiKey;
+      const request = fetchCheck(
+        url,
+        null,
+        apiKey
+          ? {
+              'X-Api-Key': apiKey,
+            }
+          : {},
+      );
       requests.push(request);
     });
 
@@ -290,6 +297,7 @@ function Actions() {
       configFiles.data.services.attains.serviceUrl +
       `actions?ActionIdentifier=${actionId}` +
       `&organizationIdentifier=${orgId}`;
+    const apiKey = configFiles.data.services.attains.apiKey;
 
     function onError(err) {
       setLoading(false);
@@ -297,9 +305,15 @@ function Actions() {
       console.error(err);
     }
 
-    fetchCheck(url, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    })
+    fetchCheck(
+      url,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    )
       .then((res) => {
         if (res.items.length < 1) {
           setLoading(false);

--- a/app/client/src/components/pages/Attains.tsx
+++ b/app/client/src/components/pages/Attains.tsx
@@ -79,10 +79,17 @@ function Attains() {
     const url =
       configFiles.data.services.attains.serviceUrl +
       'domains?domainName=ParameterName';
+    const apiKey = configFiles.data.services.attains.apiKey;
 
-    fetchCheck(url, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    })
+    fetchCheck(
+      url,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    )
       .then((res) => {
         setLoading(false);
         setAttainsData(res.sort(compareContextName)); // sorted alphabetically by ATTAINS context

--- a/app/client/src/components/pages/Attains.tsx
+++ b/app/client/src/components/pages/Attains.tsx
@@ -80,7 +80,9 @@ function Attains() {
       configFiles.data.services.attains.serviceUrl +
       'domains?domainName=ParameterName';
 
-    fetchCheck(url)
+    fetchCheck(url, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    })
       .then((res) => {
         setLoading(false);
         setAttainsData(res.sort(compareContextName)); // sorted alphabetically by ATTAINS context

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
@@ -633,11 +633,12 @@ function AdvancedSearch() {
         // Fire off requests for any watersheds that we don't already have data for
         if (!watershedResults.hasOwnProperty(watershed.value)) {
           // run a fetch to get the assessments in the huc
+          const apiKey = configFiles.data.services.attains.apiKey;
           requests.push(
             fetchCheck(
               `${configFiles.data.services.attains.serviceUrl}huc12summary?huc=${watershed.value}`,
               null,
-              { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+              apiKey ? { 'X-Api-Key': apiKey } : {},
             ),
           );
         }

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
@@ -636,6 +636,8 @@ function AdvancedSearch() {
           requests.push(
             fetchCheck(
               `${configFiles.data.services.attains.serviceUrl}huc12summary?huc=${watershed.value}`,
+              null,
+              { 'X-Api-Key': configFiles.data.services.attains.apiKey },
             ),
           );
         }

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
@@ -307,9 +307,16 @@ function WaterQualityOverview() {
       // use the excludeAsssessments flag to improve performance, since we only
       // need the documents and reportStatusCode
       const url = `${configFiles.data.services.attains.serviceUrl}assessments?organizationId=${orgID}&reportingCycle=${year}&excludeAssessments=Y`;
-      fetchCheck(url, getSignal(), {
-        'X-Api-Key': configFiles.data.services.attains.apiKey,
-      })
+      const apiKey = configFiles.data.services.attains.apiKey;
+      fetchCheck(
+        url,
+        getSignal(),
+        apiKey
+          ? {
+              'X-Api-Key': apiKey,
+            }
+          : {},
+      )
         .then((res) => {
           const orgData = res.items[0];
           setOrganizationData({ status: 'success', data: orgData ?? {} });
@@ -327,9 +334,16 @@ function WaterQualityOverview() {
   const fetchIntroText = useCallback(
     (orgID) => {
       const url = `${configFiles.data.services.attains.serviceUrl}metrics?organizationId=${orgID}`;
-      fetchCheck(url, getSignal(), {
-        'X-Api-Key': configFiles.data.services.attains.apiKey,
-      })
+      const apiKey = configFiles.data.services.attains.apiKey;
+      fetchCheck(
+        url,
+        getSignal(),
+        apiKey
+          ? {
+              'X-Api-Key': apiKey,
+            }
+          : {},
+      )
         .then((res) => {
           // check for missing data
           if (res.length === 0) {
@@ -383,10 +397,17 @@ function WaterQualityOverview() {
       `${configFiles.data.services.attains.serviceUrl}usesStateSummary` +
       `?organizationId=${stateAndOrganization.organizationId}` +
       reportingCycleParam;
+    const apiKey = configFiles.data.services.attains.apiKey;
 
-    fetchCheck(url, getSignal(), {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    })
+    fetchCheck(
+      url,
+      getSignal(),
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    )
       .then((res) => {
         // for states like Alaska that have no reporting cycles
         if (
@@ -469,8 +490,9 @@ function WaterQualityOverview() {
   const fetchSurveyData = useCallback(
     (orgID) => {
       const url = `${configFiles.data.services.attains.serviceUrl}surveys?organizationId=${orgID}`;
+      const apiKey = configFiles.data.services.attains.apiKey;
       fetchCheck(url, getSignal(), {
-        'X-Api-Key': configFiles.data.services.attains.apiKey,
+        'X-Api-Key': apiKey,
       })
         .then((res) => {
           setSurveyLoading(false);
@@ -514,9 +536,16 @@ function WaterQualityOverview() {
       }
 
       const url = `${configFiles.data.services.attains.serviceUrl}states/${stateID}/organizations`;
-      fetchCheck(url, getSignal(), {
-        'X-Api-Key': configFiles.data.services.attains.apiKey,
-      })
+      const apiKey = configFiles.data.services.attains.apiKey;
+      fetchCheck(
+        url,
+        getSignal(),
+        apiKey
+          ? {
+              'X-Api-Key': apiKey,
+            }
+          : {},
+      )
         .then((res) => {
           let orgID;
 

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
@@ -491,9 +491,9 @@ function WaterQualityOverview() {
     (orgID) => {
       const url = `${configFiles.data.services.attains.serviceUrl}surveys?organizationId=${orgID}`;
       const apiKey = configFiles.data.services.attains.apiKey;
-      fetchCheck(url, getSignal(), {
+      fetchCheck(url, getSignal(), apiKey ? {
         'X-Api-Key': apiKey,
-      })
+      } : {})
         .then((res) => {
           setSurveyLoading(false);
 

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
@@ -307,7 +307,9 @@ function WaterQualityOverview() {
       // use the excludeAsssessments flag to improve performance, since we only
       // need the documents and reportStatusCode
       const url = `${configFiles.data.services.attains.serviceUrl}assessments?organizationId=${orgID}&reportingCycle=${year}&excludeAssessments=Y`;
-      fetchCheck(url, getSignal())
+      fetchCheck(url, getSignal(), {
+        'X-Api-Key': configFiles.data.services.attains.apiKey,
+      })
         .then((res) => {
           const orgData = res.items[0];
           setOrganizationData({ status: 'success', data: orgData ?? {} });
@@ -325,7 +327,9 @@ function WaterQualityOverview() {
   const fetchIntroText = useCallback(
     (orgID) => {
       const url = `${configFiles.data.services.attains.serviceUrl}metrics?organizationId=${orgID}`;
-      fetchCheck(url, getSignal())
+      fetchCheck(url, getSignal(), {
+        'X-Api-Key': configFiles.data.services.attains.apiKey,
+      })
         .then((res) => {
           // check for missing data
           if (res.length === 0) {
@@ -380,7 +384,9 @@ function WaterQualityOverview() {
       `?organizationId=${stateAndOrganization.organizationId}` +
       reportingCycleParam;
 
-    fetchCheck(url, getSignal())
+    fetchCheck(url, getSignal(), {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    })
       .then((res) => {
         // for states like Alaska that have no reporting cycles
         if (
@@ -463,7 +469,9 @@ function WaterQualityOverview() {
   const fetchSurveyData = useCallback(
     (orgID) => {
       const url = `${configFiles.data.services.attains.serviceUrl}surveys?organizationId=${orgID}`;
-      fetchCheck(url, getSignal())
+      fetchCheck(url, getSignal(), {
+        'X-Api-Key': configFiles.data.services.attains.apiKey,
+      })
         .then((res) => {
           setSurveyLoading(false);
 
@@ -506,7 +514,9 @@ function WaterQualityOverview() {
       }
 
       const url = `${configFiles.data.services.attains.serviceUrl}states/${stateID}/organizations`;
-      fetchCheck(url, getSignal())
+      fetchCheck(url, getSignal(), {
+        'X-Api-Key': configFiles.data.services.attains.apiKey,
+      })
         .then((res) => {
           let orgID;
 

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -261,9 +261,16 @@ function StateTribal() {
 
     setStatesInitialized(true);
 
-    fetchCheck(`${configFiles.data.services.attains.serviceUrl}states`, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    })
+    const apiKey = configFiles.data.services.attains.apiKey;
+    fetchCheck(
+      `${configFiles.data.services.attains.serviceUrl}states`,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    )
       .then((res) => {
         setStates({
           status: 'success',

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -261,7 +261,9 @@ function StateTribal() {
 
     setStatesInitialized(true);
 
-    fetchCheck(`${configFiles.data.services.attains.serviceUrl}states`)
+    fetchCheck(`${configFiles.data.services.attains.serviceUrl}states`, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    })
       .then((res) => {
         setStates({
           status: 'success',

--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -324,9 +324,16 @@ function WaterbodyReport() {
       `assessmentUnits?organizationId=${orgId}` +
       `&assessmentUnitIdentifier=${auId}`;
 
-    fetchCheck(url, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    }).then(
+    const apiKey = configFiles.data.services.attains.apiKey;
+    fetchCheck(
+      url,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    ).then(
       (res) => {
         if (res.items.length < 1) {
           setNoWaterbodies(true);
@@ -531,10 +538,17 @@ function WaterbodyReport() {
       `assessments?organizationId=${orgId}` +
       `&assessmentUnitIdentifier=${auId}` +
       (reportingCycleParam ? `&reportingCycle=${reportingCycleParam}` : '');
+    const apiKey = configFiles.data.services.attains.apiKey;
 
-    fetchCheck(url, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    }).then(
+    fetchCheck(
+      url,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    ).then(
       (res) => {
         if (res.items.length === 0) {
           handleNoAssessments();

--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -324,7 +324,9 @@ function WaterbodyReport() {
       `assessmentUnits?organizationId=${orgId}` +
       `&assessmentUnitIdentifier=${auId}`;
 
-    fetchCheck(url).then(
+    fetchCheck(url, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    }).then(
       (res) => {
         if (res.items.length < 1) {
           setNoWaterbodies(true);
@@ -530,7 +532,9 @@ function WaterbodyReport() {
       `&assessmentUnitIdentifier=${auId}` +
       (reportingCycleParam ? `&reportingCycle=${reportingCycleParam}` : '');
 
-    fetchCheck(url).then(
+    fetchCheck(url, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    }).then(
       (res) => {
         if (res.items.length === 0) {
           handleNoAssessments();

--- a/app/client/src/components/shared/ActionsMap.tsx
+++ b/app/client/src/components/shared/ActionsMap.tsx
@@ -131,7 +131,9 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
         configFiles.data.services.attains.serviceUrl +
         `assessmentUnits?organizationId=${orgId}` +
         `&assessmentUnitIdentifier=${auId}`;
-      const results = await fetchCheck(url);
+      const results = await fetchCheck(url, null, {
+        'X-Api-Key': configFiles.data.services.attains.apiKey,
+      });
       if (!results.items?.length) return null;
       const documents = results.items[0]?.assessmentUnits[0]?.documents;
       const allowedTypes = [
@@ -235,7 +237,7 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
                 fieldName: 'hmw-extra-content',
               };
 
-              extraContent = unitIds[auId](reportingCycle, true)
+              extraContent = unitIds[auId](reportingCycle, true);
             } else if (includePhoto) {
               const photoLink = await getPhotoLink(
                 graphic.attributes.organizationid,
@@ -252,15 +254,16 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
                 </div>
               );
             }
-              // when no content is provided just display the normal community
-              // waterbody content
+            // when no content is provided just display the normal community
+            // waterbody content
             return new Graphic({
               geometry: graphic.geometry,
               symbol,
               attributes: graphic.attributes,
               popupTemplate: {
                 title: getTitle,
-                content: (feature: Feature) => getTemplate(feature, extraContent),
+                content: (feature: Feature) =>
+                  getTemplate(feature, extraContent),
               },
             });
           }

--- a/app/client/src/components/shared/ActionsMap.tsx
+++ b/app/client/src/components/shared/ActionsMap.tsx
@@ -131,9 +131,16 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
         configFiles.data.services.attains.serviceUrl +
         `assessmentUnits?organizationId=${orgId}` +
         `&assessmentUnitIdentifier=${auId}`;
-      const results = await fetchCheck(url, null, {
-        'X-Api-Key': configFiles.data.services.attains.apiKey,
-      });
+      const apiKey = configFiles.data.services.attains.apiKey;
+      const results = await fetchCheck(
+        url,
+        null,
+        apiKey
+          ? {
+              'X-Api-Key': apiKey,
+            }
+          : {},
+      );
       if (!results.items?.length) return null;
       const documents = results.items[0]?.assessmentUnits[0]?.documents;
       const allowedTypes = [

--- a/app/client/src/components/shared/LocationMap.tsx
+++ b/app/client/src/components/shared/LocationMap.tsx
@@ -415,11 +415,18 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
           const url =
             `${configFiles.data.services.attains.serviceUrl}` +
             `assessments?organizationId=${orgId}&reportingCycle=${reportingCycle}&assessmentUnitIdentifier=${chunk}`;
+          const apiKey = configFiles.data.services.attains.apiKey;
 
           requests.push(
-            fetchCheck(url, null, {
-              'X-Api-Key': configFiles.data.services.attains.apiKey,
-            }),
+            fetchCheck(
+              url,
+              null,
+              apiKey
+                ? {
+                    'X-Api-Key': apiKey,
+                  }
+                : {},
+            ),
           );
         });
       });
@@ -507,10 +514,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         setOrphanFeatures({ features: [], status: 'fetching' });
 
         // fetch the ATTAINS Domains service Parameter Names so we can populate the Waterbody Parameters later on
+        const apiKey = configFiles.data.services.attains.apiKey;
         fetchCheck(
           `${configFiles.data.services.attains.serviceUrl}domains?domainName=ParameterName`,
           null,
-          { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+          apiKey ? { 'X-Api-Key': apiKey } : {},
         )
           .then((res) => {
             if (!res || res.length === 0) {
@@ -529,11 +537,18 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
               const url =
                 `${configFiles.data.services.attains.serviceUrl}` +
                 `assessmentUnits?assessmentUnitIdentifier=${chunk}`;
+              const apiKey = configFiles.data.services.attains.apiKey;
 
               requests.push(
-                fetchCheck(url, null, {
-                  'X-Api-Key': configFiles.data.services.attains.apiKey,
-                }),
+                fetchCheck(
+                  url,
+                  null,
+                  apiKey
+                    ? {
+                        'X-Api-Key': configFiles.data.services.attains.apiKey,
+                      }
+                    : {},
+                ),
               );
             });
 
@@ -908,10 +923,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
   const queryAttainsPlans = useCallback(
     (huc12Param) => {
       // get the plans for the selected huc
+      const apiKey = configFiles.data.services.attains.apiKey;
       fetchCheck(
         `${configFiles.data.services.attains.serviceUrl}plans?huc=${huc12Param}&summarize=Y`,
         null,
-        { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+        apiKey ? { 'X-Api-Key': apiKey } : {},
         120000,
       )
         .then((res) => {
@@ -1160,6 +1176,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       // get Protected Areas data for current huc boundaries
       getProtectedAreas(boundaries);
 
+      const attainsApiKey = configFiles.data.services.attains.apiKey;
+
       // call states service for converting statecodes to state names
       // don't re-fetch the states service if it's already populated, it doesn't vary by location
       if (statesData.status !== 'success') {
@@ -1168,7 +1186,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         fetchCheck(
           `${configFiles.data.services.attains.serviceUrl}states`,
           null,
-          { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+          attainsApiKey ? { 'X-Api-Key': attainsApiKey } : {},
         )
           .then((res) => {
             setStatesData({ status: 'success', data: res.data });
@@ -1182,7 +1200,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       fetchCheck(
         `${configFiles.data.services.attains.serviceUrl}huc12summary?huc=${huc12Param}`,
         getSignal(),
-        { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+        attainsApiKey ? { 'X-Api-Key': attainsApiKey } : {},
       ).then(
         (res) => handleMapServices(res, boundaries),
         handleMapServiceError,

--- a/app/client/src/components/shared/LocationMap.tsx
+++ b/app/client/src/components/shared/LocationMap.tsx
@@ -416,7 +416,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
             `${configFiles.data.services.attains.serviceUrl}` +
             `assessments?organizationId=${orgId}&reportingCycle=${reportingCycle}&assessmentUnitIdentifier=${chunk}`;
 
-          requests.push(fetchCheck(url));
+          requests.push(
+            fetchCheck(url, null, {
+              'X-Api-Key': configFiles.data.services.attains.apiKey,
+            }),
+          );
         });
       });
 
@@ -505,6 +509,8 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
         // fetch the ATTAINS Domains service Parameter Names so we can populate the Waterbody Parameters later on
         fetchCheck(
           `${configFiles.data.services.attains.serviceUrl}domains?domainName=ParameterName`,
+          null,
+          { 'X-Api-Key': configFiles.data.services.attains.apiKey },
         )
           .then((res) => {
             if (!res || res.length === 0) {
@@ -524,7 +530,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
                 `${configFiles.data.services.attains.serviceUrl}` +
                 `assessmentUnits?assessmentUnitIdentifier=${chunk}`;
 
-              requests.push(fetchCheck(url));
+              requests.push(
+                fetchCheck(url, null, {
+                  'X-Api-Key': configFiles.data.services.attains.apiKey,
+                }),
+              );
             });
 
             Promise.all(requests)
@@ -901,7 +911,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       fetchCheck(
         `${configFiles.data.services.attains.serviceUrl}plans?huc=${huc12Param}&summarize=Y`,
         null,
-        {},
+        { 'X-Api-Key': configFiles.data.services.attains.apiKey },
         120000,
       )
         .then((res) => {
@@ -1155,7 +1165,11 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       if (statesData.status !== 'success') {
         setStatesData({ status: 'fetching', data: [] });
 
-        fetchCheck(`${configFiles.data.services.attains.serviceUrl}states`)
+        fetchCheck(
+          `${configFiles.data.services.attains.serviceUrl}states`,
+          null,
+          { 'X-Api-Key': configFiles.data.services.attains.apiKey },
+        )
           .then((res) => {
             setStatesData({ status: 'success', data: res.data });
           })
@@ -1168,6 +1182,7 @@ function LocationMap({ layout = 'narrow', windowHeight, children }: Props) {
       fetchCheck(
         `${configFiles.data.services.attains.serviceUrl}huc12summary?huc=${huc12Param}`,
         getSignal(),
+        { 'X-Api-Key': configFiles.data.services.attains.apiKey },
       ).then(
         (res) => handleMapServices(res, boundaries),
         handleMapServiceError,

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -400,7 +400,7 @@ const waterbodyDownloadContainerStyles = css`
 `;
 
 const waterbodyInfoContainerStyles = css`
-  a > svg { 
+  a > svg {
     margin-bottom: 3px;
   }
 `;
@@ -524,7 +524,9 @@ function WaterbodyInfo({
 
     setUseAttainments({ data: null, status: 'fetching' });
 
-    fetchCheck(url)
+    fetchCheck(url, null, {
+      'X-Api-Key': configFiles.data.services.attains.apiKey,
+    })
       .then((res) => {
         if (!res?.items || res.items.length === 0) {
           setUseAttainments({ data: null, status: 'failure' });

--- a/app/client/src/components/shared/WaterbodyInfo.tsx
+++ b/app/client/src/components/shared/WaterbodyInfo.tsx
@@ -521,12 +521,19 @@ function WaterbodyInfo({
       `&organizationId=${organizationid}` +
       `&reportingCycle=${reportingcycle}` +
       `&summarize=Y`;
+    const apiKey = configFiles.services.attains.apiKey;
 
     setUseAttainments({ data: null, status: 'fetching' });
 
-    fetchCheck(url, null, {
-      'X-Api-Key': configFiles.data.services.attains.apiKey,
-    })
+    fetchCheck(
+      url,
+      null,
+      apiKey
+        ? {
+            'X-Api-Key': apiKey,
+          }
+        : {},
+    )
       .then((res) => {
         if (!res?.items || res.items.length === 0) {
           setUseAttainments({ data: null, status: 'failure' });

--- a/app/client/src/types/index.ts
+++ b/app/client/src/types/index.ts
@@ -537,7 +537,7 @@ export interface RndDraggableState {
 }
 
 export interface ServicesData {
-  attains: { serviceUrl: string; serviceUrlDev: string };
+  attains: { apiKey: string, serviceUrl: string; serviceUrlDev: string };
   basemaps: {
     default: string;
     lightGrayCanvas: string;

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -1211,10 +1211,11 @@ export async function getPollutantsFromAction(
 ) {
   try {
     const url = services.attains.serviceUrl + `actions?${parameters}`;
+    const apiKey = services.attains.apiKey;
     const res: AttainsActionsData = await fetchCheck(
       url,
       null,
-      { 'X-Api-Key': services.attains.apiKey },
+      apiKey ? { 'X-Api-Key': services.attains.apiKey } : {},
       120_000,
     );
 

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -1211,7 +1211,12 @@ export async function getPollutantsFromAction(
 ) {
   try {
     const url = services.attains.serviceUrl + `actions?${parameters}`;
-    const res: AttainsActionsData = await fetchCheck(url, null, {}, 120_000);
+    const res: AttainsActionsData = await fetchCheck(
+      url,
+      null,
+      { 'X-Api-Key': services.attains.apiKey },
+      120_000,
+    );
 
     return res.items[0].actions.map((action) => {
       // get water with matching assessment unit identifier

--- a/app/server/app/public/content/config/services.json
+++ b/app/server/app/public/content/config/services.json
@@ -63,8 +63,9 @@
     "getSSByHUC12": "https://ordspub.epa.gov/ords/grts/grtsadm/grts_rest_apex/GetSSByHUC12"
   },
   "attains": {
+    "apiKey": "HbKMDkKyzWJoihZMdbYeRq4jubuBBo5ghuV8vn0d",
     "serviceUrlDev": "https://attains-demo.epa-ow-cloud.com/attains-public/api/",
-    "serviceUrl": "https://attains.epa.gov/attains-public/api/"
+    "serviceUrl": "https://api.epa.gov/attains-debug/"
   },
   "wildScenicRivers": "https://apps.fs.usda.gov/arcx/rest/services/EDW/EDW_WildScenicRiverSegments_01/MapServer/0",
   "protectedAreasDatabase": "https://services.arcgis.com/v01gqwM5QqNysAAi/arcgis/rest/services/Protection_Mechanism_Category_PADUS/FeatureServer/0",

--- a/app/server/app/public/content/config/services.json
+++ b/app/server/app/public/content/config/services.json
@@ -65,7 +65,7 @@
   "attains": {
     "apiKey": "HbKMDkKyzWJoihZMdbYeRq4jubuBBo5ghuV8vn0d",
     "serviceUrlDev": "https://attains-demo.epa-ow-cloud.com/attains-public/api/",
-    "serviceUrl": "https://api.epa.gov/attains-debug/"
+    "serviceUrl": "https://api.epa.gov/attains-demo/"
   },
   "wildScenicRivers": "https://apps.fs.usda.gov/arcx/rest/services/EDW/EDW_WildScenicRiverSegments_01/MapServer/0",
   "protectedAreasDatabase": "https://services.arcgis.com/v01gqwM5QqNysAAi/arcgis/rest/services/Protection_Mechanism_Category_PADUS/FeatureServer/0",


### PR DESCRIPTION
## Related Issues:
* [HMW-1021](https://jira.epa.gov/browse/HMW-1021)

## Main Changes:
* Send ATTAINS calls through api.epa.gov instead of hitting the ATTAINS server directly. This requires the use of an API key.

## Steps To Test:
1. Test all ATTAINS endpoints (that aren't handled by Expert Query), and make sure they respond successfully.