### PR TITLE
HMW-1011 Fix tribe page header spacing

### DIFF
--- a/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.tsx
+++ b/app/client/src/components/pages/StateTribal.Routes.StateTribalTabs.tsx
@@ -25,12 +25,6 @@ const headingStyles = css`
   margin-top: 0 !important;
   display: flex;
   align-items: center;
-  gap: 0.3125em;
-
-  svg {
-    margin-right: 0;
-    color: #2c72b5;
-  }
 `;
 
 function StateTribalTabs() {
@@ -203,7 +197,7 @@ function StateTribalTabs() {
       <div>
         <h2 css={headingStyles}>
           <IconMapMarkedAlt aria-hidden="true" />
-          <strong>{activeState.label}</strong> at a Glance
+          <span><strong>{activeState.label}</strong> at a Glance</span>
         </h2>
         <div>{mapContent}</div>
         {activeState.attainsId && (


### PR DESCRIPTION
## Related Issues:
* [HMW-1011](https://jira.epa.gov/browse/HMW-1011)

## Main Changes:
* Fixed a spacing issue in the "<Tribe> at a Glance" header on small screens.

## Steps To Test:
1. Go to http://localhost:3000/tribe/UTEMTN.
2. Shrink the screen to less than 450px wide. Confirm the tribe name and "at a glance" wrap as a single container, rather than two separate containers.
