### PR TITLE
Feature/1026 rps legend gap

### DIFF
--- a/app/client/src/components/shared/MapLegend.tsx
+++ b/app/client/src/components/shared/MapLegend.tsx
@@ -76,6 +76,12 @@ const legendItemStyles = css`
   align-items: center;
 `;
 
+const legendItemGradientStyles = css`
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+`;
+
 const imageContainerBaseStyles = css`
   margin-right: 0.25rem;
 `;
@@ -590,7 +596,7 @@ function MapLegendContent({ view, layer, additionalLegendInfo }: CardProps) {
   // jsx
   const healthIndexLegend = (
     <li className="hmw-legend__item">
-      <div css={legendItemStyles}>
+      <div css={legendItemGradientStyles}>
         <div className="hmw-legend__symbol">
           <GradientIcon
             id="health-index-gradient"

--- a/app/client/src/utils/mapFunctions.tsx
+++ b/app/client/src/utils/mapFunctions.tsx
@@ -996,7 +996,7 @@ export function GradientIcon({
   return (
     <div style={{ display: 'flex', margin: 'auto' }}>
       <div style={{ margin: '15px 0' }}>
-        <svg width={50} height={25 * divisions + 20}>
+        <svg width={56} height={25 * divisions + 20}>
           <defs>
             <linearGradient
               id={id}
@@ -1031,7 +1031,8 @@ export function GradientIcon({
               y={25 * index + 14}
               fontSize="smaller"
             >
-              -{stop.label}
+              <tspan>-</tspan>
+              <tspan dx={6}>{stop.label}</tspan>
             </text>
           ))}
         </svg>


### PR DESCRIPTION
## Related Issues:
* [HMW-1026](https://jira.epa.gov/browse/HMW-1026)

## Main Changes:
* Added more space between watershed health scores gradient and labels.

## Steps To Test:
1. Navigate to http://localhost:3000/community/dc/protect
2. Expand Watershed Health Scores.
3. Verify there is more space between the gradient and the numeric labels to the right.
4. Open the legend and repeat step 3.
