### PR TITLE
Bugfix/1009 duplicate attains calls

### DIFF
--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -274,6 +274,9 @@ function WaterbodyReport() {
     status: 'fetching',
     layer: null,
   });
+  const [photoLinks, setPhotoLinks] = useState<Record<string, string | null>>(
+    {},
+  );
 
   function handleError() {
     setAllParameterActionIds({
@@ -342,10 +345,29 @@ function WaterbodyReport() {
 
         const {
           assessmentUnitName,
+          documents,
           locationDescriptionText,
           waterTypes,
           monitoringStations,
         } = res.items[0].assessmentUnits[0];
+
+        const allowedImageTypes = [
+          'apng',
+          'bmp',
+          'gif',
+          'jpeg',
+          'png',
+          'svg+xml',
+          'tiff',
+          'x-tiff',
+          'x-windows-bmp',
+        ].map((imageType) => `image/${imageType}`);
+        const photo = documents?.find((document) =>
+          allowedImageTypes.includes(document.documentFileType),
+        );
+        setPhotoLinks({
+          [`${orgId}-${auId}`]: photo ? photo.documentUrl : null,
+        });
 
         setWaterbodyName(assessmentUnitName);
         setWaterbodyLocation({

--- a/app/client/src/components/pages/WaterbodyReport.tsx
+++ b/app/client/src/components/pages/WaterbodyReport.tsx
@@ -49,6 +49,8 @@ import {
   status303dShortError,
   waterbodyReportError,
 } from 'config/errorMessages';
+// types
+import { FetchState } from 'types';
 
 const containerStyles = css`
   ${splitLayoutContainerStyles};
@@ -274,8 +276,8 @@ function WaterbodyReport() {
     status: 'fetching',
     layer: null,
   });
-  const [photoLinks, setPhotoLinks] = useState<Record<string, string | null>>(
-    {},
+  const [photoLinks, setPhotoLinks] = useState<FetchState<Record<string, string | null>>>(
+    { status: 'idle', data: {} },
   );
 
   function handleError() {
@@ -328,6 +330,7 @@ function WaterbodyReport() {
       `&assessmentUnitIdentifier=${auId}`;
 
     const apiKey = configFiles.data.services.attains.apiKey;
+    setPhotoLinks({ status: 'fetching', data: {} });
     fetchCheck(
       url,
       null,
@@ -365,9 +368,9 @@ function WaterbodyReport() {
         const photo = documents?.find((document) =>
           allowedImageTypes.includes(document.documentFileType),
         );
-        setPhotoLinks({
+        setPhotoLinks({ status: 'success', data: {
           [`${orgId}-${auId}`]: photo ? photo.documentUrl : null,
-        });
+        }});
 
         setWaterbodyName(assessmentUnitName);
         setWaterbodyLocation({
@@ -443,6 +446,7 @@ function WaterbodyReport() {
       },
       (err) => {
         console.error(err);
+        setPhotoLinks({ status: 'failure', data: {} });
         setWaterbodyTypes({ status: 'failure', data: [] });
         setWaterbodyLocation({ status: 'failure', text: '' });
       },
@@ -1294,7 +1298,7 @@ function WaterbodyReport() {
                                 layout="narrow"
                                 unitIds={unitIds}
                                 onLoad={setMapLayer}
-                                includePhoto
+                                photoLinks={photoLinks}
                               />
                             </div>
                           </Fragment>
@@ -1316,7 +1320,7 @@ function WaterbodyReport() {
                           layout="wide"
                           unitIds={unitIds}
                           onLoad={setMapLayer}
-                          includePhoto
+                          photoLinks={photoLinks}
                         />
                       </div>
                     </StickyBox>

--- a/app/client/src/components/shared/ActionsMap.tsx
+++ b/app/client/src/components/shared/ActionsMap.tsx
@@ -61,10 +61,10 @@ type Props = {
   layout: 'narrow' | 'wide';
   unitIds: Array<string>;
   onLoad?: Function;
-  includePhoto?: boolean;
+  photoLinks?: Record<string, string | null>;  // Keyed by `${organizationId}-${assessmentUnitIdentifier}`
 };
 
-function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
+function ActionsMap({ layout, unitIds, onLoad, photoLinks }: Props) {
   const navigate = useNavigate();
 
   const { homeWidget, mapView } = useContext(LocationSearchContext);
@@ -123,44 +123,6 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
 
   // Queries the Gis service and plots the waterbodies on the map
   const [noMapData, setNoMapData] = useState(null);
-
-  const getPhotoLink = useCallback(
-    async (orgId, auId) => {
-      if (!auId || !orgId) return null;
-      const url =
-        configFiles.data.services.attains.serviceUrl +
-        `assessmentUnits?organizationId=${orgId}` +
-        `&assessmentUnitIdentifier=${auId}`;
-      const apiKey = configFiles.data.services.attains.apiKey;
-      const results = await fetchCheck(
-        url,
-        null,
-        apiKey
-          ? {
-              'X-Api-Key': apiKey,
-            }
-          : {},
-      );
-      if (!results.items?.length) return null;
-      const documents = results.items[0]?.assessmentUnits[0]?.documents;
-      const allowedTypes = [
-        'apng',
-        'bmp',
-        'gif',
-        'jpeg',
-        'png',
-        'svg+xml',
-        'tiff',
-        'x-tiff',
-        'x-windows-bmp',
-      ].map((imageType) => `image/${imageType}`);
-      const photo = documents?.find((document) =>
-        allowedTypes.includes(document.documentFileType),
-      );
-      return photo ? photo.documentURL : null;
-    },
-    [configFiles],
-  );
 
   // Plots the assessments. Also re-plots if the layout changes
   useEffect(() => {
@@ -245,11 +207,9 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
               };
 
               extraContent = unitIds[auId](reportingCycle, true);
-            } else if (includePhoto) {
-              const photoLink = await getPhotoLink(
-                graphic.attributes.organizationid,
-                graphic.attributes.assessmentunitidentifier,
-              );
+            } else if (photoLinks) {
+              const key = `${graphic.attributes.organizationid}-${graphic.attributes.assessmentunitidentifier}`;
+              const photoLink = photoLinks[key];
 
               extraContent = photoLink && (
                 <div css={imageContainerStyles}>
@@ -329,10 +289,9 @@ function ActionsMap({ layout, unitIds, onLoad, includePhoto }: Props) {
     actionsWaterbodies,
     configFiles,
     fetchStatus,
-    getPhotoLink,
     navigate,
     onLoad,
-    includePhoto,
+    photoLinks,
     unitIds,
   ]);
 

--- a/app/client/src/components/shared/ActionsMap.tsx
+++ b/app/client/src/components/shared/ActionsMap.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router';
 import Graphic from '@arcgis/core/Graphic';
@@ -18,7 +18,6 @@ import { useConfigFilesState } from 'contexts/ConfigFiles';
 import { useLayers } from 'contexts/Layers';
 import { LocationSearchContext } from 'contexts/locationSearch';
 // helpers
-import { fetchCheck } from 'utils/fetchUtils';
 import {
   useDynamicPopup,
   useSharedLayers,
@@ -38,7 +37,7 @@ import {
 } from 'config/errorMessages';
 // types
 import type { ReactNode } from 'react';
-import type { Feature } from 'types';
+import type { Feature, FetchState } from 'types';
 
 const containerStyles = css`
   display: flex;
@@ -61,7 +60,7 @@ type Props = {
   layout: 'narrow' | 'wide';
   unitIds: Array<string>;
   onLoad?: Function;
-  photoLinks?: Record<string, string | null>;  // Keyed by `${organizationId}-${assessmentUnitIdentifier}`
+  photoLinks?: FetchState<Record<string, string | null>>;  // Data keyed by `${organizationId}-${assessmentUnitIdentifier}`
 };
 
 function ActionsMap({ layout, unitIds, onLoad, photoLinks }: Props) {
@@ -127,6 +126,7 @@ function ActionsMap({ layout, unitIds, onLoad, photoLinks }: Props) {
   // Plots the assessments. Also re-plots if the layout changes
   useEffect(() => {
     if (!unitIds || !actionsWaterbodies) return;
+    if (photoLinks && ['idle', 'fetching'].includes(photoLinks.status)) return; // wait to plot until photo links are fetched
     if (fetchStatus) return; // only do a fetch if there is no status
 
     function plotAssessments(unitIds: Array<string>) {
@@ -207,9 +207,9 @@ function ActionsMap({ layout, unitIds, onLoad, photoLinks }: Props) {
               };
 
               extraContent = unitIds[auId](reportingCycle, true);
-            } else if (photoLinks) {
+            } else if (photoLinks?.status === 'success') {
               const key = `${graphic.attributes.organizationid}-${graphic.attributes.assessmentunitidentifier}`;
-              const photoLink = photoLinks[key];
+              const photoLink = photoLinks.data[key];
 
               extraContent = photoLink && (
                 <div css={imageContainerStyles}>


### PR DESCRIPTION
## Related Issues:
* [HMW-1009](https://jira.epa.gov/browse/HMW-1009)

## Main Changes:
* Save the waterbody photo links in `WaterbodyReport` state instead of using separate calls in the `ActionsMap` component.

## Steps To Test:
1. Replace the dynamic link in WaterbodyReport:372 with a static image link, e.g. `[`${orgId}-${auId}`]: 'https://picsum.photos/200',` (there was only one waterbody with an image used for testing in #687, but that image has since disappeared).
2. Open the network tab of the developer tools and search for https://api.epa.gov/attains-demo/assessmentUnits?organizationId=DOEE&assessmentUnitIdentifier=DCANA00E_01.
3. Navigate to http://localhost:3000/waterbody-report/DOEE/DCANA00E_01/2022. Confirm the call to the specified ATTAINS URL occurs only once.
4. Confirm an image is shown in the waterbody popup.