### PR TITLE
Bugfix/1020 duplicate state page calls

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.tsx
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.tsx
@@ -25,9 +25,10 @@ const headingStyles = css`
   margin-top: 0 !important;
   display: flex;
   align-items: center;
+  gap: 0.3125em;
 
   svg {
-    margin-right: 0.3125em;
+    margin-right: 0;
     color: #2c72b5;
   }
 `;

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
@@ -125,16 +125,16 @@ function retrieveFeatures({
         // parse the requests
         Promise.all(requests)
           .then((responses) => {
+            if (!responses || responses.length === 0) resolve({ features: [] });
+
             // save the first response to get the metadata
             let combinedObject = responses[0];
 
-            const features = responses.reduce((acc, cur) => {
-              return {
-                ...acc,
-                features: acc.features.concat(cur.features),
-              };
-            });
-            combinedObject.features = features.features;
+            const features = responses.reduce(
+              (acc, cur) => acc.concat(cur.features),
+              [],
+            );
+            combinedObject.features = features;
 
             // resolve the promise
             resolve(combinedObject);

--- a/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.AdvancedSearch.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { useWindowSize } from '@reach/window-size';
 import Select, { createFilter } from 'react-select';
@@ -266,24 +266,15 @@ function AdvancedSearch() {
   const [serviceError, setServiceError] = useState(false);
   const [showMap, setShowMap] = useState(false);
 
-  const [
-    parameterGroupOptions,
-    setParameterGroupOptions, //
-  ] = useState(null);
-
   // Get the list of parameters available for this state.
   // This data comes from the usesStateSummary service response
   // which is called from WaterQualityOverview.
-  useEffect(() => {
-    if (currentSummary.status === 'fetching') return;
-    if (currentSummary.status === 'failure') {
-      setParameterGroupOptions([]);
-      setServiceError(true);
-      return;
-    }
+  // null = still loading (drives isLoading prop on Select)
+  const parameterGroupOptions = useMemo(() => {
+    if (currentSummary.status !== 'success') return null;
 
     // get a unique list of parameterGroups as they are in attains
-    const uniqueParameterGroups = [];
+    const uniqueParameterGroups: string[] = [];
     currentSummary.data?.waterTypes?.forEach((waterType) => {
       waterType.useAttainments.forEach((useAttainment) => {
         useAttainment.parameters.forEach((parameter) => {
@@ -295,19 +286,18 @@ function AdvancedSearch() {
       });
     });
 
-    // get the public friendly versions of the parameterGroups
-    let parameterGroupOptions = configFiles.data.impairmentFields.filter(
-      (field) =>
+    // get the public friendly versions of the parameterGroups, sorted
+    return configFiles.data.impairmentFields
+      .filter((field) =>
         uniqueParameterGroups.includes(field.parameterGroup.toUpperCase()),
-    );
-
-    // sort the options
-    parameterGroupOptions = parameterGroupOptions.sort((a, b) => {
-      return a.label.toUpperCase() > b.label.toUpperCase() ? 1 : -1;
-    });
-
-    setParameterGroupOptions(parameterGroupOptions);
+      )
+      .sort((a, b) => (a.label.toUpperCase() > b.label.toUpperCase() ? 1 : -1));
   }, [configFiles, currentSummary]);
+
+  // Set serviceError when summary fetch fails
+  useEffect(() => {
+    if (currentSummary.status === 'failure') setServiceError(true);
+  }, [currentSummary.status]);
 
   // Get the maxRecordCount of the watersheds layer
   const [watershedMrcError, setWatershedMrcError] = useState(false);
@@ -419,6 +409,11 @@ function AdvancedSearch() {
       return;
     }
 
+    // Guard against stale stateAndOrganization from a previous state/tribe.
+    // fetchStateOrgId always sets stateAndOrganization.state = activeState.value,
+    // so a mismatch means the context hasn't updated yet for the new selection.
+    if (stateAndOrganization.state !== activeState.value) return;
+
     // query for initial load
     if (!currentFilter) {
       const queryParams = {
@@ -496,6 +491,7 @@ function AdvancedSearch() {
         });
     }
   }, [
+    activeState,
     configFiles,
     currentFilter,
     getSignal,
@@ -1097,9 +1093,9 @@ function AdvancedSearch() {
   );
 
   const { width, height } = useWindowSize();
-  const [mapShownInitialized, setMapShownInitialized] = useState(false);
+  const mapShownInitialized = useRef(false);
   useEffect(() => {
-    if (mapShownInitialized || !width) return;
+    if (mapShownInitialized.current || !width) return;
 
     if (width > 960) {
       setShowMap(true);
@@ -1107,8 +1103,8 @@ function AdvancedSearch() {
       setShowMap(false);
     }
 
-    setMapShownInitialized(true);
-  }, [mapShownInitialized, width]);
+    mapShownInitialized.current = true;
+  }, [width]);
 
   const mapContent = (
     <StateMap

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
@@ -561,6 +561,7 @@ function WaterQualityOverview() {
       setSurveyLoading(true);
       setSurveyDocuments([]);
       setYearSelected('');
+      setUsesStateSummaryServiceError(false);
       setServiceError(false);
       setSurveyServiceError(false);
       setNoDataError(false);
@@ -597,6 +598,7 @@ function WaterQualityOverview() {
     setCurrentSummary,
     setIntroText,
     setOrganizationData,
+    setUsesStateSummaryServiceError,
     fetchStateOrgId,
   ]);
 

--- a/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
+++ b/app/client/src/components/pages/StateTribal.Tabs.WaterQualityOverview.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import Select from 'react-select';
 import { Tabs, TabList, Tab, TabPanel, TabPanels } from '@reach/tabs';
@@ -346,7 +346,7 @@ function WaterQualityOverview() {
   );
 
   // summary service has the different years of data for recreation/eco/fish/water/other
-  const [usesStateSummaryCalled, setUsesStateSummaryCalled] = useState(false);
+  const usesStateSummaryCalled = useRef(false);
   useEffect(() => {
     if (
       !stateAndOrganization ||
@@ -355,7 +355,7 @@ function WaterQualityOverview() {
           activeState.value !== stateAndOrganization.state)) ||
       (activeState.source === 'Tribe' &&
         activeState.attainsId !== stateAndOrganization.organizationId) ||
-      usesStateSummaryCalled
+      usesStateSummaryCalled.current
     ) {
       return;
     }
@@ -445,7 +445,7 @@ function WaterQualityOverview() {
         });
       });
 
-    setUsesStateSummaryCalled(true);
+    usesStateSummaryCalled.current = true;
   }, [
     activeState,
     configFiles,
@@ -456,7 +456,6 @@ function WaterQualityOverview() {
     setCurrentSummary,
     setUsesStateSummaryServiceError,
     stateAndOrganization,
-    usesStateSummaryCalled,
   ]);
 
   // Get the survey data and survey documents
@@ -567,7 +566,7 @@ function WaterQualityOverview() {
       setNoDataError(false);
       setSurveyData(null);
       setOrganizationData({ status: 'fetching', data: {} });
-      setUsesStateSummaryCalled(false);
+      usesStateSummaryCalled.current = false;
       setCurrentReportingCycle({
         status: 'fetching',
         reportingCycle: '',

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -400,7 +400,6 @@ function StateTribal() {
 
   const handleSubmit = (selection) => {
     if (!selection) return;
-    setActiveState(selection);
 
     if (selection.source === 'State') {
       navigate(`/state/${selection.value}/water-quality-overview`);

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -199,8 +199,10 @@ function StateTribal() {
 
   // get tribes from the tribeMapping data
   const tribes = useMemo(() => {
-    if (organizations.status === 'failure') return { status: 'failure', data: [] };
-    if (organizations.status !== 'success') return { status: 'fetching', data: [] };
+    if (organizations.status === 'failure')
+      return { status: 'failure', data: [] };
+    if (organizations.status !== 'success')
+      return { status: 'fetching', data: [] };
 
     const tribeMapping = Object.values(
       [
@@ -306,10 +308,8 @@ function StateTribal() {
   // update selectedState whenever activeState changes
   // (e.g. when a user navigates directly to '/state/DC/advanced-search')
   useEffect(() => {
-    setUsesStateSummaryServiceError(false);
-
     if (activeState.value) setSelectedStateTribe(activeState);
-  }, [activeState, setUsesStateSummaryServiceError]);
+  }, [activeState]);
 
   // get the state intro and metrics data
   const stateIntro = introText.status === 'success' ? introText.data : null;
@@ -584,116 +584,119 @@ function StateTribal() {
           </>
         )}
 
-        {usesStateSummaryServiceError ? (
+        {usesStateSummaryServiceError && (
           <div css={modifiedErrorBoxStyles}>
             {usesStateSummaryServiceInvalidResponse(
               activeState.source,
               activeState.label,
             )}
           </div>
-        ) : (
-          <div>
-            {activeState.value !== '' && (
+        )}
+
+        {!usesStateSummaryServiceError && activeState.value !== '' && (
+          <>
+            {introText.status === 'fetching' && <LoadingSpinner />}
+            {introText.status === 'failure' && (
+              <div css={modifiedErrorBoxStyles}>
+                <p>{stateGeneralError(activeState.source)}</p>
+              </div>
+            )}
+            {introText.status === 'success' && (
               <>
-                {introText.status === 'fetching' && <LoadingSpinner />}
-                {introText.status === 'failure' && (
+                {!stateIntro ? (
                   <div css={modifiedErrorBoxStyles}>
-                    <p>{stateGeneralError(activeState.source)}</p>
+                    <p>{stateNoDataError(activeState.label)}</p>
                   </div>
-                )}
-                {introText.status === 'success' && (
+                ) : (
                   <>
-                    {!stateIntro ? (
-                      <div css={modifiedErrorBoxStyles}>
-                        <p>{stateNoDataError(activeState.label)}</p>
-                      </div>
-                    ) : (
+                    {stateIntro.organizationMetrics.length > 0 && (
                       <>
-                        {stateIntro.organizationMetrics.length > 0 && (
-                          <>
-                            <h2 css={headingStyles}>
-                              <IconChartLine aria-hidden="true" />
-                              <span>
-                                <strong>{activeState.label}</strong> by the
-                                Numbers
-                              </span>
-                            </h2>
+                        <h2 css={headingStyles}>
+                          <IconChartLine aria-hidden="true" />
+                          <span>
+                            <strong>{activeState.label}</strong> by the
+                            Numbers
+                          </span>
+                        </h2>
 
-                            <div css={keyMetricsStyles}>
-                              {stateIntro.organizationMetrics.map((metric) => {
-                                if (!metric?.value || !metric.label) {
-                                  return null;
-                                }
+                        <div css={keyMetricsStyles}>
+                          {stateIntro.organizationMetrics.map((metric) => {
+                            if (!metric?.value || !metric.label) {
+                              return null;
+                            }
 
-                                let value = Number(metric.value);
-                                if (!value) {
-                                  // just in case the service has a non-numeric string in the future
-                                  value = metric.value;
-                                } else if (value <= 1) {
-                                  // numbers <=1 convert to percentages
-                                  value = (value * 100).toLocaleString() + '%';
-                                } else {
-                                  value = value.toLocaleString();
-                                }
+                            let value = Number(metric.value);
+                            if (!value) {
+                              // just in case the service has a non-numeric string in the future
+                              value = metric.value;
+                            } else if (value <= 1) {
+                              // numbers <=1 convert to percentages
+                              value = (value * 100).toLocaleString() + '%';
+                            } else {
+                              value = value.toLocaleString();
+                            }
 
-                                return (
-                                  <div
-                                    css={keyMetricStyles}
-                                    key={`${metric.label}-${metric.value}`}
-                                  >
-                                    <span css={keyMetricNumberStyles}>
-                                      {value}
-                                    </span>
-                                    <p css={keyMetricLabelStyles}>
-                                      {metric.label}
-                                      <br />
-                                      <em>{metric.unit}</em>
-                                    </p>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                            <p css={byTheNumbersExplanationStyles}>
-                              Waters not assessed do not show up in summaries
-                              below.
-                            </p>
-                          </>
-                        )}
-
-                        {stateIntro.description && (
-                          <>
-                            <h2 css={headingStyles}>
-                              <IconWater aria-hidden="true" />
-                              <span>
-                                About <strong>{activeState.label}</strong>
-                              </span>
-                            </h2>
-                            <div css={modifiedIntroBoxStyles}>
-                              <p>
-                                <ShowLessMore
-                                  text={stateIntro.description}
-                                  charLimit={450}
-                                />
-                              </p>
-                            </div>
-                          </>
-                        )}
-
-                        <DisclaimerModal
-                          buttonStyles={disclaimerStyles}
-                          disclaimerKey="stateTribal"
-                        />
+                            return (
+                              <div
+                                css={keyMetricStyles}
+                                key={`${metric.label}-${metric.value}`}
+                              >
+                                <span css={keyMetricNumberStyles}>
+                                  {value}
+                                </span>
+                                <p css={keyMetricLabelStyles}>
+                                  {metric.label}
+                                  <br />
+                                  <em>{metric.unit}</em>
+                                </p>
+                              </div>
+                            );
+                          })}
+                        </div>
+                        <p css={byTheNumbersExplanationStyles}>
+                          Waters not assessed do not show up in summaries
+                          below.
+                        </p>
                       </>
                     )}
+
+                    {stateIntro.description && (
+                      <>
+                        <h2 css={headingStyles}>
+                          <IconWater aria-hidden="true" />
+                          <span>
+                            About <strong>{activeState.label}</strong>
+                          </span>
+                        </h2>
+                        <div css={modifiedIntroBoxStyles}>
+                          <p>
+                            <ShowLessMore
+                              text={stateIntro.description}
+                              charLimit={450}
+                            />
+                          </p>
+                        </div>
+                      </>
+                    )}
+
+                    <DisclaimerModal
+                      buttonStyles={disclaimerStyles}
+                      disclaimerKey="stateTribal"
+                    />
                   </>
                 )}
               </>
             )}
-
-            {/* Outlet is either StateIntro or StateTabs */}
-            <Outlet context={{ tribes, states }} />
-          </div>
+          </>
         )}
+
+        {/* Outlet is either StateIntro or StateTabs. Always rendered so its
+            effects run even when the service error overlay is shown — this
+            allows the error to be cleared when the user navigates to a new
+            state/tribe without needing to unmount/remount the Outlet. */}
+        <div css={usesStateSummaryServiceError ? { display: 'none' } : undefined}>
+          <Outlet context={{ tribes, states }} />
+        </div>
       </div>
     </Page>
   );

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -170,7 +170,6 @@ function StateTribal() {
     setActiveState,
     setErrorType,
     setIntroText,
-    setUsesStateSummaryServiceError,
     usesStateSummaryServiceError,
   } = useContext(StateTribalTabsContext);
 

--- a/app/client/src/components/pages/StateTribal.tsx
+++ b/app/client/src/components/pages/StateTribal.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router';
 import Select from 'react-select';
 import IconDoubleAngleRight from '~icons/fa7-solid/angles-right';
@@ -198,15 +198,9 @@ function StateTribal() {
   }, [navigate, setErrorType]);
 
   // get tribes from the tribeMapping data
-  const [tribes, setTribes] = useState({ status: 'fetching', data: [] });
-  useEffect(() => {
-    if (organizations.status === 'failure') {
-      setTribes({ status: 'failure', data: [] });
-      return;
-    }
-    if (organizations.status !== 'success') {
-      return;
-    }
+  const tribes = useMemo(() => {
+    if (organizations.status === 'failure') return { status: 'failure', data: [] };
+    if (organizations.status !== 'success') return { status: 'fetching', data: [] };
 
     const tribeMapping = Object.values(
       [
@@ -230,8 +224,7 @@ function StateTribal() {
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
-    const tempTribes = [];
-    tribeMapping.forEach((tribe) => {
+    const data = tribeMapping.map((tribe) => {
       const { attainsId } = tribe;
       const tribeAttains = attainsId
         ? organizations.data.find(
@@ -241,25 +234,25 @@ function StateTribal() {
           )
         : null;
 
-      tempTribes.push({
+      return {
         ...tribe,
         attainsId: tribeAttains ? attainsId : null,
         value: tribe.attainsId ?? tribe.wqxIds[0],
         label: tribe.name,
-        source: 'Tribe',
-      });
+        source: 'Tribe' as const,
+      };
     });
 
-    setTribes({ status: 'success', data: tempTribes });
+    return { status: 'success', data };
   }, [configFiles, organizations]);
 
   // query attains for the list of states
   const [states, setStates] = useState({ status: 'fetching', data: [] });
-  const [statesInitialized, setStatesInitialized] = useState(false);
+  const statesInitialized = useRef(false);
   useEffect(() => {
-    if (statesInitialized) return;
+    if (statesInitialized.current) return;
 
-    setStatesInitialized(true);
+    statesInitialized.current = true;
 
     fetchCheck(`${configFiles.data.services.attains.serviceUrl}states`)
       .then((res) => {
@@ -271,7 +264,7 @@ function StateTribal() {
         });
       })
       .catch((_err) => setStates({ status: 'failure', data: [] }));
-  }, [configFiles, statesInitialized]);
+  }, [configFiles]);
 
   // reset active state if on state intro page
   useEffect(() => {
@@ -288,13 +281,12 @@ function StateTribal() {
   // selectedState used for the HTML select menu, so we don't immediately
   // update activeState every time the user changes the selected state
   const [selectedSource, setSelectedSource] = useState('All');
-  const [selectOptions, setSelectOptions] = useState([]);
   const [selectedStateTribe, setSelectedStateTribe] = useState(
     activeState.value ? activeState : null,
   );
 
-  // updates the selectOptions based on the selectedSource
-  useEffect(() => {
+  // derives the selectOptions based on the selectedSource
+  const selectOptions = useMemo(() => {
     const options = [];
     if (selectedSource === 'All') {
       options.push({
@@ -308,8 +300,7 @@ function StateTribal() {
     }
     if (selectedSource === 'State') options.push(...states.data);
     if (selectedSource === 'Tribe') options.push(...tribes.data);
-
-    setSelectOptions(options);
+    return options;
   }, [selectedSource, states, tribes]);
 
   // update selectedState whenever activeState changes


### PR DESCRIPTION
## Related Issues:
* [HMW-1011](https://jira.epa.gov/browse/HMW-1011)
* [HMW-1020](https://jira.epa.gov/browse/HMW-1020)

## Main Changes:
* Add spacing between the tribe name and "at a Glance" on the tribal page.
* Remove an unnecessary `setActiveState` call. Instead, just navigate to the desired state/tribe page and let that page calculate and set the active state from the params.
* Refactored to remove some `useEffect`s and cut down on re-rendering.

## Steps To Test:
1. Navigate to http://localhost:3000/tribe/CHOCNAT. Verify there is proper spacing in "The Choctaw Nation of Oklahoma
at a Glance".
2. Navigate to Alaska. Confirm all data on the page loads.
3. Switch to American Samoa (which has no reporting cycles), and confirm the Uses State Summary Service error shows. Previously, stale data from the previous selected state would show at the top, with an error in the overview pane.
