### PR TITLE
Test out new WQP legacy webservices

### DIFF
--- a/app/server/app/public/content/config/services.json
+++ b/app/server/app/public/content/config/services.json
@@ -33,11 +33,11 @@
   },
   "glossaryURL": "https://etss.epa.gov/synaptica_rest_services/api/vocabs/name/HMW%20Glossary/terms/full",
   "waterQualityPortal": {
-    "domainValues": "https://www.waterqualitydata.us/Codes",
+    "domainValues": "https://wqp.dmap-stage.aws.epa.gov/Codes",
     "userInterface": "https://www.waterqualitydata.us/",
-    "stationSearch": "https://www.waterqualitydata.us/data/Station/search?",
-    "resultSearch": "https://www.waterqualitydata.us/data/Result/search?",
-    "monitoringLocation": "https://www.waterqualitydata.us/data/summary/monitoringlocation/",
+    "stationSearch": "https://wqp.dmap-stage.aws.epa.gov/data/Station/search?",
+    "resultSearch": "https://wqp.dmap-stage.aws.epa.gov/data/Result/search?",
+    "monitoringLocation": "https://wqp.dmap-stage.aws.epa.gov/data/summary/monitoringlocation/",
     "monitoringLocationDetails": "https://www.waterqualitydata.us/provider/"
   },
   "usgs": {


### PR DESCRIPTION
## Main Changes:
* Updated WQP services to point to new EPA-internal endpoints. I'm not sure if the domain values service is set up: will need to test after deploying.

## Steps To Test:
1. Log into EPA's VDI.
2. Test all WQP monitoring location data in How's My Waterway.
